### PR TITLE
chore: close testability gaps and add board-state scenario fixtures

### DIFF
--- a/.claude/skills/high-fidelity-frontend-testing/SKILL.md
+++ b/.claude/skills/high-fidelity-frontend-testing/SKILL.md
@@ -63,12 +63,28 @@ driving the game without simulating clicks. In a Playwright test use
 | `draw()` | Draw from stock (recycles when empty). |
 | `findCard(id)` | Locate a card by id, e.g. `"hearts-A"`. |
 | `toggleAutoPlay()` / `isWon()` | Drive the solver / check victory. |
+| `listScenarios()` | Names of the built-in board-state fixtures. |
+| `loadScenario(name)` | Jump straight to a named fixture (see below). |
 
-To set up an exact board state, build a `GameState` object and call
-`loadState(JSON.stringify(state))` — see `oneMoveFromWinning()` in
-`e2e/user-journey.spec.ts` for a worked example.
+To set up an exact board state, prefer a **named scenario** (next section); for
+a one-off, build a `GameState` object and call `loadState(JSON.stringify(state))`.
 
-### 3. Stable selectors (`data-testid`)
+### 3. Board-state scenarios (fast re-runs)
+
+Some positions — winnable end-games, one-move-from-win — are impractical to
+reach by playing from a seed. `packages/app/src/testScenarios.ts` defines named
+fixtures that craft them directly:
+
+| Scenario | Position |
+|---|---|
+| `oneMoveFromWinning` | One click from victory — exercises the win modal. |
+| `autoCompleteReady` | Fully-sorted end-game; auto-play solves it to a win. |
+| `fourKingsToWin` | Foundations A→Q, four Kings in the tableau. |
+
+Load one via the bridge: `window.__solitaire.loadScenario('autoCompleteReady')`,
+or in a spec with the `loadScenario(page, name)` helper. See `e2e/scenarios.spec.ts`.
+
+### 4. Stable selectors (`data-testid`)
 
 Locate elements by `data-testid`, never by coordinates. The conventions:
 
@@ -80,7 +96,17 @@ Locate elements by `data-testid`, never by coordinates. The conventions:
   `valid-moves-btn`, `god-mode-btn`, `auto-play-btn`,
   `difficulty-btn-1`..`difficulty-btn-5`, `control-panel`, `move-counter`,
   `move-count`.
+- Replay controls: `replay-controls`, `replay-exit-btn`, `replay-back-btn`,
+  `replay-play-btn`, `replay-forward-btn`, `replay-progress`,
+  `replay-progress-bar`, `replay-speed-select`.
+- Activity log: `activity-log`, `activity-log-toggle-btn`,
+  `activity-log-copy-btn`, `activity-log-clear-btn`, `activity-log-entries`,
+  `activity-log-entry`, `activity-log-count`.
 - Containers: `game-board`, `win-modal`.
+
+Every card and pile also carries an ARIA `role` + `aria-label`, so
+`getByRole('button', { name: 'A of hearts' })` and Playwright MCP's
+accessibility-tree mode work as first-class locators.
 
 In Playwright: `page.getByTestId('draw-pile')`. Always wait for readiness with
 the `waitForGame` helper (`e2e/helpers.ts`) before asserting. Add a
@@ -125,8 +151,6 @@ game).
 
 ## Recommended enhancements (not yet done)
 
-- Add ARIA `role="button"` + `aria-label` to cards/piles so Playwright MCP's
-  accessibility-tree mode and `getByRole` work as first-class locators.
 - Add `toHaveScreenshot()` visual-regression baselines once the UI is stable.
 
 ## Pre-flight checklist

--- a/packages/app/e2e/helpers.ts
+++ b/packages/app/e2e/helpers.ts
@@ -1,8 +1,9 @@
 import { expect, type Page } from '@playwright/test';
 import type { GameSummary, SolitaireTestBridge } from '../src/testBridge';
+import type { ScenarioName } from '../src/testScenarios';
 
 /** Re-export bridge types so specs have a single import site. */
