### PR TITLE
fix: derive ActivityLog visible logs instead of setState-in-effect

### DIFF
--- a/packages/app/src/components/ActivityLog.tsx
+++ b/packages/app/src/components/ActivityLog.tsx
@@ -1,16 +1,17 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useGameStore } from '../store/gameStore';
 import type { Move, Card } from '../types';
 
 const ActivityLog: React.FC = () => {
   const moveHistory = useGameStore((state) => state.moveHistory);
   const [isMinimized, setIsMinimized] = useState(false);
-  const [visibleLogs, setVisibleLogs] = useState<Move[]>([]);
+  // "Clear View" hides the log until the next move arrives. Remembering the
+  // history length at clear time keeps visibleLogs a pure derivation of
+  // moveHistory, rather than mirroring it into state via a setState-in-effect.
+  const [clearedAtLength, setClearedAtLength] = useState(-1);
 
-  // Update visible logs when move history changes
-  useEffect(() => {
-    setVisibleLogs(moveHistory);
-  }, [moveHistory]);
+  const visibleLogs: Move[] =
+    moveHistory.length === clearedAtLength ? [] : moveHistory;
 
   const formatCard = (card: Card): string => {
     const suitSymbols: Record<string, string> = {
@@ -83,7 +84,7 @@ const ActivityLog: React.FC = () => {
   };
 
   const handleClearView = () => {
-    setVisibleLogs([]);
+    setClearedAtLength(moveHistory.length);
   };
 
   const handleToggleMinimize = () => {


### PR DESCRIPTION
## Summary

`ActivityLog` mirrored `moveHistory` into local state inside a `useEffect`:

```tsx
const [visibleLogs, setVisibleLogs] = useState<Move[]>([]);
useEffect(() => { setVisibleLogs(moveHistory); }, [moveHistory]);
```

Calling `setState` synchronously within an effect triggers cascading
renders. The upgraded `eslint-plugin-react-hooks` (dev-dependencies bump,
PR #149) promotes this to an **error**, which fails CI Lint.

This derives `visibleLogs` directly from `moveHistory` and keeps only the
history length at the last "Clear View" click. Behaviour is unchanged:
"Clear View" hides the log until the next move, then the full history
reappears (the previous effect did the same).

This unblocks #149.

## Test plan

- `pnpm run lint` / `build` / `build:libs` pass locally on Node 24 / pnpm 11.
- CI: Lint, Test, E2E, Build.