-export type { GameSummary, SolitaireTestBridge };
+export type { GameSummary, SolitaireTestBridge, ScenarioName };
 
 /**
  * Waits until the game board has rendered and the `window.__solitaire` test
@@ -16,6 +17,15 @@ export async function waitForGame(page: Page): Promise<void> {
 /** Reads the compact game summary via the test bridge. */
 export function summary(page: Page): Promise<GameSummary> {
   return page.evaluate(() => window.__solitaire!.getSummary());
+}
+
+/**
+ * Loads a named board-state fixture via the test bridge — a fast, deterministic
+ * jump to an interesting position. Asserts the load succeeded.
+ */
+export async function loadScenario(page: Page, name: ScenarioName): Promise<void> {
+  const ok = await page.evaluate((n) => window.__solitaire!.loadScenario(n), name);
+  expect(ok, `scenario "${name}" should load`).toBe(true);
 }
 
 /**

--- a/packages/app/e2e/scenarios.spec.ts
+++ b/packages/app/e2e/scenarios.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '@playwright/test';
+import { waitForGame, summary, loadScenario } from './helpers';
+
+/**
+ * Exercises the named board-state fixtures (`src/testScenarios.ts`) end-to-end.
+ * These give tests a fast, deterministic jump to positions that are impractical
+ * to reach by playing from a seed.
+ */
+
+test.describe('Board-state scenarios', () => {
+  test('the bridge exposes the expected scenario names', async ({ page }) => {
+    await page.goto('/');
+    await waitForGame(page);
+
+    const names = await page.evaluate(() => window.__solitaire!.listScenarios());
+    expect(names).toEqual(
+      expect.arrayContaining(['oneMoveFromWinning', 'autoCompleteReady', 'fourKingsToWin']),
+    );
+  });
+
+  test('loadScenario rejects an unknown name', async ({ page }) => {
+    await page.goto('/');
+    await waitForGame(page);
+
+    const ok = await page.evaluate(() => window.__solitaire!.loadScenario('does-not-exist'));
+    expect(ok).toBe(false);
+  });
+
+  test('every scenario loads a complete, valid 52-card board', async ({ page }) => {
+    await page.goto('/');
+    await waitForGame(page);
+
+    for (const name of ['oneMoveFromWinning', 'autoCompleteReady', 'fourKingsToWin'] as const) {
+      await loadScenario(page, name);
+      const s = await summary(page);
+      const tableauTotal = s.tableauSizes.reduce((a, b) => a + b, 0);
+      expect(s.foundationTotal + tableauTotal + s.drawPile + s.discardPile).toBe(52);
+      expect(s.gameWon).toBe(false);
+    }
+  });
+
+  test('autoCompleteReady is solved to a win by auto-play', async ({ page }) => {
+    await page.goto('/');
+    await waitForGame(page);
+    await loadScenario(page, 'autoCompleteReady');
+
+    // The Ace of each suit is exposed — reachable via the new ARIA button role.
+    await expect(page.getByRole('button', { name: 'A of hearts' })).toBeVisible();
+
+    await page.evaluate(() => window.__solitaire!.toggleAutoPlay());
+
+    await expect.poll(() => summary(page).then((s) => s.foundationTotal), {
+      timeout: 20_000,
+    }).toBe(52);
+    expect(await page.evaluate(() => window.__solitaire!.isWon())).toBe(true);
+  });
+
+  test('fourKingsToWin: one foundation click hands off to auto-complete', async ({ page }) => {
+    await page.goto('/');
+    await waitForGame(page);
+    await loadScenario(page, 'fourKingsToWin');
+
+    // Moving the first King leaves the board sorted with the stock empty, so
+    // auto-complete takes over and finishes the remaining three Kings.
+    await page.getByTestId('card-hearts-K').click();
+    await page.getByTestId('foundation-hearts').click();
+
+    await expect(page.getByTestId('win-modal')).toBeVisible({ timeout: 10_000 });
+    const s = await summary(page);
+    expect(s.gameWon).toBe(true);
+    expect(s.foundationTotal).toBe(52);
+  });
+});

--- a/packages/app/e2e/test-bridge.spec.ts
+++ b/packages/app/e2e/test-bridge.spec.ts
@@ -48,7 +48,7 @@ test.describe('window.__solitaire test bridge', () => {
       keys: Object.keys(window.__solitaire!).sort(),
     }));
 
-    expect(info.version).toBe(1);
+    expect(info.version).toBe(2);
     expect(info.keys).toEqual(
       [
         'deselect',
@@ -58,6 +58,8 @@ test.describe('window.__solitaire test bridge', () => {
         'getState',
         'getSummary',
         'isWon',
+        'listScenarios',
+        'loadScenario',
         'loadState',
         'moveToFoundation',
         'moveToTableau',

--- a/packages/app/e2e/user-journey.spec.ts
+++ b/packages/app/e2e/user-journey.spec.ts
@@ -1,62 +1,20 @@
 import { test, expect } from '@playwright/test';
-import { waitForGame, summary } from './helpers';
-import type { Card, GameState, Rank, Suit } from '../src/types';
+import { waitForGame, summary, loadScenario } from './helpers';
 
 /**
  * End-to-end win journey — plays the app the way a real player would, through
- * visible UI only. Winning a real deal is impractical to script, so the bridge
- * crafts a deterministic one-move-from-winning state; the actual winning move
- * is then performed by real clicks. This covers the win path that the deal- and
- * interaction-focused specs cannot reach.
+ * visible UI only. Winning a real deal is impractical to script, so the
+ * `oneMoveFromWinning` scenario fixture jumps straight to a deterministic
+ * one-move-from-victory state; the actual winning move is then performed by
+ * real clicks. This covers the win path that the deal- and interaction-focused
+ * specs cannot reach.
  */
-
-const RANKS: Rank[] = ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K'];
-
-function card(suit: Suit, rank: Rank): Card {
-  return { suit, rank, faceUp: true, id: `${suit}-${rank}` };
-}
-
-/** A full A→K foundation pile for one suit. */
-function fullFoundation(suit: Suit): Card[] {
-  return RANKS.map((rank) => card(suit, rank));
-}
-
-/**
- * A game one move from victory: hearts/diamonds/clubs complete, spades filled
- * A→Q, and the spades King sitting face-up on tableau column 0.
- */
-function oneMoveFromWinning(): string {
-  const state: GameState = {
-    drawPile: [],
-    discardPile: [],
-    foundations: {
-      hearts: fullFoundation('hearts'),
-      diamonds: fullFoundation('diamonds'),
-      clubs: fullFoundation('clubs'),
-      spades: RANKS.slice(0, 12).map((rank) => card('spades', rank)),
-    },
-    tableau: [[card('spades', 'K')], [], [], [], [], [], []],
-    moveHistory: [],
-    showValidMoves: true,
-    godMode: false,
-    autoPlayEnabled: false,
-    autoPlayInProgress: false,
-    difficulty: 3,
-    gameWon: false,
-    completionProgress: 98,
-    replayMode: false,
-    replayIndex: 0,
-    replayPaused: false,
-    replaySpeed: 1000,
-  };
-  return JSON.stringify(state);
-}
 
 test.describe('User journey: winning the game', () => {
   test('completing the last move shows the win modal and statistics', async ({ page }) => {
     await page.goto('/');
     await waitForGame(page);
-    await page.evaluate((json) => window.__solitaire!.loadState(json), oneMoveFromWinning());
+    await loadScenario(page, 'oneMoveFromWinning');
 
     // Not won yet — the modal must be absent.
     await expect(page.getByTestId('win-modal')).toBeHidden();
@@ -80,7 +38,7 @@ test.describe('User journey: winning the game', () => {
   }) => {
     await page.goto('/');
     await waitForGame(page);
-    await page.evaluate((json) => window.__solitaire!.loadState(json), oneMoveFromWinning());
+    await loadScenario(page, 'oneMoveFromWinning');
 
     await page.getByTestId('card-spades-K').click();
     await page.getByTestId('foundation-spades').click();

--- a/packages/app/src/components/ActivityLog.tsx
+++ b/packages/app/src/components/ActivityLog.tsx
@@ -92,11 +92,12 @@ const ActivityLog: React.FC = () => {
   };
 
   return (
-    <div className="bg-white/90 backdrop-blur-sm rounded-lg shadow-xl w-full overflow-hidden">
+    <div data-testid="activity-log" className="bg-white/90 backdrop-blur-sm rounded-lg shadow-xl w-full overflow-hidden">
       {/* Header */}
       <div className="bg-blue-600 text-white px-4 py-2 flex items-center justify-between">
         <h3 className="text-lg font-bold">Activity Log</h3>
         <button
+          data-testid="activity-log-toggle-btn"
           onClick={handleToggleMinimize}
           className="hover:bg-blue-700 rounded px-2 py-1 transition-colors text-sm font-semibold"
           aria-label={isMinimized ? 'Expand' : 'Minimize'}
@@ -111,6 +112,7 @@ const ActivityLog: React.FC = () => {
           {/* Controls */}
           <div className="p-3 border-b border-gray-200 flex gap-2">
             <button
+              data-testid="activity-log-copy-btn"
               onClick={handleCopyToClipboard}
               className="flex-1 bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-3 rounded transition-colors text-sm"
               disabled={visibleLogs.length === 0}
@@ -118,6 +120,7 @@ const ActivityLog: React.FC = () => {
               📋 Copy
             </button>
             <button
+              data-testid="activity-log-clear-btn"
               onClick={handleClearView}
               className="flex-1 bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-3 rounded transition-colors text-sm"
               disabled={visibleLogs.length === 0}
@@ -127,7 +130,7 @@ const ActivityLog: React.FC = () => {
           </div>
 
           {/* Log Display */}
-          <div className="h-48 lg:h-96 overflow-y-auto p-3 bg-gray-50">
+          <div data-testid="activity-log-entries" className="h-48 lg:h-96 overflow-y-auto p-3 bg-gray-50">
             {visibleLogs.length === 0 ? (
               <p className="text-gray-500 text-center text-sm mt-8">No activities yet</p>
             ) : (
@@ -138,6 +141,7 @@ const ActivityLog: React.FC = () => {
                   return (
                     <div
                       key={`${move.timestamp}-${index}`}
+                      data-testid="activity-log-entry"
                       className={`text-xs p-2 rounded shadow-sm border transition-colors ${
                         isDeadendOrLoop
                           ? 'bg-red-50 border-red-300 text-red-900 font-semibold'
@@ -156,7 +160,7 @@ const ActivityLog: React.FC = () => {
 
           {/* Footer */}
           <div className="px-3 py-2 bg-gray-100 border-t border-gray-200">
-            <p className="text-xs text-gray-600 text-center">
+            <p data-testid="activity-log-count" className="text-xs text-gray-600 text-center">
               Total: {visibleLogs.length} {visibleLogs.length === 1 ? 'activity' : 'activities'}
             </p>
           </div>

--- a/packages/app/src/components/Card.tsx
+++ b/packages/app/src/components/Card.tsx
@@ -28,6 +28,9 @@ interface CardProps {
 const Card: React.FC<CardProps> = ({ card, onClick, isInteractable = false, isSelected = false, hasValidMoves = false, godMode = false }) => {
   const { suit, rank, faceUp } = card;
 
+  // Accessible name — also makes cards reachable via Playwright's getByRole.
+  const ariaLabel = faceUp ? `${rank} of ${suit}` : 'Face-down card';
+
   // Check for reduced motion preference
   const shouldReduceMotion = useMemo(() => checkReducedMotion(), []);
 
@@ -94,6 +97,8 @@ const Card: React.FC<CardProps> = ({ card, onClick, isInteractable = false, isSe
         >
           <motion.div
             onClick={onClick}
+            role={onClick ? 'button' : undefined}
+            aria-label={ariaLabel}
             className={`w-20 h-28 bg-white border-2 border-gray-300 rounded-lg flex flex-col p-2 cursor-pointer shadow-md select-none ${color} ${getHighlightClass()} opacity-40`}
             whileHover={isInteractable && !shouldReduceMotion ? "hover" : undefined}
             variants={hoverVariants}
@@ -123,6 +128,8 @@ const Card: React.FC<CardProps> = ({ card, onClick, isInteractable = false, isSe
         data-card-rank={rank}
         data-card-faceup="false"
         onClick={onClick}
+        role={onClick ? 'button' : undefined}
+        aria-label={ariaLabel}
         className={`w-20 h-28 bg-blue-900 border-2 border-blue-700 rounded-lg flex items-center justify-center cursor-pointer shadow-md select-none ${getHighlightClass()}`}
         initial={shouldReduceMotion ? undefined : "faceDown"}
         animate={shouldReduceMotion ? undefined : "faceDown"}
@@ -143,6 +150,8 @@ const Card: React.FC<CardProps> = ({ card, onClick, isInteractable = false, isSe
       data-card-rank={rank}
       data-card-faceup="true"
       onClick={onClick}
+      role={onClick ? 'button' : undefined}
+      aria-label={ariaLabel}
       className={`w-20 h-28 bg-white border-2 border-gray-300 rounded-lg flex flex-col p-2 cursor-pointer shadow-md select-none ${color} ${getHighlightClass()}`}
       initial={shouldReduceMotion ? undefined : "faceUp"}
       animate={shouldReduceMotion ? undefined : (isSelected ? { scale: 1.05 } : "faceUp")}

--- a/packages/app/src/components/ControlPanel.tsx
+++ b/packages/app/src/components/ControlPanel.tsx
@@ -100,7 +100,7 @@ const ControlPanel: React.FC = () => {
       {/* Move Counter */}
       <div data-testid="move-counter" className="bg-green-600 text-white font-bold py-2 px-4 rounded text-center mb-4">
         <div className="text-sm">Moves</div>
-        <div className="text-2xl">{moveCount}</div>
+        <div data-testid="move-count" className="text-2xl">{moveCount}</div>
       </div>
 
       {/* Metrics Display */}

--- a/packages/app/src/components/DrawPile.tsx
+++ b/packages/app/src/components/DrawPile.tsx
@@ -27,8 +27,14 @@ const DrawPile: React.FC = () => {
   };
 
   return (
-    <motion.div 
+    <motion.div
       data-testid="draw-pile"
+      role="button"
+      aria-label={
+        drawPile.length > 0
+          ? `Draw pile, ${drawPile.length} cards`
+          : 'Draw pile empty, click to recycle'
+      }
       className={`relative w-20 h-28 ${replayMode ? 'cursor-not-allowed opacity-75' : 'cursor-pointer'}`}
       onClick={replayMode ? undefined : drawCard}
       whileHover={shouldReduceMotion || replayMode ? {} : { scale: 1.05 }}

--- a/packages/app/src/components/FoundationPile.tsx
+++ b/packages/app/src/components/FoundationPile.tsx
@@ -66,7 +66,13 @@ const FoundationPile: React.FC<FoundationPileProps> = ({ suit }) => {
   };
 
   return (
-    <div data-testid={`foundation-${suit}`} className="relative w-20 h-28" onClick={handleClick}>
+    <div
+      data-testid={`foundation-${suit}`}
+      role="button"
+      aria-label={`${suit} foundation, ${foundation.length} cards`}
+      className="relative w-20 h-28"
+      onClick={handleClick}
+    >
       <AnimatePresence mode="wait">
         {foundation.length > 0 ? (
           <motion.div 

--- a/packages/app/src/components/ReplayControls.tsx
+++ b/packages/app/src/components/ReplayControls.tsx
@@ -46,10 +46,11 @@ const ReplayControls: React.FC = () => {
   };
 
   return (
-    <div className="bg-white/95 backdrop-blur-sm rounded-lg shadow-xl p-4 mb-4">
+    <div data-testid="replay-controls" className="bg-white/95 backdrop-blur-sm rounded-lg shadow-xl p-4 mb-4">
       <div className="flex items-center justify-between mb-3">
         <h3 className="text-lg font-bold text-gray-800">🎬 Replay Mode</h3>
         <button
+          data-testid="replay-exit-btn"
           onClick={stopReplay}
           className="px-3 py-1 bg-red-600 hover:bg-red-700 text-white font-semibold rounded transition-colors text-sm"
         >
@@ -60,7 +61,7 @@ const ReplayControls: React.FC = () => {
       {/* Progress Bar */}
       <div className="mb-3">
         <div className="flex justify-between items-center mb-1">
-          <span className="text-sm font-semibold text-gray-700">
+          <span data-testid="replay-progress" className="text-sm font-semibold text-gray-700">
             Move {replayIndex} / {totalMoves}
           </span>
           <span className="text-xs text-gray-600">
@@ -68,6 +69,7 @@ const ReplayControls: React.FC = () => {
           </span>
         </div>
         <div
+          data-testid="replay-progress-bar"
           className="w-full bg-gray-200 rounded-full h-3 cursor-pointer"
           onClick={handleProgressClick}
         >
@@ -81,6 +83,7 @@ const ReplayControls: React.FC = () => {
       {/* Control Buttons */}
       <div className="flex items-center justify-center gap-2 mb-3">
         <button
+          data-testid="replay-back-btn"
           onClick={stepBackward}
           disabled={isAtStart}
           className="px-3 py-2 bg-gray-600 hover:bg-gray-700 text-white font-semibold rounded transition-colors text-sm disabled:bg-gray-400 disabled:cursor-not-allowed"
@@ -91,6 +94,7 @@ const ReplayControls: React.FC = () => {
         
         {replayPaused || isAtEnd ? (
           <button
+            data-testid="replay-play-btn"
             onClick={isAtEnd ? () => {
               goToReplayIndex(0);
               resumeReplay();
@@ -102,6 +106,7 @@ const ReplayControls: React.FC = () => {
           </button>
         ) : (
           <button
+            data-testid="replay-play-btn"
             onClick={pauseReplay}
             className="px-4 py-2 bg-yellow-600 hover:bg-yellow-700 text-white font-semibold rounded transition-colors text-sm"
             title="Pause"
@@ -111,6 +116,7 @@ const ReplayControls: React.FC = () => {
         )}
         
         <button
+          data-testid="replay-forward-btn"
           onClick={stepForward}
           disabled={isAtEnd}
           className="px-3 py-2 bg-gray-600 hover:bg-gray-700 text-white font-semibold rounded transition-colors text-sm disabled:bg-gray-400 disabled:cursor-not-allowed"
@@ -127,6 +133,7 @@ const ReplayControls: React.FC = () => {
         </label>
         <select
           id="replay-speed"
+          data-testid="replay-speed-select"
           value={replaySpeed}
           onChange={handleSpeedChange}
           className="px-2 py-1 border border-gray-300 rounded text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"

--- a/packages/app/src/components/TableauColumn.tsx
+++ b/packages/app/src/components/TableauColumn.tsx
@@ -88,7 +88,13 @@ const TableauColumn: React.FC<TableauColumnProps> = ({ columnIndex }) => {
   };
 
   return (
-    <div data-testid={`tableau-column-${columnIndex}`} className="relative w-20" style={{ minHeight: `${columnHeight}px` }}>
+    <div
+      data-testid={`tableau-column-${columnIndex}`}
+      role="group"
+      aria-label={`Tableau column ${columnIndex + 1}`}
+      className="relative w-20"
+      style={{ minHeight: `${columnHeight}px` }}
+    >
       {column.length > 0 ? (
         <div className="relative">
           <AnimatePresence mode="popLayout">
@@ -140,6 +146,8 @@ const TableauColumn: React.FC<TableauColumnProps> = ({ columnIndex }) => {
       ) : (
         <motion.div
           onClick={handleEmptyColumnClick}
+          role="button"
+          aria-label={`Tableau column ${columnIndex + 1}, empty`}
           className={`w-20 h-28 border-2 border-dashed rounded-lg bg-gray-100 cursor-pointer transition-all ${
             isValidDestination
               ? 'border-cyan-500 bg-cyan-100 ring-4 ring-cyan-400 shadow-lg shadow-cyan-500/50'

--- a/packages/app/src/testBridge.ts
+++ b/packages/app/src/testBridge.ts
@@ -19,6 +19,7 @@
  */
 
 import { useGameStore } from './store/gameStore';
+import { scenarios, scenarioNames, isScenarioName } from './testScenarios';
 import type { Card, Difficulty, GameState, Suit } from './types';
 
 /** Compact, token-efficient game snapshot for agents. */
@@ -94,6 +95,13 @@ export interface SolitaireTestBridge {
     | { source: 'discard' }
     | { source: 'foundation'; suit: Suit }
     | null;
+  /** Names of the built-in board-state fixtures available to `loadScenario`. */
+  listScenarios: () => string[];
+  /**
+   * Load a named board-state fixture for a fast, deterministic re-run — see
+   * the `testScenarios` module. Returns `false` for an unknown name.
+   */
+  loadScenario: (name: string) => boolean;
 }
 
 declare global {
@@ -171,7 +179,7 @@ export function installTestBridge(): void {
   }
 
   const bridge: SolitaireTestBridge = {
-    version: 1,
+    version: 2,
     getState: () => useGameStore.getState(),
     getSummary: () => buildSummary(useGameStore.getState()),
     newGame: (options) =>
@@ -187,6 +195,10 @@ export function installTestBridge(): void {
     toggleAutoPlay: () => useGameStore.getState().toggleAutoPlay(),
     isWon: () => useGameStore.getState().gameWon,
     findCard: (cardId) => locateCard(useGameStore.getState(), cardId),
+    listScenarios: () => [...scenarioNames],
+    loadScenario: (name) =>
+      isScenarioName(name) &&
+      useGameStore.getState().importGameState(JSON.stringify(scenarios[name]())),
   };
 
   window.__solitaire = bridge;

--- a/packages/app/src/testScenarios.test.ts
+++ b/packages/app/src/testScenarios.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { scenarios, scenarioNames, isScenarioName } from './testScenarios';
+import { useGameStore } from './store/gameStore';
+
+/**
+ * Validates that every board-state fixture is a complete, legal 52-card deal
+ * the store will accept — a broken fixture should fail here, not mid-test.
+ */
+
+describe('testScenarios', () => {
+  beforeEach(() => {
+    useGameStore.getState().initializeGame();
+  });
+
+  it('exposes a non-empty, consistent scenario list', () => {
+    expect(scenarioNames.length).toBeGreaterThan(0);
+    expect(scenarioNames).toEqual(Object.keys(scenarios));
+  });
+
+  it.each(scenarioNames)('"%s" is a complete 52-card deal with unique cards', (name) => {
+    const state = scenarios[name]();
+    const allCards = [
+      ...state.drawPile,
+      ...state.discardPile,
+      ...state.foundations.hearts,
+      ...state.foundations.diamonds,
+      ...state.foundations.clubs,
+      ...state.foundations.spades,
+      ...state.tableau.flat(),
+    ];
+
+    expect(allCards).toHaveLength(52);
+    expect(new Set(allCards.map((c) => c.id)).size).toBe(52);
+    expect(state.tableau).toHaveLength(7);
+  });
+
+  it.each(scenarioNames)('"%s" is accepted by importGameState', (name) => {
+    const ok = useGameStore.getState().importGameState(JSON.stringify(scenarios[name]()));
+    expect(ok).not.toBe(false);
+  });
+
+  it('isScenarioName guards unknown names', () => {
+    expect(isScenarioName('oneMoveFromWinning')).toBe(true);
+    expect(isScenarioName('nope')).toBe(false);
+  });
+});

--- a/packages/app/src/testScenarios.ts
+++ b/packages/app/src/testScenarios.ts
@@ -1,0 +1,132 @@
+/**
+ * Named board-state fixtures for fast, deterministic re-runs.
+ *
+ * Some game states — winnable end-games, fully-sorted boards, one-move-from-win
+ * — are impractical to reach by playing from a seed. These factories craft them
+ * directly so tests (and agents driving the `window.__solitaire` bridge) can
+ * jump straight to an interesting position.
+ *
+ * Each factory returns a fresh, complete 52-card `GameState`. Load one with
+ * `window.__solitaire.loadScenario('<name>')` or `importGameState(...)`.
+ *
+ * @module testScenarios
+ */
+
+import type { Card, GameState, Rank, Suit } from './types';
+
+const RANKS: Rank[] = ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K'];
+
+/** Builds a single card. Ids follow the `card-<suit>-<rank>` test-id convention. */
+function card(suit: Suit, rank: Rank, faceUp = true): Card {
+  return { suit, rank, faceUp, id: `${suit}-${rank}` };
+}
+
+/** A full A→K run for one suit, all face up. */
+function fullSuit(suit: Suit): Card[] {
+  return RANKS.map((rank) => card(suit, rank));
+}
+
+/** Fills in sensible defaults so a factory only specifies what matters. */
+function baseState(partial: Partial<GameState>): GameState {
+  return {
+    drawPile: [],
+    discardPile: [],
+    foundations: { hearts: [], diamonds: [], clubs: [], spades: [] },
+    tableau: [[], [], [], [], [], [], []],
+    moveHistory: [],
+    showValidMoves: true,
+    godMode: false,
+    autoPlayEnabled: false,
+    autoPlayInProgress: false,
+    difficulty: 3,
+    gameWon: false,
+    completionProgress: 0,
+    replayMode: false,
+    replayIndex: 0,
+    replayPaused: false,
+    replaySpeed: 1000,
+    ...partial,
+  };
+}
+
+/**
+ * One move from victory: hearts/diamonds/clubs complete, spades filled A→Q, and
+ * the spades King sitting face-up on tableau column 0. Clicking the King then
+ * its foundation wins. Use to exercise the win modal and end-of-game UI.
+ */
+function oneMoveFromWinning(): GameState {
+  return baseState({
+    foundations: {
+      hearts: fullSuit('hearts'),
+      diamonds: fullSuit('diamonds'),
+      clubs: fullSuit('clubs'),
+      spades: RANKS.slice(0, 12).map((rank) => card('spades', rank)),
+    },
+    tableau: [[card('spades', 'K')], [], [], [], [], [], []],
+    completionProgress: 98,
+  });
+}
+
+/**
+ * A fully-sorted end-game: every card face up, stock and discard empty, each of
+ * four columns a complete suit stacked K→A (Ace exposed). Foundations empty.
+ * Toggling auto-play must drive this to a win using foundation moves only.
+ */
+function autoCompleteReady(): GameState {
+  return baseState({
+    tableau: [
+      [...fullSuit('hearts')].reverse(),
+      [...fullSuit('diamonds')].reverse(),
+      [...fullSuit('clubs')].reverse(),
+      [...fullSuit('spades')].reverse(),
+      [],
+      [],
+      [],
+    ],
+  });
+}
+
+/**
+ * Foundations filled A→Q for all four suits, the four Kings spread across
+ * tableau columns 0–3. Exactly four foundation moves win — a quick, fully
+ * deterministic interaction scenario.
+ */
+function fourKingsToWin(): GameState {
+  const upToQueen = RANKS.slice(0, 12);
+  return baseState({
+    foundations: {
+      hearts: upToQueen.map((rank) => card('hearts', rank)),
+      diamonds: upToQueen.map((rank) => card('diamonds', rank)),
+      clubs: upToQueen.map((rank) => card('clubs', rank)),
+      spades: upToQueen.map((rank) => card('spades', rank)),
+    },
+    tableau: [
+      [card('hearts', 'K')],
+      [card('diamonds', 'K')],
+      [card('clubs', 'K')],
+      [card('spades', 'K')],
+      [],
+      [],
+      [],
+    ],
+    completionProgress: 92,
+  });
+}
+
+/** All available scenario factories, keyed by name. */
+export const scenarios = {
+  oneMoveFromWinning,
+  autoCompleteReady,
+  fourKingsToWin,
+} satisfies Record<string, () => GameState>;
+
+/** Union of valid scenario names. */
+export type ScenarioName = keyof typeof scenarios;
+
+/** Ordered list of scenario names. */
+export const scenarioNames = Object.keys(scenarios) as ScenarioName[];
+
+/** Type guard for an arbitrary string being a known scenario name. */
+export function isScenarioName(name: string): name is ScenarioName {
+  return name in scenarios;
+}


### PR DESCRIPTION
Follow-up to #152. Closes the remaining UI testability gaps and adds reusable board-state fixtures for fast, deterministic test re-runs.

## Testability gaps closed

- **ReplayControls** — `data-testid` on the container and every interactive element: `replay-controls`, `replay-exit-btn`, `replay-back-btn`, `replay-play-btn`, `replay-forward-btn`, `replay-progress`, `replay-progress-bar`, `replay-speed-select`.
- **ActivityLog** — `activity-log`, `activity-log-toggle-btn`, `activity-log-copy-btn`, `activity-log-clear-btn`, `activity-log-entries`, `activity-log-entry`, `activity-log-count`.
- **ControlPanel** — `move-count` on the move value (the convention was documented but missing).
- **ARIA** — cards and piles now carry `role` + `aria-label`, so `getByRole('button', { name: 'A of hearts' })` and Playwright MCP's accessibility-tree mode work as first-class locators. (Card `role` is set only when the card is interactive, avoiding invalid nested buttons.)

## Board-state scenarios

New `src/testScenarios.ts` defines named `GameState` fixtures for positions impractical to reach from a seed:

| Scenario | Position |
|---|---|
| `oneMoveFromWinning` | One click from victory. |
| `autoCompleteReady` | Fully-sorted end-game; auto-play solves it. |
| `fourKingsToWin` | Foundations A→Q, four Kings in the tableau. |

- Test bridge gains `listScenarios()` and `loadScenario(name)`; `version` bumped to 2.
- e2e helper `loadScenario(page, name)`; `user-journey.spec.ts` now uses the shared fixture instead of an inline crafted state.
- New `e2e/scenarios.spec.ts` (5 tests) and unit `src/testScenarios.test.ts` (validates each fixture is a complete, unique 52-card deal the store accepts).
- Skill doc updated with the new selectors, bridge methods and scenarios.

## Verification

Lint clean · 135 unit tests pass · 39 e2e tests pass · production build succeeds.