### PR TITLE
feat: AI Move Advisor (LLM-powered next-best-move)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Solitaire — environment variables
+#
+# Copy this file to `.env` (which is git-ignored) and fill in your values.
+# Used only for LOCAL DEVELOPMENT convenience: in `pnpm dev`, the AI Move
+# Advisor will fall back to this key so you don't have to paste it into the UI.
+# It is NEVER bundled into a production build.
+#
+# Get a key at: https://aistudio.google.com/apikey
+GEMINI_API_KEY=your-gemini-api-key-here

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@ dist
 dist-ssr
 *.local
 
+# Environment files — contain secrets (e.g. GEMINI_API_KEY); never commit
+.env
+.env.*
+!.env.example
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/packages/app/e2e/ai-advisor.spec.ts
+++ b/packages/app/e2e/ai-advisor.spec.ts
@@ -1,0 +1,152 @@
+import { test, expect } from '@playwright/test';
+import { waitForGame, summary } from './helpers';
+
+/**
+ * E2E coverage for the AI Move Advisor.
+ *
+ * Every test installs a deterministic provider stub via the test bridge
+ * (`setAIProviderStub`), so these tests never make a network call and never
+ * need a real API key.
+ */
+test.describe('AI Move Advisor', () => {
+  test('renders the AI advisor panel and Ask AI button', async ({ page }) => {
+    await page.goto('/?seed=1');
+    await waitForGame(page);
+
+    await expect(page.getByTestId('ai-advisor-panel')).toBeVisible();
+    await expect(page.getByTestId('ask-ai-btn')).toBeVisible();
+  });
+
+  test('asks the AI, applies the chosen move, and logs the reasoning', async ({ page }) => {
+    await page.goto('/?seed=1');
+    await waitForGame(page);
+
+    // Install a stub that always picks the first legal move.
+    await page.evaluate(() => {
+      window.__solitaire!.setAIProviderStub(() => ({
+        moveIndex: 0,
+        reasoning: 'E2E stub: opening the game.',
+        confidence: 0.83,
+      }));
+    });
+
+    const before = (await summary(page)).moveCount;
+    await page.getByTestId('ask-ai-btn').click();
+
+    // Wait for the decision to be recorded.
+    await page.waitForFunction(() => window.__solitaire!.getAIState().decisionCount === 1);
+
+    // A move was applied.
+    expect((await summary(page)).moveCount).toBeGreaterThan(before);
+
+    // The advisor panel shows the decision + reasoning.
+    await expect(page.getByTestId('ai-last-decision')).toBeVisible();
+    await expect(page.getByTestId('ai-reasoning')).toContainText('opening the game');
+
+    // The activity log surfaces the AI reasoning on the move entry.
+    await expect(page.getByTestId('activity-log-ai-reasoning').first()).toContainText(
+      'opening the game',
+    );
+
+    // No error, not stuck thinking.
+    const ai = await page.evaluate(() => window.__solitaire!.getAIState());
+    expect(ai.thinking).toBe(false);
+    expect(ai.error).toBeNull();
+  });
+
+  test('surfaces a provider error in the advisor panel', async ({ page }) => {
+    await page.goto('/?seed=1');
+    await waitForGame(page);
+
+    await page.evaluate(() => {
+      window.__solitaire!.setAIProviderStub(() => {
+        throw new Error('E2E stub failure');
+      });
+    });
+
+    const before = (await summary(page)).moveCount;
+    await page.getByTestId('ask-ai-btn').click();
+
+    await page.waitForFunction(() => window.__solitaire!.getAIState().error !== null);
+
+    await expect(page.getByTestId('ai-error')).toContainText('E2E stub failure');
+    // The board is untouched on failure.
+    expect((await summary(page)).moveCount).toBe(before);
+  });
+
+  test('opens and closes the API key modal', async ({ page }) => {
+    await page.goto('/?seed=1');
+    await waitForGame(page);
+
+    await page.getByTestId('ai-settings-toggle-btn').click();
+    await page.getByTestId('ai-key-settings-btn').click();
+
+    await expect(page.getByTestId('ai-key-modal')).toBeVisible();
+    await expect(page.getByTestId('ai-model-input')).toBeVisible();
+
+    await page.getByTestId('ai-key-modal-close-btn').click();
+    await expect(page.getByTestId('ai-key-modal')).toBeHidden();
+  });
+
+  test('applies a context preset chosen in AI settings', async ({ page }) => {
+    await page.goto('/?seed=1');
+    await waitForGame(page);
+
+    await page.getByTestId('ai-settings-toggle-btn').click();
+    await page.getByTestId('ai-preset-select').selectOption('minimal');
+
+    const ai = await page.evaluate(() => window.__solitaire!.getAIState());
+    expect(ai.preset).toBe('minimal');
+  });
+
+  test('AI auto-play keeps making moves until stopped', async ({ page }) => {
+    await page.goto('/?seed=1');
+    await waitForGame(page);
+
+    await page.evaluate(() => {
+      window.__solitaire!.setAIProviderStub(() => ({
+        moveIndex: 0,
+        reasoning: 'E2E stub: auto-play move.',
+        confidence: 0.5,
+      }));
+    });
+
+    // Start auto-play.
+    await page.getByTestId('ai-auto-play-btn').click();
+    await expect(page.getByTestId('ai-auto-badge')).toBeVisible();
+
+    // It keeps playing move after move on its own.
+    await page.waitForFunction(() => window.__solitaire!.getAIState().decisionCount >= 3, null, {
+      timeout: 15000,
+    });
+    expect(await page.evaluate(() => window.__solitaire!.getAIState().autoPlay)).toBe(true);
+
+    // Stop it.
+    await page.getByTestId('ai-auto-play-btn').click();
+    await expect(page.getByTestId('ai-auto-badge')).toBeHidden();
+    expect(await page.evaluate(() => window.__solitaire!.getAIState().autoPlay)).toBe(false);
+
+    // Every auto-play move is logged with its AI reasoning.
+    expect(await page.getByTestId('activity-log-ai-reasoning').count()).toBeGreaterThanOrEqual(2);
+  });
+
+  test('respects the chosen move index from the stub', async ({ page }) => {
+    await page.goto('/?seed=1');
+    await waitForGame(page);
+
+    // Pick the last legal move rather than the first.
+    await page.evaluate(() => {
+      window.__solitaire!.setAIProviderStub((ctx) => ({
+        moveIndex: ctx.legalMoves.length - 1,
+        reasoning: 'E2E stub: chose the last legal move.',
+        confidence: 0.5,
+      }));
+    });
+
+    await page.getByTestId('ask-ai-btn').click();
+    await page.waitForFunction(() => window.__solitaire!.getAIState().decisionCount === 1);
+
+    const ai = await page.evaluate(() => window.__solitaire!.getAIState());
+    expect(ai.lastDecision?.reasoning).toContain('last legal move');
+  });
+});

--- a/packages/app/e2e/test-bridge.spec.ts
+++ b/packages/app/e2e/test-bridge.spec.ts
@@ -48,13 +48,16 @@ test.describe('window.__solitaire test bridge', () => {
       keys: Object.keys(window.__solitaire!).sort(),
     }));
 
-    expect(info.version).toBe(2);
+    expect(info.version).toBe(3);
     expect(info.keys).toEqual(
       [
+        'askAI',
+        'cancelAI',
         'deselect',
         'draw',
         'exportState',
         'findCard',
+        'getAIState',
         'getState',
         'getSummary',
         'isWon',
@@ -65,6 +68,9 @@ test.describe('window.__solitaire test bridge', () => {
         'moveToTableau',
         'newGame',
         'select',
+        'setAIConfig',
+        'setAIProviderStub',
+        'toggleAIAutoPlay',
         'toggleAutoPlay',
         'version',
       ].sort(),

--- a/packages/app/scripts/gemma-smoke.mts
+++ b/packages/app/scripts/gemma-smoke.mts
@@ -1,0 +1,64 @@
+/**
+ * One-off smoke test: exercises the real GeminiProvider against the live
+ * gemma-4-31b-it model. Not part of the test suite. Run with:
+ *   GEMINI_API_KEY=... npx tsx scripts/gemma-smoke.mts
+ */
+import { geminiProvider } from '../src/ai/providers/GeminiProvider';
+import { buildSystemInstruction } from '../src/ai/context/systemInstruction';
+import { DEFAULT_AI_CONFIG } from '../src/ai/context/presets';
+import type { AIMoveContext } from '../src/ai/types';
+
+const context: AIMoveContext = {
+  notation: 'rank then suit (A 2-9 T J Q K; H D C S)',
+  foundations: { hearts: null, diamonds: null, clubs: null, spades: null },
+  tableau: [
+    { faceDownCount: 0, faceUp: ['KS'] },
+    { faceDownCount: 1, faceUp: ['9H'] },
+    { faceDownCount: 2, faceUp: ['AD'] },
+    { faceDownCount: 3, faceUp: ['7C'] },
+    { faceDownCount: 4, faceUp: ['QS'] },
+    { faceDownCount: 5, faceUp: ['4H'] },
+    { faceDownCount: 6, faceUp: ['TC'] },
+  ],
+  discardTop: null,
+  drawPileCount: 24,
+  canRecycleStock: false,
+  legalMoves: [
+    { index: 0, type: 'draw_card', describe: 'Draw the next card from the stock' },
+    {
+      index: 1,
+      type: 'tableau_to_foundation',
+      describe: 'Send AD from column 3 to the diamonds foundation',
+    },
+    {
+      index: 2,
+      type: 'tableau_to_tableau',
+      describe: 'Move 9H from column 2 to column 7 (onto TC)',
+    },
+  ],
+};
+
+const key = process.env.GEMINI_API_KEY;
+if (!key) {
+  console.error('GEMINI_API_KEY not set');
+  process.exit(1);
+}
+
+const started = Date.now();
+geminiProvider
+  .suggestMove({
+    apiKey: key,
+    model: 'gemma-4-31b-it',
+    systemInstruction: buildSystemInstruction(DEFAULT_AI_CONFIG),
+    context,
+  })
+  .then((decision) => {
+    console.log(`OK in ${((Date.now() - started) / 1000).toFixed(1)}s`);
+    console.log(JSON.stringify(decision, null, 2));
+    const chosen = context.legalMoves[decision.moveIndex];
+    console.log(`Chosen move: ${chosen?.describe}`);
+  })
+  .catch((err) => {
+    console.error(`FAILED in ${((Date.now() - started) / 1000).toFixed(1)}s:`, err);
+    process.exit(1);
+  });

--- a/packages/app/src/adapters/coreAdapter.ts
+++ b/packages/app/src/adapters/coreAdapter.ts
@@ -12,6 +12,7 @@
 
 import type { GameState as CoreGameState, Move as CoreMove } from '@chayuto/solitaire-core';
 import type { GameState as UIGameState, Card, Move } from '../types';
+import { DEFAULT_AI_CONFIG } from '../ai/context/presets';
 
 /**
  * Convert UI GameState to Core GameState
@@ -94,6 +95,15 @@ export function coreToUI(coreState: CoreGameState, existingUIState: UIGameState)
     replayIndex: existingUIState.replayIndex,
     replayPaused: existingUIState.replayPaused,
     replaySpeed: existingUIState.replaySpeed,
+
+    // Preserve AI advisor fields from existing state
+    aiConfig: existingUIState.aiConfig,
+    aiThinking: existingUIState.aiThinking,
+    aiAutoPlay: existingUIState.aiAutoPlay,
+    aiThinkingSince: existingUIState.aiThinkingSince,
+    aiError: existingUIState.aiError,
+    aiDecisionLog: existingUIState.aiDecisionLog,
+    aiKeyModalOpen: existingUIState.aiKeyModalOpen,
   };
 }
 
@@ -113,6 +123,13 @@ export function getDefaultUIFields(): Pick<
   | 'replayIndex'
   | 'replayPaused'
   | 'replaySpeed'
+  | 'aiConfig'
+  | 'aiThinking'
+  | 'aiAutoPlay'
+  | 'aiThinkingSince'
+  | 'aiError'
+  | 'aiDecisionLog'
+  | 'aiKeyModalOpen'
 > {
   return {
     selectedCard: undefined,
@@ -125,5 +142,12 @@ export function getDefaultUIFields(): Pick<
     replayIndex: -1,
     replayPaused: false,
     replaySpeed: 1000,
+    aiConfig: DEFAULT_AI_CONFIG,
+    aiThinking: false,
+    aiAutoPlay: false,
+    aiThinkingSince: undefined,
+    aiError: undefined,
+    aiDecisionLog: [],
+    aiKeyModalOpen: false,
   };
 }

--- a/packages/app/src/ai/cardNotation.ts
+++ b/packages/app/src/ai/cardNotation.ts
@@ -1,0 +1,46 @@
+/**
+ * Compact card notation shared by the AI context payload and move descriptions.
+ *
+ * Cards are written rank-first, as in standard card notation: `AS` = Ace of
+ * Spades, `TD` = Ten of Diamonds, `3H` = Three of Hearts, `KC` = King of Clubs.
+ *
+ * @module ai/cardNotation
+ */
+
+import type { Card, Rank, Suit } from '../types';
+
+/** Single-letter suit codes. */
+const SUIT_LETTER: Record<Suit, string> = {
+  hearts: 'H',
+  diamonds: 'D',
+  clubs: 'C',
+  spades: 'S',
+};
+
+/** Human-readable suit names, for descriptions. */
+export const SUIT_NAME: Record<Suit, string> = {
+  hearts: 'hearts',
+  diamonds: 'diamonds',
+  clubs: 'clubs',
+  spades: 'spades',
+};
+
+/** One-line explanation of the notation, included in the AI context payload. */
+export const NOTATION_LEGEND =
+  'Cards are written rank then suit. Ranks: A 2 3 4 5 6 7 8 9 T(=10) J Q K. ' +
+  'Suits: H=hearts D=diamonds C=clubs S=spades. Example: "TD" = Ten of Diamonds.';
+
+/** Short rank code (`10` becomes `T`; all others are unchanged). */
+export function rankShort(rank: Rank): string {
+  return rank === '10' ? 'T' : rank;
+}
+
+/** Short notation for a card, e.g. `TD`, `AS`, `3H`. */
+export function cardShort(card: Card): string {
+  return rankShort(card.rank) + SUIT_LETTER[card.suit];
+}
+
+/** Short notation for a list of cards, bottom-to-top. */
+export function cardsShort(cards: readonly Card[]): string[] {
+  return cards.map(cardShort);
+}

--- a/packages/app/src/ai/constants.ts
+++ b/packages/app/src/ai/constants.ts
@@ -1,0 +1,34 @@
+/**
+ * Constants for the AI Move Advisor.
+ *
+ * @module ai/constants
+ */
+
+/**
+ * Request timeout for an AI move suggestion, in milliseconds.
+ *
+ * `gemma-4-31b-it` is a *thinking* model: it reasons internally before
+ * answering, and on a complex board that can take a couple of minutes. We
+ * allow a generous 3.5-minute ceiling so a slow-but-valid response is not
+ * killed prematurely.
+ */
+export const AI_REQUEST_TIMEOUT_MS = 210_000;
+
+/** Maximum number of past AI decisions retained in the store's decision log. */
+export const AI_DECISION_LOG_LIMIT = 30;
+
+/**
+ * Pause between moves while the AI is auto-playing the whole game. The LLM
+ * round-trip dominates the pacing; this is just a brief visible beat so the
+ * board update is perceptible before the next request starts.
+ */
+export const AI_AUTO_MOVE_DELAY = 800;
+
+/** Board-state hashes retained for AI auto-play loop detection. */
+export const AI_AUTO_HISTORY_LIMIT = 60;
+
+/** Sampling temperature for move suggestions — low, for consistent advice. */
+export const AI_TEMPERATURE = 0.3;
+
+/** Base URL for the Google Generative Language REST API. */
+export const GEMINI_API_BASE = 'https://generativelanguage.googleapis.com/v1beta';

--- a/packages/app/src/ai/context/buildContext.test.ts
+++ b/packages/app/src/ai/context/buildContext.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for the AI context payload builder.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { MoveCommand } from '@chayuto/solitaire-core';
+import type { Card, GameState, Move, Rank, Suit } from '../../types';
+import { buildContext } from './buildContext';
+import { applyPreset, DEFAULT_AI_CONFIG } from './presets';
+
+const card = (suit: Suit, rank: Rank, faceUp = true): Card => ({
+  suit,
+  rank,
+  faceUp,
+  id: `${suit}-${rank}`,
+});
+
+const drawMove = (c: Card): Move => ({ type: 'draw_card', timestamp: 0, card: c });
+
+function makeState(overrides: Partial<GameState> = {}): GameState {
+  return {
+    drawPile: [],
+    discardPile: [],
+    foundations: { hearts: [], diamonds: [], clubs: [], spades: [] },
+    tableau: [[], [], [], [], [], [], []],
+    moveHistory: [],
+    showValidMoves: true,
+    godMode: false,
+    autoPlayEnabled: false,
+    autoPlayInProgress: false,
+    difficulty: 3,
+    gameWon: false,
+    completionProgress: 25,
+    perceivedDifficulty: 50,
+    replayMode: false,
+    replayIndex: 0,
+    replayPaused: false,
+    replaySpeed: 1000,
+    ...overrides,
+  };
+}
+
+const LEGAL_MOVES: MoveCommand[] = [
+  { type: 'draw_card' },
+  { type: 'discard_to_foundation', to: { suit: 'hearts' } },
+];
+
+describe('buildContext', () => {
+  it('always includes the board and legal moves', () => {
+    const state = makeState({
+      foundations: { hearts: [], diamonds: [], clubs: [], spades: [card('spades', 'A')] },
+      discardPile: [card('hearts', '2')],
+      drawPile: [card('diamonds', '3')],
+      tableau: [[card('clubs', '5', false), card('hearts', '8')], [], [], [], [], [], []],
+    });
+    const ctx = buildContext(state, LEGAL_MOVES, applyPreset(DEFAULT_AI_CONFIG, 'minimal'));
+
+    expect(ctx.foundations.spades).toBe('AS');
+    expect(ctx.foundations.hearts).toBeNull();
+    expect(ctx.discardTop).toBe('2H');
+    expect(ctx.drawPileCount).toBe(1);
+    expect(ctx.tableau[0].faceDownCount).toBe(1);
+    expect(ctx.tableau[0].faceUp).toEqual(['8H']);
+    expect(ctx.legalMoves).toHaveLength(2);
+    expect(ctx.legalMoves[0].index).toBe(0);
+    expect(ctx.legalMoves[1].index).toBe(1);
+    expect(ctx.legalMoves[1].describe).toContain('hearts foundation');
+  });
+
+  it('omits optional fields under the minimal preset', () => {
+    const state = makeState({ moveHistory: [drawMove(card('clubs', '4'))] });
+    const ctx = buildContext(state, LEGAL_MOVES, applyPreset(DEFAULT_AI_CONFIG, 'minimal'));
+
+    expect(ctx.metrics).toBeUndefined();
+    expect(ctx.recentMoves).toBeUndefined();
+    expect(ctx.seenDrawPileCards).toBeUndefined();
+    expect(ctx.reasoningTrail).toBeUndefined();
+    expect(ctx.hiddenInfo).toBeUndefined();
+  });
+
+  it('includes metrics and history under the standard preset', () => {
+    const state = makeState({
+      moveHistory: [drawMove(card('clubs', '4')), drawMove(card('spades', '7'))],
+    });
+    const ctx = buildContext(state, LEGAL_MOVES, applyPreset(DEFAULT_AI_CONFIG, 'standard'));
+
+    expect(ctx.metrics).toEqual({
+      completionProgress: 25,
+      perceivedDifficulty: 50,
+      moveCount: 2,
+      difficulty: 3,
+    });
+    expect(ctx.recentMoves).toEqual(['draw 4C', 'draw 7S']);
+  });
+
+  it('reports only seen stock cards (player-fair) when seeHiddenCards is off', () => {
+    const seen = card('diamonds', '3');
+    const unseen = card('spades', '9');
+    const state = makeState({
+      drawPile: [seen, unseen],
+      // Only the diamond 3 was previously drawn, so only it has been "seen".
+      moveHistory: [drawMove(seen)],
+    });
+    const config = { ...applyPreset(DEFAULT_AI_CONFIG, 'standard'), seeHiddenCards: false };
+    const ctx = buildContext(state, LEGAL_MOVES, config);
+
+    expect(ctx.seenDrawPileCards).toEqual(['3D']);
+    expect(ctx.hiddenInfo).toBeUndefined();
+    expect(ctx.tableau[0].faceDown).toBeUndefined();
+  });
+
+  it('reveals all hidden information when seeHiddenCards is on', () => {
+    const state = makeState({
+      drawPile: [card('diamonds', '3'), card('spades', '9')],
+      tableau: [[card('clubs', '5', false), card('hearts', '8')], [], [], [], [], [], []],
+    });
+    const config = { ...applyPreset(DEFAULT_AI_CONFIG, 'detailed'), seeHiddenCards: true };
+    const ctx = buildContext(state, LEGAL_MOVES, config);
+
+    expect(ctx.hiddenInfo?.drawPileOrder).toEqual(['3D', '9S']);
+    expect(ctx.tableau[0].faceDown).toEqual(['5C']);
+  });
+
+  it('attaches heuristic scores when enabled', () => {
+    const state = makeState({
+      tableau: [[card('spades', 'A')], [], [], [], [], [], []],
+    });
+    const legal: MoveCommand[] = [
+      { type: 'tableau_to_foundation', from: { column: 0, cardIndex: 0 }, to: { suit: 'spades' } },
+    ];
+    const config = { ...applyPreset(DEFAULT_AI_CONFIG, 'detailed'), includeHeuristicScores: true };
+    const ctx = buildContext(state, legal, config);
+
+    expect(typeof ctx.legalMoves[0].heuristicScore).toBe('number');
+  });
+
+  it('includes the AI reasoning trail when a decision log is supplied', () => {
+    const state = makeState();
+    const config = applyPreset(DEFAULT_AI_CONFIG, 'standard');
+    const ctx = buildContext(state, LEGAL_MOVES, config, [
+      {
+        timestamp: 0,
+        moveType: 'draw_card',
+        describe: 'Draw a card',
+        reasoning: 'No better move.',
+        confidence: 0.6,
+        model: 'gemma-4-31b-it',
+      },
+    ]);
+
+    expect(ctx.reasoningTrail).toEqual([
+      { move: 'Draw a card', reasoning: 'No better move.' },
+    ]);
+  });
+});

--- a/packages/app/src/ai/context/buildContext.ts
+++ b/packages/app/src/ai/context/buildContext.ts
@@ -1,0 +1,199 @@
+/**
+ * Builds the structured game context sent to the LLM.
+ *
+ * The context always includes the visible board and a numbered list of legal
+ * moves; optional fields (history, metrics, heuristic scores, seen stock cards,
+ * the AI's own reasoning trail, full hidden information) are gated by the
+ * active {@link AIConfig}.
+ *
+ * @module ai/context/buildContext
+ */
+
+import type { MoveCommand } from '@chayuto/solitaire-core';
+import type { GameState, Suit } from '../../types';
+import type { AIConfig, AIDecisionRecord, AILegalMove, AIMoveContext } from '../types';
+import { cardShort } from '../cardNotation';
+import { describeMoveCommand, summarizeHistoryMove } from './describeMove';
+import { collectPossibleMoves, scoreMoves } from '../../autoplay';
+import type { PossibleMove } from '../../autoplay';
+
+const SUITS: Suit[] = ['hearts', 'diamonds', 'clubs', 'spades'];
+
+/** Move history entry types that are bookkeeping, not real player moves. */
+const NON_PLAYER_MOVE_TYPES = new Set([
+  'flip_card',
+  'autoplay_start',
+  'autoplay_stop',
+  'autoplay_deadend',
+  'autoplay_loop_detected',
+]);
+
+/**
+ * Match a {@link MoveCommand} to a scored {@link PossibleMove} from the
+ * autoplay heuristic, returning its score (or `undefined` for stock moves,
+ * which the heuristic does not score).
+ */
+function heuristicScoreFor(
+  command: MoveCommand,
+  scored: PossibleMove[],
+): number | undefined {
+  const match = scored.find((m) => {
+    switch (command.type) {
+      case 'tableau_to_tableau':
+        return (
+          m.source === 'tableau' &&
+          m.targetType === 'tableau' &&
+          m.sourceColumn === command.from?.column &&
+          m.sourceCardIndex === command.from?.cardIndex &&
+          m.targetColumn === command.to?.column
+        );
+      case 'tableau_to_foundation':
+        return (
+          m.source === 'tableau' &&
+          m.targetType === 'foundation' &&
+          m.sourceColumn === command.from?.column &&
+          m.sourceCardIndex === command.from?.cardIndex &&
+          m.targetSuit === command.to?.suit
+        );
+      case 'discard_to_tableau':
+        return (
+          m.source === 'discard' &&
+          m.targetType === 'tableau' &&
+          m.targetColumn === command.to?.column
+        );
+      case 'discard_to_foundation':
+        return (
+          m.source === 'discard' &&
+          m.targetType === 'foundation' &&
+          m.targetSuit === command.to?.suit
+        );
+      default:
+        return false;
+    }
+  });
+  return match ? Math.round(match.score) : undefined;
+}
+
+/** Stock cards the player has already cycled past, in upcoming-draw order. */
+function computeSeenDrawPileCards(state: GameState): string[] {
+  const drawnIds = new Set(
+    state.moveHistory.filter((m) => m.type === 'draw_card').map((m) => m.card.id),
+  );
+  return state.drawPile.filter((c) => drawnIds.has(c.id)).map(cardShort);
+}
+
+/**
+ * Build the AI context payload for the current game state.
+ *
+ * @param state - The current UI game state.
+ * @param legalMoves - Legal move commands (from the core engine), in the order
+ *   the LLM will see them; `legalMoves[i]` corresponds to `index: i`.
+ * @param config - The active AI configuration.
+ * @param decisionLog - Past AI decisions, used for the reasoning trail.
+ */
+export function buildContext(
+  state: GameState,
+  legalMoves: MoveCommand[],
+  config: AIConfig,
+  decisionLog: readonly AIDecisionRecord[] = [],
+): AIMoveContext {
+  // --- Heuristic scores (optional, computed once) ---
+  let scored: PossibleMove[] = [];
+  if (config.includeHeuristicScores) {
+    scored = scoreMoves(collectPossibleMoves(state), state);
+  }
+
+  // --- Legal moves ---
+  const aiLegalMoves: AILegalMove[] = legalMoves.map((command, index) => {
+    const entry: AILegalMove = {
+      index,
+      type: command.type,
+      describe: describeMoveCommand(command, state),
+    };
+    if (config.includeHeuristicScores) {
+      const score = heuristicScoreFor(command, scored);
+      if (score !== undefined) entry.heuristicScore = score;
+    }
+    return entry;
+  });
+
+  // --- Foundations ---
+  const foundations = {} as Record<Suit, string | null>;
+  for (const suit of SUITS) {
+    const pile = state.foundations[suit];
+    foundations[suit] = pile.length > 0 ? cardShort(pile[pile.length - 1]) : null;
+  }
+
+  // --- Tableau ---
+  const tableau = state.tableau.map((column) => {
+    const faceDown = column.filter((c) => !c.faceUp);
+    const faceUp = column.filter((c) => c.faceUp);
+    const col: AIMoveContext['tableau'][number] = {
+      faceDownCount: faceDown.length,
+      faceUp: faceUp.map(cardShort),
+    };
+    if (config.seeHiddenCards && faceDown.length > 0) {
+      col.faceDown = faceDown.map(cardShort);
+    }
+    return col;
+  });
+
+  const discardTop =
+    state.discardPile.length > 0
+      ? cardShort(state.discardPile[state.discardPile.length - 1])
+      : null;
+
+  const context: AIMoveContext = {
+    notation:
+      'Cards: rank then suit (A 2-9 T J Q K; H D C S). Tableau columns and faceUp arrays are listed bottom-to-top.',
+    foundations,
+    tableau,
+    discardTop,
+    drawPileCount: state.drawPile.length,
+    canRecycleStock: state.drawPile.length === 0 && state.discardPile.length > 0,
+    legalMoves: aiLegalMoves,
+  };
+
+  // --- Optional: game metrics ---
+  if (config.includeGameMetrics) {
+    context.metrics = {
+      completionProgress: Math.round(state.completionProgress),
+      perceivedDifficulty: state.perceivedDifficulty,
+      moveCount: state.moveHistory.length,
+      difficulty: state.difficulty,
+    };
+  }
+
+  // --- Optional: recent move history ---
+  if (config.includeMoveHistory && config.moveHistoryLimit > 0) {
+    const playerMoves = state.moveHistory.filter(
+      (m) => !NON_PLAYER_MOVE_TYPES.has(m.type),
+    );
+    context.recentMoves = playerMoves
+      .slice(-config.moveHistoryLimit)
+      .map(summarizeHistoryMove);
+  }
+
+  // --- Optional: seen stock cards ---
+  if (config.includeSeenDrawPileCards) {
+    const seen = computeSeenDrawPileCards(state);
+    if (seen.length > 0) context.seenDrawPileCards = seen;
+  }
+
+  // --- Optional: full hidden information ---
+  if (config.seeHiddenCards) {
+    context.hiddenInfo = {
+      drawPileOrder: state.drawPile.map(cardShort),
+    };
+  }
+
+  // --- Optional: the AI's own reasoning trail ---
+  if (config.includeReasoningTrail && config.reasoningTrailLimit > 0) {
+    const trail = decisionLog
+      .slice(-config.reasoningTrailLimit)
+      .map((d) => ({ move: d.describe, reasoning: d.reasoning }));
+    if (trail.length > 0) context.reasoningTrail = trail;
+  }
+
+  return context;
+}

--- a/packages/app/src/ai/context/describeMove.test.ts
+++ b/packages/app/src/ai/context/describeMove.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for human-readable move descriptions.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { MoveCommand } from '@chayuto/solitaire-core';
+import type { Card, GameState, Move, Rank, Suit } from '../../types';
+import { describeMoveCommand, summarizeHistoryMove } from './describeMove';
+
+const card = (suit: Suit, rank: Rank, faceUp = true): Card => ({
+  suit,
+  rank,
+  faceUp,
+  id: `${suit}-${rank}`,
+});
+
+function makeState(overrides: Partial<GameState> = {}): GameState {
+  return {
+    drawPile: [],
+    discardPile: [],
+    foundations: { hearts: [], diamonds: [], clubs: [], spades: [] },
+    tableau: [[], [], [], [], [], [], []],
+    moveHistory: [],
+    showValidMoves: true,
+    godMode: false,
+    autoPlayEnabled: false,
+    autoPlayInProgress: false,
+    difficulty: 3,
+    gameWon: false,
+    completionProgress: 0,
+    replayMode: false,
+    replayIndex: 0,
+    replayPaused: false,
+    replaySpeed: 1000,
+    ...overrides,
+  };
+}
+
+describe('describeMoveCommand', () => {
+  it('describes draw_card', () => {
+    expect(describeMoveCommand({ type: 'draw_card' }, makeState())).toMatch(/draw/i);
+  });
+
+  it('describes recycle_stock', () => {
+    expect(describeMoveCommand({ type: 'recycle_stock' }, makeState())).toMatch(/recycle/i);
+  });
+
+  it('describes tableau_to_foundation with the card and suit', () => {
+    const state = makeState({
+      tableau: [[card('spades', 'A')], [], [], [], [], [], []],
+    });
+    const cmd: MoveCommand = {
+      type: 'tableau_to_foundation',
+      from: { column: 0, cardIndex: 0 },
+      to: { suit: 'spades' },
+    };
+    const text = describeMoveCommand(cmd, state);
+    expect(text).toContain('AS');
+    expect(text).toContain('spades foundation');
+    expect(text).toContain('column 1');
+  });
+
+  it('describes discard_to_foundation', () => {
+    const state = makeState({ discardPile: [card('hearts', '2')] });
+    const cmd: MoveCommand = {
+      type: 'discard_to_foundation',
+      to: { suit: 'hearts' },
+    };
+    expect(describeMoveCommand(cmd, state)).toBe(
+      'Send 2H from the waste to the hearts foundation',
+    );
+  });
+
+  it('flags a move onto an empty column', () => {
+    const state = makeState({
+      tableau: [[card('spades', 'K')], [], [], [], [], [], []],
+    });
+    const cmd: MoveCommand = {
+      type: 'tableau_to_tableau',
+      from: { column: 0, cardIndex: 0 },
+      to: { column: 1 },
+    };
+    expect(describeMoveCommand(cmd, state)).toContain('(empty)');
+  });
+
+  it('flags a move that reveals a hidden card', () => {
+    const state = makeState({
+      tableau: [
+        [card('clubs', '5', false), card('hearts', '8')],
+        [card('spades', '9')],
+        [],
+        [],
+        [],
+        [],
+        [],
+      ],
+    });
+    const cmd: MoveCommand = {
+      type: 'tableau_to_tableau',
+      from: { column: 0, cardIndex: 1 },
+      to: { column: 1 },
+    };
+    const text = describeMoveCommand(cmd, state);
+    expect(text).toContain('8H');
+    expect(text).toContain('reveals a hidden card');
+  });
+
+  it('counts extra cards in a multi-card sequence', () => {
+    const state = makeState({
+      tableau: [
+        [card('hearts', '8'), card('spades', '7'), card('hearts', '6')],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+      ],
+    });
+    const cmd: MoveCommand = {
+      type: 'tableau_to_tableau',
+      from: { column: 0, cardIndex: 0 },
+      to: { column: 1 },
+    };
+    expect(describeMoveCommand(cmd, state)).toContain('plus 2 more');
+  });
+});
+
+describe('summarizeHistoryMove', () => {
+  it('summarizes a draw', () => {
+    const move: Move = { type: 'draw_card', timestamp: 0, card: card('diamonds', '10') };
+    expect(summarizeHistoryMove(move)).toBe('draw TD');
+  });
+
+  it('summarizes a tableau-to-foundation move', () => {
+    const move: Move = {
+      type: 'tableau_to_foundation',
+      timestamp: 0,
+      card: card('clubs', 'A'),
+      from: { source: 'tableau', columnIndex: 2 },
+      to: { target: 'foundation', suit: 'clubs' },
+    };
+    expect(summarizeHistoryMove(move)).toBe('AC col 3 -> clubs foundation');
+  });
+});

--- a/packages/app/src/ai/context/describeMove.ts
+++ b/packages/app/src/ai/context/describeMove.ts
@@ -1,0 +1,100 @@
+/**
+ * Human-readable descriptions of moves, for the AI prompt and the UI.
+ *
+ * @module ai/context/describeMove
+ */
+
+import type { MoveCommand } from '@chayuto/solitaire-core';
+import type { GameState, Move } from '../../types';
+import { cardShort, SUIT_NAME } from '../cardNotation';
+
+/** 1-based column label for prompts ("column 1" .. "column 7"). */
+function col(index: number): string {
+  return `column ${index + 1}`;
+}
+
+/**
+ * Describe a legal {@link MoveCommand} in plain language, resolving the cards
+ * it involves from the current game state.
+ */
+export function describeMoveCommand(command: MoveCommand, state: GameState): string {
+  switch (command.type) {
+    case 'draw_card':
+      return 'Draw the next card from the stock onto the waste';
+
+    case 'recycle_stock':
+      return 'Recycle the waste pile back into the stock';
+
+    case 'tableau_to_foundation': {
+      const column = state.tableau[command.from?.column ?? -1] ?? [];
+      const card = column[column.length - 1];
+      return card
+        ? `Send ${cardShort(card)} from ${col(command.from!.column!)} to the ${SUIT_NAME[card.suit]} foundation`
+        : `Send the top card of ${col(command.from?.column ?? 0)} to its foundation`;
+    }
+
+    case 'discard_to_foundation': {
+      const card = state.discardPile[state.discardPile.length - 1];
+      return card
+        ? `Send ${cardShort(card)} from the waste to the ${SUIT_NAME[card.suit]} foundation`
+        : 'Send the waste card to its foundation';
+    }
+
+    case 'discard_to_tableau': {
+      const card = state.discardPile[state.discardPile.length - 1];
+      const target = state.tableau[command.to?.column ?? -1] ?? [];
+      const empty = target.length === 0 ? ' (empty)' : '';
+      return card
+        ? `Move ${cardShort(card)} from the waste to ${col(command.to!.column!)}${empty}`
+        : `Move the waste card to ${col(command.to?.column ?? 0)}`;
+    }
+
+    case 'tableau_to_tableau': {
+      const fromCol = command.from?.column ?? -1;
+      const cardIndex = command.from?.cardIndex ?? -1;
+      const column = state.tableau[fromCol] ?? [];
+      const card = column[cardIndex];
+      const moved = column.length - cardIndex;
+      const extra = moved > 1 ? ` plus ${moved - 1} more` : '';
+      const reveals =
+        cardIndex > 0 && column[cardIndex - 1] && !column[cardIndex - 1].faceUp
+          ? ' (reveals a hidden card)'
+          : '';
+      const target = state.tableau[command.to?.column ?? -1] ?? [];
+      const empty = target.length === 0 ? ' (empty)' : '';
+      return card
+        ? `Move ${cardShort(card)}${extra} from ${col(fromCol)} to ${col(command.to!.column!)}${empty}${reveals}`
+        : `Move cards from ${col(fromCol)} to ${col(command.to?.column ?? 0)}`;
+    }
+
+    case 'flip_card':
+      return `Flip a card face-up in ${col(command.from?.column ?? 0)}`;
+
+    default:
+      return 'Unknown move';
+  }
+}
+
+/**
+ * Compactly summarize a recorded {@link Move} from the move history, e.g.
+ * `"draw TD"`, `"move 7S col 3 -> col 5"`, `"AS -> spades"`.
+ */
+export function summarizeHistoryMove(move: Move): string {
+  const card = cardShort(move.card);
+  switch (move.type) {
+    case 'draw_card':
+      return `draw ${card}`;
+    case 'tableau_to_tableau':
+      return `move ${card} col ${(move.from?.columnIndex ?? 0) + 1} -> col ${(move.to?.columnIndex ?? 0) + 1}`;
+    case 'tableau_to_foundation':
+      return `${card} col ${(move.from?.columnIndex ?? 0) + 1} -> ${move.to?.suit ?? '?'} foundation`;
+    case 'discard_to_tableau':
+      return `${card} waste -> col ${(move.to?.columnIndex ?? 0) + 1}`;
+    case 'discard_to_foundation':
+      return `${card} waste -> ${move.to?.suit ?? '?'} foundation`;
+    case 'flip_card':
+      return `flip ${card} col ${(move.from?.columnIndex ?? 0) + 1}`;
+    default:
+      return move.type;
+  }
+}

--- a/packages/app/src/ai/context/presets.ts
+++ b/packages/app/src/ai/context/presets.ts
@@ -1,0 +1,81 @@
+/**
+ * Context verbosity presets for the AI advisor.
+ *
+ * A preset is a bundle of the optional context toggles in {@link AIConfig}.
+ * The `custom` preset is not listed here — it simply leaves every toggle under
+ * the user's direct control.
+ *
+ * @module ai/context/presets
+ */
+
+import type { AIConfig, AIContextPreset } from '../types';
+
+/** The subset of {@link AIConfig} fields that a preset controls. */
+export type PresetFields = Pick<
+  AIConfig,
+  | 'includeMoveHistory'
+  | 'moveHistoryLimit'
+  | 'includeGameMetrics'
+  | 'includeStrategyGuidance'
+  | 'includeHeuristicScores'
+  | 'includeSeenDrawPileCards'
+  | 'includeReasoningTrail'
+  | 'reasoningTrailLimit'
+>;
+
+/** Toggle bundles for the three non-custom presets. */
+export const PRESET_FIELDS: Record<Exclude<AIContextPreset, 'custom'>, PresetFields> = {
+  // Cheapest: only the board and the legal moves.
+  minimal: {
+    includeMoveHistory: false,
+    moveHistoryLimit: 0,
+    includeGameMetrics: false,
+    includeStrategyGuidance: false,
+    includeHeuristicScores: false,
+    includeSeenDrawPileCards: false,
+    includeReasoningTrail: false,
+    reasoningTrailLimit: 0,
+  },
+  // Balanced default.
+  standard: {
+    includeMoveHistory: true,
+    moveHistoryLimit: 10,
+    includeGameMetrics: true,
+    includeStrategyGuidance: true,
+    includeHeuristicScores: false,
+    includeSeenDrawPileCards: true,
+    includeReasoningTrail: true,
+    reasoningTrailLimit: 5,
+  },
+  // Maximum quality: adds heuristic scores and a longer history.
+  detailed: {
+    includeMoveHistory: true,
+    moveHistoryLimit: 15,
+    includeGameMetrics: true,
+    includeStrategyGuidance: true,
+    includeHeuristicScores: true,
+    includeSeenDrawPileCards: true,
+    includeReasoningTrail: true,
+    reasoningTrailLimit: 8,
+  },
+};
+
+/** The default AI configuration for a fresh session. */
+export const DEFAULT_AI_CONFIG: AIConfig = {
+  provider: 'gemini',
+  model: 'gemma-4-31b-it',
+  preset: 'standard',
+  seeHiddenCards: false,
+  ...PRESET_FIELDS.standard,
+};
+
+/**
+ * Return a new config with a preset applied. For `custom`, the existing
+ * toggles are kept untouched; provider/model/`seeHiddenCards` are always kept.
+ */
+export function applyPreset(config: AIConfig, preset: AIContextPreset): AIConfig {
+  if (preset === 'custom') {
+    return { ...config, preset };
+  }
+  return { ...config, preset, ...PRESET_FIELDS[preset] };
+}

--- a/packages/app/src/ai/context/rulesPrimer.ts
+++ b/packages/app/src/ai/context/rulesPrimer.ts
@@ -1,0 +1,47 @@
+/**
+ * Static text blocks for the AI advisor prompt: the rules of Klondike
+ * Solitaire and optional strategy guidance.
+ *
+ * Including the rules explicitly means the model reasons from a known, correct
+ * specification rather than relying on its (possibly imperfect) priors.
+ *
+ * @module ai/context/rulesPrimer
+ */
+
+/** The role + rules of the game. Always included in the prompt. */
+export const RULES_PRIMER = `You are an expert Klondike Solitaire strategist acting as an advisor.
+
+KLONDIKE SOLITAIRE RULES (this variant):
+- There are 7 tableau columns, 4 foundations (one per suit), a stock (draw) pile and a waste (discard) pile.
+- Foundations are built UP by suit, starting from the Ace: A, 2, 3, ... up to King.
+- Tableau columns are built DOWN in alternating colors (red on black, black on red). Example: a black 7 can go on a red 8.
+- Only a King (or a valid sequence headed by a King) may be moved onto an EMPTY tableau column.
+- A face-up run of cards in a tableau column may be moved together as a unit onto another column.
+- The top card of a column, or a valid run, may move to another column; the top card may move to a foundation.
+- The top (most recent) card of the waste pile may move to a tableau column or a foundation.
+- Drawing turns the next stock card face-up onto the waste. When the stock is empty it can be recycled from the waste.
+- When a face-down tableau card is exposed by a move, it flips face-up automatically.
+- The game is WON when all 52 cards reach the foundations.
+
+THE GOAL: choose the single move that gives the best chance of eventually winning.`;
+
+/** Klondike strategy heuristics. Included when `includeStrategyGuidance` is on. */
+export const STRATEGY_GUIDANCE = `STRATEGY GUIDANCE (heuristics, not absolute rules):
+- Prioritize moves that turn over (reveal) a face-down tableau card — hidden cards are the main obstacle.
+- Play Aces and 2s to the foundations promptly; they are rarely useful in the tableau.
+- Be cautious sending higher cards to the foundations too early — they are sometimes needed to receive tableau cards.
+- Do not empty a column unless you have a King ready to occupy it.
+- Prefer exposing new cards and creating useful sequences over shuffling cards between columns with no gain.
+- Drawing from the stock is reasonable when no productive tableau/foundation move exists.
+- Avoid moves that simply undo a recent move or lead nowhere.`;
+
+/** Instructions describing the required JSON output. Always included. */
+export const OUTPUT_INSTRUCTION = `RESPONSE FORMAT:
+You will receive the current game as JSON, including a numbered array "legalMoves".
+Choose exactly ONE move from "legalMoves".
+Respond with ONLY a single JSON object — no prose, no markdown fences — of the form:
+{"moveIndex": <number>, "reasoning": <string>, "confidence": <number>, "alternativeMoveIndex": <number>}
+- moveIndex: the "index" of your chosen move from the legalMoves array.
+- reasoning: 1-3 concise sentences explaining why this move is best.
+- confidence: your confidence the move is best, a number from 0 to 1.
+- alternativeMoveIndex: optional; the index of your second-choice move.`;

--- a/packages/app/src/ai/context/systemInstruction.ts
+++ b/packages/app/src/ai/context/systemInstruction.ts
@@ -1,0 +1,19 @@
+/**
+ * Assembles the system-instruction text for an AI request from the static
+ * rule/strategy/output blocks, honoring the active configuration.
+ *
+ * @module ai/context/systemInstruction
+ */
+
+import type { AIConfig } from '../types';
+import { OUTPUT_INSTRUCTION, RULES_PRIMER, STRATEGY_GUIDANCE } from './rulesPrimer';
+
+/** Build the full system instruction for a move-suggestion request. */
+export function buildSystemInstruction(config: AIConfig): string {
+  const parts = [RULES_PRIMER];
+  if (config.includeStrategyGuidance) {
+    parts.push(STRATEGY_GUIDANCE);
+  }
+  parts.push(OUTPUT_INSTRUCTION);
+  return parts.join('\n\n');
+}

--- a/packages/app/src/ai/decision/schema.test.ts
+++ b/packages/app/src/ai/decision/schema.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for AI decision validation.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseDecision, validateDecision } from './schema';
+import { AIError } from '../types';
+
+describe('validateDecision', () => {
+  const LEGAL_COUNT = 5;
+
+  it('accepts a well-formed decision', () => {
+    const result = validateDecision(
+      { moveIndex: 2, reasoning: 'Best move.', confidence: 0.8 },
+      LEGAL_COUNT,
+    );
+    expect(result).toEqual({
+      moveIndex: 2,
+      reasoning: 'Best move.',
+      confidence: 0.8,
+      alternativeMoveIndex: undefined,
+    });
+  });
+
+  it('rejects a non-object', () => {
+    expect(() => validateDecision('nope', LEGAL_COUNT)).toThrow(AIError);
+    expect(() => validateDecision(null, LEGAL_COUNT)).toThrow(AIError);
+    expect(() => validateDecision([1, 2], LEGAL_COUNT)).toThrow(AIError);
+  });
+
+  it('rejects a non-integer moveIndex', () => {
+    expect(() =>
+      validateDecision({ moveIndex: 1.5, reasoning: 'x', confidence: 1 }, LEGAL_COUNT),
+    ).toThrow(/non-integer/);
+  });
+
+  it('rejects a moveIndex below range', () => {
+    expect(() =>
+      validateDecision({ moveIndex: -1, reasoning: 'x', confidence: 1 }, LEGAL_COUNT),
+    ).toThrow(/outside the valid range/);
+  });
+
+  it('rejects a moveIndex at or above the legal count', () => {
+    expect(() =>
+      validateDecision({ moveIndex: 5, reasoning: 'x', confidence: 1 }, LEGAL_COUNT),
+    ).toThrow(/outside the valid range/);
+  });
+
+  it('accepts a string moveIndex that is integral', () => {
+    const result = validateDecision(
+      { moveIndex: '3', reasoning: 'x', confidence: 0.5 },
+      LEGAL_COUNT,
+    );
+    expect(result.moveIndex).toBe(3);
+  });
+
+  it('coerces a missing reasoning to a placeholder', () => {
+    const result = validateDecision({ moveIndex: 0, confidence: 0.5 }, LEGAL_COUNT);
+    expect(result.reasoning).toBe('No reasoning provided.');
+  });
+
+  it('coerces an empty reasoning to a placeholder', () => {
+    const result = validateDecision(
+      { moveIndex: 0, reasoning: '   ', confidence: 0.5 },
+      LEGAL_COUNT,
+    );
+    expect(result.reasoning).toBe('No reasoning provided.');
+  });
+
+  it('clamps confidence into [0, 1]', () => {
+    expect(
+      validateDecision({ moveIndex: 0, reasoning: 'x', confidence: -3 }, LEGAL_COUNT)
+        .confidence,
+    ).toBe(0);
+  });
+
+  it('rescales a 0-100 confidence to 0-1', () => {
+    expect(
+      validateDecision({ moveIndex: 0, reasoning: 'x', confidence: 90 }, LEGAL_COUNT)
+        .confidence,
+    ).toBeCloseTo(0.9);
+  });
+
+  it('defaults a missing/NaN confidence to 0.5', () => {
+    expect(
+      validateDecision({ moveIndex: 0, reasoning: 'x' }, LEGAL_COUNT).confidence,
+    ).toBe(0.5);
+  });
+
+  it('keeps a valid alternativeMoveIndex', () => {
+    const result = validateDecision(
+      { moveIndex: 0, reasoning: 'x', confidence: 1, alternativeMoveIndex: 3 },
+      LEGAL_COUNT,
+    );
+    expect(result.alternativeMoveIndex).toBe(3);
+  });
+
+  it('drops an out-of-range alternativeMoveIndex', () => {
+    const result = validateDecision(
+      { moveIndex: 0, reasoning: 'x', confidence: 1, alternativeMoveIndex: 99 },
+      LEGAL_COUNT,
+    );
+    expect(result.alternativeMoveIndex).toBeUndefined();
+  });
+
+  it('drops an alternativeMoveIndex equal to moveIndex', () => {
+    const result = validateDecision(
+      { moveIndex: 2, reasoning: 'x', confidence: 1, alternativeMoveIndex: 2 },
+      LEGAL_COUNT,
+    );
+    expect(result.alternativeMoveIndex).toBeUndefined();
+  });
+});
+
+describe('parseDecision', () => {
+  it('parses a plain JSON response', () => {
+    const result = parseDecision('{"moveIndex":1,"reasoning":"go","confidence":0.7}', 3);
+    expect(result.moveIndex).toBe(1);
+  });
+
+  it('parses a fenced JSON response', () => {
+    const result = parseDecision(
+      '```json\n{"moveIndex":0,"reasoning":"go","confidence":1}\n```',
+      3,
+    );
+    expect(result.moveIndex).toBe(0);
+  });
+
+  it('parses JSON that follows reasoning prose (thinking model output)', () => {
+    const text =
+      'Let me think... index 2 reveals a card.\n{"moveIndex":2,"reasoning":"reveal","confidence":0.9}';
+    expect(parseDecision(text, 5).moveIndex).toBe(2);
+  });
+
+  it('throws bad_response for unparseable output', () => {
+    try {
+      parseDecision('the model rambled and never answered', 3);
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(AIError);
+      expect((err as AIError).kind).toBe('bad_response');
+    }
+  });
+});

--- a/packages/app/src/ai/decision/schema.ts
+++ b/packages/app/src/ai/decision/schema.ts
@@ -1,0 +1,110 @@
+/**
+ * Validation of the LLM's raw output into a trusted {@link AIMoveDecision}.
+ *
+ * The LLM only ever returns an *index* into the legal-moves list we supplied,
+ * so it is structurally impossible for it to choose an illegal move. This
+ * module enforces that the index is in range and coerces the remaining fields
+ * into safe values.
+ *
+ * @module ai/decision/schema
+ */
+
+import { AIError, type AIMoveDecision } from '../types';
+import { parseLooseJsonObject } from '../jsonExtract';
+
+/** Clamp a number into `[min, max]`. */
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * Validate a parsed object into an {@link AIMoveDecision}.
+ *
+ * `moveIndex` is validated strictly — an out-of-range or non-integer index is
+ * rejected, because applying it would touch the board. `reasoning` and
+ * `confidence` are display-only and are coerced to safe defaults rather than
+ * rejected, so a sound move choice is never discarded over cosmetics.
+ *
+ * @param raw - The parsed model output (object expected).
+ * @param legalMoveCount - Number of legal moves offered to the model.
+ * @throws {AIError} of kind `bad_response` when `moveIndex` is unusable.
+ */
+export function validateDecision(raw: unknown, legalMoveCount: number): AIMoveDecision {
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new AIError('bad_response', 'AI response was not a JSON object.');
+  }
+  const obj = raw as Record<string, unknown>;
+
+  // --- moveIndex (strict) ---
+  const rawIndex = obj.moveIndex;
+  const moveIndex =
+    typeof rawIndex === 'number'
+      ? rawIndex
+      : typeof rawIndex === 'string'
+        ? Number(rawIndex)
+        : NaN;
+  if (!Number.isInteger(moveIndex)) {
+    throw new AIError(
+      'bad_response',
+      `AI returned a non-integer moveIndex (${JSON.stringify(rawIndex)}).`,
+    );
+  }
+  if (moveIndex < 0 || moveIndex >= legalMoveCount) {
+    throw new AIError(
+      'bad_response',
+      `AI chose move index ${moveIndex}, which is outside the valid range 0..${legalMoveCount - 1}.`,
+    );
+  }
+
+  // --- reasoning (coerced) ---
+  const reasoning =
+    typeof obj.reasoning === 'string' && obj.reasoning.trim().length > 0
+      ? obj.reasoning.trim()
+      : 'No reasoning provided.';
+
+  // --- confidence (coerced + clamped) ---
+  let confidence = typeof obj.confidence === 'number' ? obj.confidence : Number(obj.confidence);
+  if (!Number.isFinite(confidence)) {
+    confidence = 0.5;
+  }
+  // Tolerate models that answer on a 0-100 scale.
+  if (confidence > 1) {
+    confidence = confidence / 100;
+  }
+  confidence = clamp(confidence, 0, 1);
+
+  // --- alternativeMoveIndex (optional, dropped if invalid) ---
+  let alternativeMoveIndex: number | undefined;
+  const rawAlt = obj.alternativeMoveIndex;
+  const alt =
+    typeof rawAlt === 'number'
+      ? rawAlt
+      : typeof rawAlt === 'string'
+        ? Number(rawAlt)
+        : NaN;
+  if (Number.isInteger(alt) && alt >= 0 && alt < legalMoveCount && alt !== moveIndex) {
+    alternativeMoveIndex = alt;
+  }
+
+  return { moveIndex, reasoning, confidence, alternativeMoveIndex };
+}
+
+/**
+ * Parse free-form model output text into a validated {@link AIMoveDecision}.
+ *
+ * @param text - Raw text returned by the model.
+ * @param legalMoveCount - Number of legal moves offered to the model.
+ * @throws {AIError} of kind `bad_response` when the text cannot be parsed or
+ *   the decision is invalid.
+ */
+export function parseDecision(text: string, legalMoveCount: number): AIMoveDecision {
+  const parsed = parseLooseJsonObject(text);
+  if (parsed === null) {
+    const preview = text.trim().slice(0, 160);
+    throw new AIError(
+      'bad_response',
+      `AI did not return parseable JSON. Response began: "${preview}"`,
+    );
+  }
+  return validateDecision(parsed, legalMoveCount);
+}

--- a/packages/app/src/ai/index.ts
+++ b/packages/app/src/ai/index.ts
@@ -1,0 +1,50 @@
+/**
+ * AI Move Advisor — public surface.
+ *
+ * Lets a player ask an LLM (Google Gemini / Gemma) for the next best move.
+ * The model receives a structured game snapshot plus a numbered list of legal
+ * moves and must return its choice as an index into that list.
+ *
+ * @module ai
+ */
+
+export * from './types';
+export {
+  AI_REQUEST_TIMEOUT_MS,
+  AI_DECISION_LOG_LIMIT,
+  AI_AUTO_MOVE_DELAY,
+  AI_AUTO_HISTORY_LIMIT,
+} from './constants';
+
+// Configuration / presets
+export { DEFAULT_AI_CONFIG, PRESET_FIELDS, applyPreset } from './context/presets';
+
+// Context building
+export { buildContext } from './context/buildContext';
+export { buildSystemInstruction } from './context/systemInstruction';
+export { describeMoveCommand, summarizeHistoryMove } from './context/describeMove';
+export { NOTATION_LEGEND } from './cardNotation';
+
+// Decision validation
+export { validateDecision, parseDecision } from './decision/schema';
+
+// Providers
+export {
+  getProvider,
+  listProviders,
+  setProviderOverride,
+  getProviderOverride,
+  createStubProvider,
+} from './providers';
+export type { StubDecisionFn } from './providers';
+
+// Key storage
+export {
+  getKey,
+  getEffectiveKey,
+  setKey,
+  clearKey,
+  hasUsableKey,
+  hasUserKey,
+  getDevFallbackKey,
+} from './keyStore';

--- a/packages/app/src/ai/jsonExtract.test.ts
+++ b/packages/app/src/ai/jsonExtract.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests for lenient JSON extraction from free-form model output.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { extractFirstJsonObject, parseLooseJsonObject } from './jsonExtract';
+
+describe('extractFirstJsonObject', () => {
+  it('extracts a plain object', () => {
+    expect(extractFirstJsonObject('{"a":1}')).toBe('{"a":1}');
+  });
+
+  it('extracts an object embedded in prose', () => {
+    const text = 'Here is my answer: {"moveIndex": 2, "confidence": 0.9} — done.';
+    expect(extractFirstJsonObject(text)).toBe('{"moveIndex": 2, "confidence": 0.9}');
+  });
+
+  it('handles nested objects', () => {
+    const text = 'noise {"a": {"b": 1}, "c": 2} trailing';
+    expect(extractFirstJsonObject(text)).toBe('{"a": {"b": 1}, "c": 2}');
+  });
+
+  it('ignores braces inside string literals', () => {
+    const text = '{"reasoning": "use the } brace { trick"}';
+    expect(extractFirstJsonObject(text)).toBe(text);
+  });
+
+  it('ignores escaped quotes inside strings', () => {
+    const text = '{"reasoning": "she said \\"hi\\" }"}';
+    expect(extractFirstJsonObject(text)).toBe(text);
+  });
+
+  it('returns null when there is no object', () => {
+    expect(extractFirstJsonObject('no json here')).toBeNull();
+  });
+
+  it('returns null for an unbalanced object', () => {
+    expect(extractFirstJsonObject('{"a": 1')).toBeNull();
+  });
+});
+
+describe('parseLooseJsonObject', () => {
+  it('parses plain JSON', () => {
+    expect(parseLooseJsonObject('{"x":1}')).toEqual({ x: 1 });
+  });
+
+  it('parses JSON wrapped in a markdown fence', () => {
+    expect(parseLooseJsonObject('```json\n{"x":1}\n```')).toEqual({ x: 1 });
+  });
+
+  it('parses JSON wrapped in a bare fence', () => {
+    expect(parseLooseJsonObject('```\n{"x":2}\n```')).toEqual({ x: 2 });
+  });
+
+  it('parses JSON embedded after reasoning prose', () => {
+    const text = 'I think move 1 is best.\n\n{"moveIndex": 1, "confidence": 0.8}';
+    expect(parseLooseJsonObject(text)).toEqual({ moveIndex: 1, confidence: 0.8 });
+  });
+
+  it('returns null for unparseable input', () => {
+    expect(parseLooseJsonObject('completely not json')).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(parseLooseJsonObject('')).toBeNull();
+  });
+});

--- a/packages/app/src/ai/jsonExtract.ts
+++ b/packages/app/src/ai/jsonExtract.ts
@@ -1,0 +1,87 @@
+/**
+ * Lenient extraction of a JSON object from free-form model output.
+ *
+ * Thinking models (e.g. `gemma-4-31b-it`) and chat models sometimes wrap their
+ * answer in markdown fences or emit reasoning prose alongside it. This module
+ * recovers the intended JSON object from such output.
+ *
+ * @module ai/jsonExtract
+ */
+
+/**
+ * Extract the first balanced top-level `{...}` object from `text`.
+ *
+ * Brace counting is string-aware: braces inside JSON string literals (and
+ * escaped quotes) are ignored. Returns the object's source substring, or
+ * `null` if no balanced object is found.
+ */
+export function extractFirstJsonObject(text: string): string | null {
+  const start = text.indexOf('{');
+  if (start === -1) return null;
+
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === '\\') {
+        escaped = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = true;
+    } else if (ch === '{') {
+      depth++;
+    } else if (ch === '}') {
+      depth--;
+      if (depth === 0) {
+        return text.slice(start, i + 1);
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Parse a JSON object out of free-form model output.
+ *
+ * Tries, in order: the whole (fence-stripped) string, then the first balanced
+ * `{...}` object found within it. Returns the parsed value, or `null` if
+ * nothing usable could be parsed.
+ */
+export function parseLooseJsonObject(text: string): unknown {
+  // Strip a leading/trailing markdown code fence if present.
+  const stripped = text
+    .trim()
+    .replace(/^```(?:json)?\s*/i, '')
+    .replace(/\s*```$/i, '')
+    .trim();
+
+  // Fast path: the whole thing is valid JSON.
+  try {
+    return JSON.parse(stripped);
+  } catch {
+    // Fall through to substring extraction.
+  }
+
+  const candidate = extractFirstJsonObject(stripped);
+  if (candidate) {
+    try {
+      return JSON.parse(candidate);
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}

--- a/packages/app/src/ai/keyStore.test.ts
+++ b/packages/app/src/ai/keyStore.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests for the session-scoped API key store.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  clearKey,
+  getEffectiveKey,
+  getKey,
+  hasUsableKey,
+  hasUserKey,
+  setKey,
+} from './keyStore';
+
+describe('keyStore', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('returns null when no key is stored', () => {
+    expect(getKey('gemini')).toBeNull();
+    expect(hasUserKey('gemini')).toBe(false);
+  });
+
+  it('stores and retrieves a key', () => {
+    setKey('gemini', 'my-secret-key');
+    expect(getKey('gemini')).toBe('my-secret-key');
+    expect(hasUserKey('gemini')).toBe(true);
+  });
+
+  it('trims whitespace around a stored key', () => {
+    setKey('gemini', '  spaced-key  ');
+    expect(getKey('gemini')).toBe('spaced-key');
+  });
+
+  it('treats a blank key as a clear', () => {
+    setKey('gemini', 'real-key');
+    setKey('gemini', '   ');
+    expect(getKey('gemini')).toBeNull();
+  });
+
+  it('clearKey removes a stored key', () => {
+    setKey('gemini', 'real-key');
+    clearKey('gemini');
+    expect(getKey('gemini')).toBeNull();
+  });
+
+  it('persists the key under the sessionStorage namespace', () => {
+    setKey('gemini', 'abc123');
+    expect(sessionStorage.getItem('solitaire.ai.key.gemini')).toBe('abc123');
+  });
+
+  it('getEffectiveKey returns the stored key', () => {
+    setKey('gemini', 'effective-key');
+    expect(getEffectiveKey('gemini')).toBe('effective-key');
+    expect(hasUsableKey('gemini')).toBe(true);
+  });
+
+  it('getEffectiveKey returns null when nothing is available', () => {
+    // The dev fallback key is empty in test builds.
+    expect(getEffectiveKey('gemini')).toBeNull();
+    expect(hasUsableKey('gemini')).toBe(false);
+  });
+});

--- a/packages/app/src/ai/keyStore.ts
+++ b/packages/app/src/ai/keyStore.ts
@@ -1,0 +1,87 @@
+/**
+ * Session-scoped storage for LLM API keys.
+ *
+ * Keys live in `sessionStorage` only: they survive page reloads within the
+ * same browser tab but are cleared when the tab closes. They are never written
+ * to `localStorage`, never exported with a save file, and never logged.
+ *
+ * This is the *only* module permitted to read or write API keys to storage.
+ *
+ * @module ai/keyStore
+ */
+
+import type { AIProviderId } from './types';
+
+/** `sessionStorage` key prefix for provider API keys. */
+const STORAGE_PREFIX = 'solitaire.ai.key.';
+
+/** Safely access `sessionStorage` (absent in SSR / some test environments). */
+function getStorage(): Storage | null {
+  try {
+    if (typeof window === 'undefined' || !window.sessionStorage) return null;
+    return window.sessionStorage;
+  } catch {
+    // Accessing sessionStorage can throw in sandboxed iframes / privacy modes.
+    return null;
+  }
+}
+
+/**
+ * Dev-only fallback key, injected from the repo-root `.env` at build time.
+ * Empty string in production builds. Lets `pnpm dev` use a `.env` key without
+ * pasting it into the UI. See `vite.config.ts`.
+ */
+export function getDevFallbackKey(): string {
+  try {
+    return typeof __DEV_GEMINI_KEY__ === 'string' ? __DEV_GEMINI_KEY__ : '';
+  } catch {
+    return '';
+  }
+}
+
+/** Retrieve the stored API key for a provider, or `null` if none is set. */
+export function getKey(provider: AIProviderId): string | null {
+  const storage = getStorage();
+  if (!storage) return null;
+  const value = storage.getItem(STORAGE_PREFIX + provider);
+  return value && value.length > 0 ? value : null;
+}
+
+/**
+ * Retrieve the key to actually use for a request: the user-provided key if
+ * present, otherwise the dev fallback key (development builds only).
+ */
+export function getEffectiveKey(provider: AIProviderId): string | null {
+  const stored = getKey(provider);
+  if (stored) return stored;
+  const fallback = getDevFallbackKey();
+  return fallback.length > 0 ? fallback : null;
+}
+
+/** Store an API key for a provider. An empty/blank key clears it instead. */
+export function setKey(provider: AIProviderId, key: string): void {
+  const storage = getStorage();
+  if (!storage) return;
+  const trimmed = key.trim();
+  if (trimmed.length === 0) {
+    storage.removeItem(STORAGE_PREFIX + provider);
+  } else {
+    storage.setItem(STORAGE_PREFIX + provider, trimmed);
+  }
+}
+
+/** Remove a provider's stored API key. */
+export function clearKey(provider: AIProviderId): void {
+  const storage = getStorage();
+  storage?.removeItem(STORAGE_PREFIX + provider);
+}
+
+/** Whether a usable key (user-provided or dev fallback) exists for a provider. */
+export function hasUsableKey(provider: AIProviderId): boolean {
+  return getEffectiveKey(provider) !== null;
+}
+
+/** Whether the user has explicitly stored a key (ignores the dev fallback). */
+export function hasUserKey(provider: AIProviderId): boolean {
+  return getKey(provider) !== null;
+}

--- a/packages/app/src/ai/providers/GeminiProvider.test.ts
+++ b/packages/app/src/ai/providers/GeminiProvider.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for the Gemini / Gemma provider — HTTP and response handling are
+ * exercised against a mocked `fetch`.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { geminiProvider } from './GeminiProvider';
+import { AIError, type AIMoveContext, type AIRequest } from '../types';
+
+const context: AIMoveContext = {
+  notation: 'test',
+  foundations: { hearts: null, diamonds: null, clubs: null, spades: null },
+  tableau: [],
+  discardTop: null,
+  drawPileCount: 0,
+  canRecycleStock: false,
+  legalMoves: [
+    { index: 0, type: 'draw_card', describe: 'Draw' },
+    { index: 1, type: 'discard_to_foundation', describe: 'To foundation' },
+  ],
+};
+
+const request: AIRequest = {
+  apiKey: 'test-key',
+  model: 'gemma-4-31b-it',
+  systemInstruction: 'Be a solitaire advisor.',
+  context,
+};
+
+/** Build a minimal `Response`-like object. */
+function mockResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+describe('geminiProvider.suggestMove', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('rejects when no API key is supplied', async () => {
+    await expect(geminiProvider.suggestMove({ ...request, apiKey: '' })).rejects.toMatchObject({
+      kind: 'no_key',
+    });
+  });
+
+  it('parses a thinking-model response, ignoring "thought" parts', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse(200, {
+        candidates: [
+          {
+            content: {
+              parts: [
+                { text: 'Internal reasoning about the board...', thought: true },
+                { text: '{"moveIndex":1,"reasoning":"Bank the card.","confidence":0.9}' },
+              ],
+            },
+            finishReason: 'STOP',
+          },
+        ],
+      }),
+    );
+
+    const decision = await geminiProvider.suggestMove(request);
+    expect(decision.moveIndex).toBe(1);
+    expect(decision.reasoning).toBe('Bank the card.');
+    expect(decision.confidence).toBeCloseTo(0.9);
+  });
+
+  it('falls back to all parts when none are flagged as thoughts', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse(200, {
+        candidates: [
+          {
+            content: {
+              parts: [{ text: '{"moveIndex":0,"reasoning":"Draw.","confidence":0.5}' }],
+            },
+            finishReason: 'STOP',
+          },
+        ],
+      }),
+    );
+
+    const decision = await geminiProvider.suggestMove(request);
+    expect(decision.moveIndex).toBe(0);
+  });
+
+  it('maps HTTP 401 to an invalid_key error', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse(401, { error: { code: 401, message: 'API key not valid' } }),
+    );
+    await expect(geminiProvider.suggestMove(request)).rejects.toMatchObject({
+      kind: 'invalid_key',
+    });
+  });
+
+  it('maps HTTP 429 to a rate_limited error', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse(429, { error: { code: 429, message: 'Quota exceeded' } }),
+    );
+    await expect(geminiProvider.suggestMove(request)).rejects.toMatchObject({
+      kind: 'rate_limited',
+    });
+  });
+
+  it('maps HTTP 404 to a config error', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse(404, { error: { code: 404, message: 'model not found' } }),
+    );
+    await expect(geminiProvider.suggestMove(request)).rejects.toMatchObject({
+      kind: 'config',
+    });
+  });
+
+  it('maps HTTP 503 to an unavailable error', async () => {
+    vi.mocked(fetch).mockResolvedValue(mockResponse(503, { error: { code: 503 } }));
+    await expect(geminiProvider.suggestMove(request)).rejects.toMatchObject({
+      kind: 'unavailable',
+    });
+  });
+
+  it('maps a network failure to a network error', async () => {
+    vi.mocked(fetch).mockRejectedValue(new TypeError('Failed to fetch'));
+    await expect(geminiProvider.suggestMove(request)).rejects.toMatchObject({
+      kind: 'network',
+    });
+  });
+
+  it('maps an aborted fetch to an aborted error', async () => {
+    vi.mocked(fetch).mockRejectedValue(new DOMException('aborted', 'AbortError'));
+    await expect(geminiProvider.suggestMove(request)).rejects.toMatchObject({
+      kind: 'aborted',
+    });
+  });
+
+  it('rejects bad_response when the model returns no usable text', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse(200, {
+        candidates: [{ content: { parts: [] }, finishReason: 'SAFETY' }],
+      }),
+    );
+    await expect(geminiProvider.suggestMove(request)).rejects.toMatchObject({
+      kind: 'bad_response',
+    });
+  });
+
+  it('rejects bad_response when the model picks an out-of-range index', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse(200, {
+        candidates: [
+          {
+            content: {
+              parts: [{ text: '{"moveIndex":7,"reasoning":"x","confidence":1}' }],
+            },
+          },
+        ],
+      }),
+    );
+    await expect(geminiProvider.suggestMove(request)).rejects.toBeInstanceOf(AIError);
+  });
+});

--- a/packages/app/src/ai/providers/GeminiProvider.ts
+++ b/packages/app/src/ai/providers/GeminiProvider.ts
@@ -1,0 +1,193 @@
+/**
+ * Google Gemini / Gemma provider for the AI Move Advisor.
+ *
+ * Calls the Generative Language REST API directly from the browser using the
+ * user's own API key. There is no backend: the key is sent only to Google.
+ *
+ * Design notes:
+ * - The request is a single user message: the system instruction, the game
+ *   context JSON, and the output instruction are concatenated. Gemma models do
+ *   not reliably support a separate `systemInstruction`, so folding everything
+ *   into one message keeps a single code path that works for both Gemma and
+ *   Gemini models.
+ * - `gemma-4-31b-it` is a *thinking* model: its response splits into parts
+ *   flagged `thought: true` (internal reasoning) and the final answer part.
+ *   We read only the non-thought parts, then parse leniently as a safety net.
+ *
+ * @module ai/providers/GeminiProvider
+ */
+
+import { AI_REQUEST_TIMEOUT_MS, AI_TEMPERATURE, GEMINI_API_BASE } from '../constants';
+import { parseDecision } from '../decision/schema';
+import { AIError, type AIMoveDecision, type AIProvider, type AIRequest } from '../types';
+
+/** Shape of a single content part in a Gemini API response. */
+interface GeminiPart {
+  text?: string;
+  thought?: boolean;
+}
+
+/** Minimal shape of the Gemini `generateContent` response we rely on. */
+interface GeminiResponse {
+  candidates?: {
+    content?: { parts?: GeminiPart[] };
+    finishReason?: string;
+  }[];
+  promptFeedback?: { blockReason?: string };
+  error?: { code?: number; message?: string; status?: string };
+}
+
+/** Map a non-OK HTTP response to a typed {@link AIError}. */
+function errorFromHttp(status: number, body: GeminiResponse | null): AIError {
+  const message = body?.error?.message ?? '';
+  const lower = message.toLowerCase();
+
+  if (status === 429) {
+    return new AIError('rate_limited', 'Gemini rate limit reached. Wait a moment and try again.');
+  }
+  if (status === 401 || status === 403) {
+    return new AIError('invalid_key', 'Gemini rejected the API key. Check that it is valid.');
+  }
+  if (status === 400) {
+    if (lower.includes('api key') || lower.includes('api_key')) {
+      return new AIError('invalid_key', 'Gemini rejected the API key. Check that it is valid.');
+    }
+    return new AIError('bad_response', `Gemini rejected the request: ${message || 'bad request'}.`);
+  }
+  if (status === 404) {
+    return new AIError(
+      'config',
+      `Model not found (404). ${message || 'Check the model id in AI settings.'}`,
+    );
+  }
+  if (status >= 500) {
+    return new AIError('unavailable', 'Gemini is temporarily unavailable. Try again shortly.');
+  }
+  return new AIError('network', `Gemini request failed (HTTP ${status}). ${message}`.trim());
+}
+
+/** Extract the model's answer text from a successful response. */
+function extractAnswerText(data: GeminiResponse): string {
+  const candidate = data.candidates?.[0];
+  if (!candidate) {
+    const block = data.promptFeedback?.blockReason;
+    throw new AIError(
+      'bad_response',
+      block
+        ? `Gemini blocked the request (${block}).`
+        : 'Gemini returned no candidates.',
+    );
+  }
+
+  const parts = candidate.content?.parts ?? [];
+  // Prefer non-"thought" parts (the final answer of a thinking model).
+  const answer = parts
+    .filter((p) => p.thought !== true && typeof p.text === 'string')
+    .map((p) => p.text as string)
+    .join('')
+    .trim();
+  if (answer.length > 0) return answer;
+
+  // Fallback: some models do not flag thought parts — use everything.
+  const all = parts
+    .filter((p) => typeof p.text === 'string')
+    .map((p) => p.text as string)
+    .join('')
+    .trim();
+  if (all.length > 0) return all;
+
+  throw new AIError(
+    'bad_response',
+    `Gemini returned an empty answer (finishReason: ${candidate.finishReason ?? 'unknown'}).`,
+  );
+}
+
+/** The Google Gemini / Gemma provider. */
+export const geminiProvider: AIProvider = {
+  id: 'gemini',
+  displayName: 'Google Gemini / Gemma',
+  requiresKey: true,
+  defaultModel: 'gemma-4-31b-it',
+  availableModels: [
+    'gemma-4-31b-it',
+    'gemma-4-26b-a4b-it',
+    'gemini-2.5-flash',
+    'gemini-2.5-pro',
+  ],
+  apiKeyUrl: 'https://aistudio.google.com/apikey',
+
+  async suggestMove(request: AIRequest): Promise<AIMoveDecision> {
+    if (!request.apiKey) {
+      throw new AIError('no_key', 'No Gemini API key configured.');
+    }
+
+    // Single user message: system instruction + game context + (output rules
+    // are already inside the system instruction).
+    const prompt =
+      `${request.systemInstruction}\n\n` +
+      `CURRENT GAME (JSON):\n${JSON.stringify(request.context)}\n\n` +
+      'Now choose the best move and reply with only the JSON object.';
+
+    const body = {
+      contents: [{ role: 'user', parts: [{ text: prompt }] }],
+      generationConfig: { temperature: AI_TEMPERATURE },
+    };
+
+    // Combine our timeout with any caller-supplied abort signal.
+    const controller = new AbortController();
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, AI_REQUEST_TIMEOUT_MS);
+    const onParentAbort = () => controller.abort();
+    request.signal?.addEventListener('abort', onParentAbort);
+
+    const url =
+      `${GEMINI_API_BASE}/models/${encodeURIComponent(request.model)}:generateContent` +
+      `?key=${encodeURIComponent(request.apiKey)}`;
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        throw new AIError(
+          timedOut ? 'timeout' : 'aborted',
+          timedOut
+            ? `The model did not respond within ${Math.round(AI_REQUEST_TIMEOUT_MS / 1000)}s.`
+            : 'The AI request was cancelled.',
+        );
+      }
+      throw new AIError('network', 'Could not reach Gemini. Check your network connection.');
+    } finally {
+      clearTimeout(timer);
+      request.signal?.removeEventListener('abort', onParentAbort);
+    }
+
+    let data: GeminiResponse | null;
+    try {
+      data = (await response.json()) as GeminiResponse;
+    } catch {
+      data = null;
+    }
+
+    if (!response.ok) {
+      throw errorFromHttp(response.status, data);
+    }
+    if (!data) {
+      throw new AIError('bad_response', 'Gemini returned a response that was not JSON.');
+    }
+    if (data.error) {
+      throw errorFromHttp(data.error.code ?? 500, data);
+    }
+
+    const text = extractAnswerText(data);
+    return parseDecision(text, request.context.legalMoves.length);
+  },
+};

--- a/packages/app/src/ai/providers/index.ts
+++ b/packages/app/src/ai/providers/index.ts
@@ -1,0 +1,57 @@
+/**
+ * Provider registry for the AI Move Advisor.
+ *
+ * The rest of the app resolves providers through {@link getProvider}, never by
+ * importing a concrete provider directly. Adding a new provider means adding it
+ * to {@link REGISTRY} — no store or UI changes are required.
+ *
+ * A test override ({@link setProviderOverride}) lets the test bridge swap in a
+ * deterministic stub.
+ *
+ * @module ai/providers
+ */
+
+import { AIError, type AIProvider, type AIProviderId } from '../types';
+import { geminiProvider } from './GeminiProvider';
+
+/** All registered providers, keyed by id. */
+const REGISTRY: Record<AIProviderId, AIProvider> = {
+  gemini: geminiProvider,
+};
+
+/** Active test override; when set, {@link getProvider} returns it for any id. */
+let override: AIProvider | null = null;
+
+/**
+ * Resolve the provider to use. Returns the test override when one is set,
+ * otherwise the registered provider for `id`.
+ *
+ * @throws {AIError} of kind `config` when `id` is unknown.
+ */
+export function getProvider(id: AIProviderId): AIProvider {
+  if (override) return override;
+  const provider = REGISTRY[id];
+  if (!provider) {
+    throw new AIError('config', `Unknown AI provider: ${id}`);
+  }
+  return provider;
+}
+
+/** All registered providers (ignores any test override). */
+export function listProviders(): AIProvider[] {
+  return Object.values(REGISTRY);
+}
+
+/** Install (or clear, with `null`) a provider override for testing. */
+export function setProviderOverride(provider: AIProvider | null): void {
+  override = provider;
+}
+
+/** The current provider override, if any. */
+export function getProviderOverride(): AIProvider | null {
+  return override;
+}
+
+export { geminiProvider } from './GeminiProvider';
+export { createStubProvider } from './stubProvider';
+export type { StubDecisionFn } from './stubProvider';

--- a/packages/app/src/ai/providers/stubProvider.ts
+++ b/packages/app/src/ai/providers/stubProvider.ts
@@ -1,0 +1,43 @@
+/**
+ * A stub provider for deterministic testing.
+ *
+ * Wraps a caller-supplied decision function so tests (unit and E2E via the
+ * test bridge) can exercise the full advisor pipeline without a network call
+ * or a real API key.
+ *
+ * @module ai/providers/stubProvider
+ */
+
+import type { AIMoveContext, AIMoveDecision, AIProvider } from '../types';
+
+/** A function that turns a game context into a decision. */
+export type StubDecisionFn = (
+  context: AIMoveContext,
+) => AIMoveDecision | Promise<AIMoveDecision>;
+
+/**
+ * Create a stub {@link AIProvider} backed by `decide`.
+ *
+ * The stub requires no API key. By default it picks the first legal move with
+ * a placeholder reasoning — pass `decide` to control the choice.
+ */
+export function createStubProvider(decide?: StubDecisionFn): AIProvider {
+  const fallback: StubDecisionFn = () => ({
+    moveIndex: 0,
+    reasoning: 'Stub provider: chose the first legal move.',
+    confidence: 1,
+  });
+  const fn = decide ?? fallback;
+
+  return {
+    id: 'stub',
+    displayName: 'Stub (test)',
+    requiresKey: false,
+    defaultModel: 'stub',
+    availableModels: ['stub'],
+    apiKeyUrl: '',
+    async suggestMove(request): Promise<AIMoveDecision> {
+      return fn(request.context);
+    },
+  };
+}

--- a/packages/app/src/ai/types.ts
+++ b/packages/app/src/ai/types.ts
@@ -1,0 +1,247 @@
+/**
+ * Type definitions for the AI Move Advisor feature.
+ *
+ * The AI Move Advisor lets a player ask an LLM (currently Google Gemini) for
+ * the next best move. The LLM is given a structured snapshot of the game plus
+ * a numbered list of *legal* moves, and must return its choice as an index
+ * into that list — it can never describe an illegal move in free text.
+ *
+ * @module ai/types
+ */
+
+import type { MoveCommand } from '@chayuto/solitaire-core';
+import type { Suit } from '../types';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/** Identifier for an LLM provider. Extend this union to add new providers. */
+export type AIProviderId = 'gemini';
+
+/**
+ * Context verbosity preset. Controls how much information is sent to the LLM.
+ * `custom` unlocks every individual toggle in {@link AIConfig}.
+ */
+export type AIContextPreset = 'minimal' | 'standard' | 'detailed' | 'custom';
+
+/**
+ * User-configurable settings for the AI advisor. Lives in the game store and
+ * persists across new games within a session (but is not exported with a save
+ * file, and the API key is never stored here — see {@link module:ai/keyStore}).
+ */
+export interface AIConfig {
+  /** Which LLM provider to use. */
+  provider: AIProviderId;
+  /** Provider-specific model id, e.g. `gemini-2.5-flash`. */
+  model: string;
+  /** Active context preset. */
+  preset: AIContextPreset;
+
+  // --- Optional context fields (gated by the preset, overridable in `custom`) ---
+
+  /** Include a list of the most recent moves played. */
+  includeMoveHistory: boolean;
+  /** How many recent moves to include when {@link includeMoveHistory} is on. */
+  moveHistoryLimit: number;
+  /** Include completion progress, perceived difficulty, move count, difficulty. */
+  includeGameMetrics: boolean;
+  /** Include a static block of Klondike strategy heuristics in the prompt. */
+  includeStrategyGuidance: boolean;
+  /** Attach the built-in autoplay heuristic score to each legal move. */
+  includeHeuristicScores: boolean;
+  /**
+   * Include the identities of stock cards the player has already cycled past.
+   * Player-visible information — not a fairness concern.
+   */
+  includeSeenDrawPileCards: boolean;
+  /** Feed the AI its own recent decisions + reasons back as context. */
+  includeReasoningTrail: boolean;
+  /** How many past AI decisions to include when {@link includeReasoningTrail} is on. */
+  reasoningTrailLimit: number;
+
+  // --- Fairness toggle (independent of the preset) ---
+
+  /**
+   * When `true`, the AI receives every hidden card (face-down tableau cards and
+   * the full unseen stock order) — an oracle/solver. When `false`, hidden cards
+   * are sent only as counts, so the AI reasons like a fair human advisor.
+   */
+  seeHiddenCards: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Context payload (what we send to the LLM)
+// ---------------------------------------------------------------------------
+
+/** A single legal move, as presented to the LLM. */
+export interface AILegalMove {
+  /** Index into the legal-moves list — the value the LLM must return. */
+  index: number;
+  /** Move type. */
+  type: MoveCommand['type'];
+  /** Human-readable description of the move. */
+  describe: string;
+  /** Autoplay heuristic score (higher = better), when heuristic scores are enabled. */
+  heuristicScore?: number;
+}
+
+/** One tableau column, as presented to the LLM. */
+export interface AITableauColumn {
+  /** Number of face-down (hidden) cards at the bottom of the column. */
+  faceDownCount: number;
+  /** Face-up cards, bottom-to-top, in card shorthand (e.g. `["KS","QH"]`). */
+  faceUp: string[];
+  /** Face-down card identities — only present when `seeHiddenCards` is enabled. */
+  faceDown?: string[];
+}
+
+/** The structured game snapshot sent to the LLM. Serialized to JSON. */
+export interface AIMoveContext {
+  /** One-line explanation of the card shorthand notation. */
+  notation: string;
+  /** Top card of each foundation in shorthand, or `null` when empty. */
+  foundations: Record<Suit, string | null>;
+  /** The seven tableau columns. */
+  tableau: AITableauColumn[];
+  /** Top (playable) waste card in shorthand, or `null`. */
+  discardTop: string | null;
+  /** Number of cards remaining in the stock. */
+  drawPileCount: number;
+  /** Whether the waste pile can be recycled back into an empty stock. */
+  canRecycleStock: boolean;
+  /** Every legal move — the LLM must pick one by its `index`. */
+  legalMoves: AILegalMove[];
+
+  // --- Optional fields ---
+
+  /** Game metrics (when `includeGameMetrics`). */
+  metrics?: {
+    completionProgress: number;
+    perceivedDifficulty: number | undefined;
+    moveCount: number;
+    difficulty: number;
+  };
+  /** Recent moves, most-recent last (when `includeMoveHistory`). */
+  recentMoves?: string[];
+  /**
+   * Stock cards the player has already seen, in the order they will be drawn
+   * (when `includeSeenDrawPileCards`).
+   */
+  seenDrawPileCards?: string[];
+  /** Full hidden information (only when `seeHiddenCards`). */
+  hiddenInfo?: {
+    /** Every stock card in draw order. */
+    drawPileOrder: string[];
+  };
+  /** The AI's own recent decisions (when `includeReasoningTrail`). */
+  reasoningTrail?: { move: string; reasoning: string }[];
+}
+
+// ---------------------------------------------------------------------------
+// Decision (what the LLM returns)
+// ---------------------------------------------------------------------------
+
+/** The structured decision an LLM must return. Validated before use. */
+export interface AIMoveDecision {
+  /** Index into the supplied legal-moves list. */
+  moveIndex: number;
+  /** The LLM's explanation of why this move is best. */
+  reasoning: string;
+  /** The LLM's self-rated confidence, 0–1. */
+  confidence: number;
+  /** Optional runner-up move index. */
+  alternativeMoveIndex?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Provider abstraction
+// ---------------------------------------------------------------------------
+
+/** A request handed to a provider's {@link AIProvider.suggestMove}. */
+export interface AIRequest {
+  /** The user's API key (empty string for providers that don't need one). */
+  apiKey: string;
+  /** Provider-specific model id. */
+  model: string;
+  /** System instruction text (rules, role, output format). */
+  systemInstruction: string;
+  /** The structured game context. */
+  context: AIMoveContext;
+  /** Optional abort signal for cancellation / timeout. */
+  signal?: AbortSignal;
+}
+
+/**
+ * An LLM provider. Implementations own only transport concerns — building the
+ * request, calling the API, parsing the raw response into an {@link AIMoveDecision}.
+ * They do not own game logic or prompt content.
+ */
+export interface AIProvider {
+  /** Stable provider id. */
+  readonly id: string;
+  /** Human-readable name shown in the UI. */
+  readonly displayName: string;
+  /** Whether this provider needs an API key (test stubs do not). */
+  readonly requiresKey: boolean;
+  /** Default model id. */
+  readonly defaultModel: string;
+  /** Selectable model ids. */
+  readonly availableModels: readonly string[];
+  /** URL where a user can obtain an API key. */
+  readonly apiKeyUrl: string;
+  /** Ask the model for a move. Rejects with an {@link AIError} on failure. */
+  suggestMove(request: AIRequest): Promise<AIMoveDecision>;
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/** Categorized failure modes for the AI advisor. */
+export type AIErrorKind =
+  | 'no_key' // no API key configured
+  | 'invalid_key' // provider rejected the key
+  | 'rate_limited' // provider rate limit hit
+  | 'network' // network failure
+  | 'timeout' // request exceeded the timeout
+  | 'aborted' // request was cancelled
+  | 'bad_response' // provider returned something unusable
+  | 'no_moves' // no legal moves to choose from
+  | 'busy' // a request is already in flight
+  | 'unavailable' // game is in a state where the advisor can't run
+  | 'config'; // misconfiguration (e.g. unknown provider)
+
+/** A typed, user-presentable error for the AI advisor. */
+export class AIError extends Error {
+  /** The categorized failure mode. */
+  readonly kind: AIErrorKind;
+
+  constructor(kind: AIErrorKind, message: string) {
+    super(message);
+    this.name = 'AIError';
+    this.kind = kind;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Store-side records
+// ---------------------------------------------------------------------------
+
+/** A record of one AI decision, kept in the store's `aiDecisionLog`. */
+export interface AIDecisionRecord {
+  /** When the decision was applied. */
+  timestamp: number;
+  /** The chosen move's type. */
+  moveType: MoveCommand['type'];
+  /** Human-readable description of the chosen move. */
+  describe: string;
+  /** The LLM's reasoning. */
+  reasoning: string;
+  /** The LLM's confidence, 0–1. */
+  confidence: number;
+  /** Description of the runner-up move, if the LLM supplied one. */
+  alternativeDescribe?: string;
+  /** Model that produced the decision. */
+  model: string;
+}

--- a/packages/app/src/components/AIAdvisorPanel.tsx
+++ b/packages/app/src/components/AIAdvisorPanel.tsx
@@ -1,0 +1,192 @@
+import { useEffect, useState } from 'react';
+import { useGameStore } from '../store/gameStore';
+import { AI_REQUEST_TIMEOUT_MS } from '../ai';
+
+/** Format a millisecond duration as `M:SS`. */
+function formatElapsed(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}
+
+/** Pick a Tailwind color band for a confidence value. */
+function confidenceColor(confidence: number): string {
+  if (confidence >= 0.75) return 'bg-green-500';
+  if (confidence >= 0.4) return 'bg-yellow-500';
+  return 'bg-red-500';
+}
+
+/**
+ * AIAdvisorPanel — shows the AI advisor's status: an elapsed-time waiting
+ * indicator while a request is in flight, the most recent decision with its
+ * reasoning and confidence, or the last error.
+ */
+const AIAdvisorPanel: React.FC = () => {
+  const aiThinking = useGameStore((s) => s.aiThinking) ?? false;
+  const aiAutoPlay = useGameStore((s) => s.aiAutoPlay) ?? false;
+  const aiThinkingSince = useGameStore((s) => s.aiThinkingSince);
+  const aiError = useGameStore((s) => s.aiError);
+  const aiDecisionLog = useGameStore((s) => s.aiDecisionLog);
+  const cancelAIRequest = useGameStore((s) => s.cancelAIRequest);
+  const toggleAIAutoPlay = useGameStore((s) => s.toggleAIAutoPlay);
+  const clearAIError = useGameStore((s) => s.clearAIError);
+
+  const lastDecision =
+    aiDecisionLog && aiDecisionLog.length > 0
+      ? aiDecisionLog[aiDecisionLog.length - 1]
+      : null;
+
+  // Live elapsed-time counter, ticking once per second while thinking. The
+  // interval callback (not the effect body) drives the updates; the display is
+  // clamped to >= 0 so a momentarily stale `now` simply shows 0:00.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!aiThinking) return;
+    const id = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(id);
+  }, [aiThinking]);
+
+  const elapsedMs = aiThinking && aiThinkingSince ? Math.max(0, now - aiThinkingSince) : 0;
+  const timeoutSeconds = Math.round(AI_REQUEST_TIMEOUT_MS / 1000);
+
+  return (
+    <div
+      data-testid="ai-advisor-panel"
+      className="bg-white/90 backdrop-blur-sm rounded-lg shadow-xl w-full overflow-hidden"
+    >
+      <div className="bg-indigo-600 text-white px-4 py-2 flex items-center justify-between">
+        <h3 className="text-lg font-bold">🤖 AI Advisor</h3>
+        {aiAutoPlay && (
+          <span
+            data-testid="ai-auto-badge"
+            className="text-[11px] font-bold bg-white/25 rounded px-2 py-0.5"
+          >
+            AUTO-PLAY
+          </span>
+        )}
+      </div>
+
+      <div className="p-3 space-y-3">
+        {/* Auto-play idle beat (between moves) */}
+        {aiAutoPlay && !aiThinking && (
+          <div
+            data-testid="ai-auto-indicator"
+            className="bg-indigo-50 border border-indigo-200 rounded p-2 flex items-center justify-between"
+          >
+            <span className="text-xs font-semibold text-indigo-800">
+              ⏳ Auto-play — next move queued…
+            </span>
+            <button
+              data-testid="ai-auto-stop-btn"
+              onClick={toggleAIAutoPlay}
+              className="bg-indigo-200 hover:bg-indigo-300 text-indigo-900 font-semibold py-1 px-2 rounded text-xs"
+            >
+              Stop
+            </button>
+          </div>
+        )}
+
+        {/* Waiting indicator */}
+        {aiThinking && (
+          <div
+            data-testid="ai-thinking-indicator"
+            className="bg-indigo-50 border border-indigo-200 rounded p-3"
+          >
+            <div className="flex items-center gap-2">
+              <span className="inline-block w-4 h-4 border-2 border-indigo-500 border-t-transparent rounded-full animate-spin" />
+              <span className="text-sm font-semibold text-indigo-800">
+                {aiAutoPlay ? 'Auto-playing…' : 'Thinking…'}
+              </span>
+              <span
+                data-testid="ai-elapsed"
+                className="ml-auto text-sm font-mono font-bold text-indigo-700 tabular-nums"
+              >
+                {formatElapsed(elapsedMs)}
+              </span>
+            </div>
+            <p className="text-xs text-indigo-700 mt-2">
+              A thinking model can take a while — up to ~{Math.round(timeoutSeconds / 60)} minutes
+              on a hard board. The board is locked until it answers.
+            </p>
+            <button
+              data-testid="ai-cancel-btn"
+              onClick={aiAutoPlay ? toggleAIAutoPlay : cancelAIRequest}
+              className="mt-2 w-full bg-indigo-200 hover:bg-indigo-300 text-indigo-900 font-semibold py-1.5 px-3 rounded text-sm"
+            >
+              {aiAutoPlay ? 'Stop Auto-Play' : 'Cancel'}
+            </button>
+          </div>
+        )}
+
+        {/* Error */}
+        {!aiThinking && aiError && (
+          <div
+            data-testid="ai-error"
+            className="bg-red-50 border border-red-300 rounded p-3"
+          >
+            <div className="flex items-start justify-between gap-2">
+              <p className="text-sm text-red-800 font-semibold">⚠️ {aiError}</p>
+              <button
+                data-testid="ai-error-dismiss-btn"
+                onClick={clearAIError}
+                className="text-red-400 hover:text-red-700 text-sm leading-none"
+                aria-label="Dismiss error"
+              >
+                ✕
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Last decision */}
+        {!aiThinking && lastDecision && (
+          <div data-testid="ai-last-decision" className="bg-gray-50 border border-gray-200 rounded p-3">
+            <p className="text-sm font-semibold text-gray-800">{lastDecision.describe}</p>
+
+            <div className="mt-2">
+              <div className="flex justify-between items-center mb-1">
+                <span className="text-xs font-semibold text-gray-600">Confidence</span>
+                <span className="text-xs font-bold text-gray-700">
+                  {Math.round(lastDecision.confidence * 100)}%
+                </span>
+              </div>
+              <div className="w-full bg-gray-200 rounded-full h-2">
+                <div
+                  className={`h-2 rounded-full transition-all ${confidenceColor(lastDecision.confidence)}`}
+                  style={{ width: `${Math.round(lastDecision.confidence * 100)}%` }}
+                />
+              </div>
+            </div>
+
+            <p
+              data-testid="ai-reasoning"
+              className="mt-2 text-xs text-gray-700 whitespace-pre-wrap break-words"
+            >
+              {lastDecision.reasoning}
+            </p>
+
+            {lastDecision.alternativeDescribe && (
+              <p className="mt-2 text-xs text-gray-500">
+                Alternative considered: {lastDecision.alternativeDescribe}
+              </p>
+            )}
+
+            <p className="mt-2 text-[10px] text-gray-400 font-mono">
+              {lastDecision.model} · {new Date(lastDecision.timestamp).toLocaleTimeString()}
+            </p>
+          </div>
+        )}
+
+        {/* Idle hint */}
+        {!aiThinking && !aiError && !lastDecision && (
+          <p className="text-xs text-gray-500 text-center py-2">
+            Use the “Ask AI” button to get a suggested move and its reasoning.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default AIAdvisorPanel;

--- a/packages/app/src/components/AIKeyModal.tsx
+++ b/packages/app/src/components/AIKeyModal.tsx
@@ -1,0 +1,190 @@
+import { useState } from 'react';
+import { useGameStore } from '../store/gameStore';
+import { DEFAULT_AI_CONFIG, listProviders } from '../ai';
+import { clearKey, getDevFallbackKey, getKey, hasUserKey, setKey } from '../ai/keyStore';
+import type { AIProviderId } from '../ai';
+
+/**
+ * Modal body. Mounted only while the modal is open, so `useState` initializers
+ * run fresh on every open — no synchronizing effect required.
+ */
+const AIKeyModalContent: React.FC = () => {
+  const aiConfig = useGameStore((s) => s.aiConfig) ?? DEFAULT_AI_CONFIG;
+  const setAIKeyModalOpen = useGameStore((s) => s.setAIKeyModalOpen);
+  const setAIConfig = useGameStore((s) => s.setAIConfig);
+
+  const providers = listProviders();
+  const provider = providers.find((p) => p.id === aiConfig.provider) ?? providers[0];
+  const providerId = aiConfig.provider as AIProviderId;
+
+  const [keyInput, setKeyInput] = useState('');
+  const [model, setModel] = useState(aiConfig.model);
+  const [keyAlreadySet, setKeyAlreadySet] = useState(() => hasUserKey(providerId));
+  const [notice, setNotice] = useState<string | null>(null);
+
+  if (!provider) return null;
+
+  const devKeyAvailable = getDevFallbackKey().length > 0;
+
+  const handleSave = () => {
+    if (model.trim().length > 0 && model.trim() !== aiConfig.model) {
+      setAIConfig({ model: model.trim() });
+    }
+    const trimmed = keyInput.trim();
+    if (trimmed.length > 0) {
+      setKey(providerId, trimmed);
+    }
+    setAIKeyModalOpen(false);
+  };
+
+  const handleClear = () => {
+    clearKey(providerId);
+    setKeyInput('');
+    setKeyAlreadySet(false);
+    setNotice('Stored key cleared for this session.');
+  };
+
+  const maskedExisting = (() => {
+    const existing = getKey(providerId);
+    if (!existing) return null;
+    return `••••••••${existing.slice(-4)}`;
+  })();
+
+  return (
+    <div
+      data-testid="ai-key-modal"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label="AI API key settings"
+    >
+      <div className="bg-white rounded-lg shadow-2xl w-full max-w-md p-6">
+        <div className="flex items-start justify-between mb-4">
+          <h2 className="text-xl font-bold text-gray-800">🤖 AI Advisor Setup</h2>
+          <button
+            data-testid="ai-key-modal-close-btn"
+            onClick={() => setAIKeyModalOpen(false)}
+            className="text-gray-400 hover:text-gray-700 text-xl leading-none"
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Provider */}
+        <label className="block text-sm font-semibold text-gray-700 mb-1">Provider</label>
+        <div className="mb-4 text-sm text-gray-800 bg-gray-100 rounded px-3 py-2">
+          {provider.displayName}
+        </div>
+
+        {/* Model */}
+        <label htmlFor="ai-model-input" className="block text-sm font-semibold text-gray-700 mb-1">
+          Model
+        </label>
+        <input
+          id="ai-model-input"
+          data-testid="ai-model-input"
+          type="text"
+          list="ai-model-options"
+          value={model}
+          onChange={(e) => setModel(e.target.value)}
+          className="w-full border border-gray-300 rounded px-3 py-2 mb-1 text-sm"
+          placeholder="e.g. gemma-4-31b-it"
+        />
+        <datalist id="ai-model-options">
+          {provider.availableModels.map((m) => (
+            <option key={m} value={m} />
+          ))}
+        </datalist>
+        <p className="text-xs text-gray-500 mb-4">
+          Default <code>gemma-4-31b-it</code> is a thinking model — a suggestion can take
+          up to ~3 minutes. Pick a faster model (e.g. <code>gemini-2.5-flash</code>) for
+          quicker, lower-quality advice.
+        </p>
+
+        {/* API key */}
+        <label htmlFor="ai-key-input" className="block text-sm font-semibold text-gray-700 mb-1">
+          API Key
+        </label>
+        {keyAlreadySet && maskedExisting && (
+          <p className="text-xs text-green-700 mb-1">
+            A key is stored for this session ({maskedExisting}). Leave blank to keep it.
+          </p>
+        )}
+        {!keyAlreadySet && devKeyAvailable && (
+          <p data-testid="ai-key-dev-note" className="text-xs text-blue-700 mb-1">
+            A local <code>.env</code> key is available and will be used automatically in
+            development. Enter a key here to override it.
+          </p>
+        )}
+        <input
+          id="ai-key-input"
+          data-testid="ai-key-input"
+          type="password"
+          value={keyInput}
+          onChange={(e) => setKeyInput(e.target.value)}
+          autoComplete="off"
+          className="w-full border border-gray-300 rounded px-3 py-2 mb-2 text-sm font-mono"
+          placeholder={keyAlreadySet ? 'Enter a new key to replace' : 'Paste your API key'}
+        />
+
+        <p className="text-xs text-gray-500 mb-4">
+          Your key is stored only in this browser tab (<code>sessionStorage</code>) and is
+          sent only to {provider.displayName} — there is no server. It is cleared when the
+          tab closes.{' '}
+          {provider.apiKeyUrl && (
+            <a
+              href={provider.apiKeyUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 underline"
+            >
+              Get a key
+            </a>
+          )}
+        </p>
+
+        {notice && (
+          <p className="text-xs text-amber-700 bg-amber-50 rounded px-2 py-1 mb-3">{notice}</p>
+        )}
+
+        <div className="flex gap-2">
+          <button
+            data-testid="ai-key-save-btn"
+            onClick={handleSave}
+            className="flex-1 bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded text-sm"
+          >
+            Save
+          </button>
+          <button
+            data-testid="ai-key-clear-btn"
+            onClick={handleClear}
+            disabled={!keyAlreadySet}
+            className={`flex-1 font-semibold py-2 px-4 rounded text-sm ${
+              keyAlreadySet
+                ? 'bg-red-600 hover:bg-red-700 text-white'
+                : 'bg-gray-200 text-gray-400 cursor-not-allowed'
+            }`}
+          >
+            Clear Key
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+/**
+ * AIKeyModal — collects the user's LLM API key and model selection.
+ *
+ * The key is stored in `sessionStorage` only (see `ai/keyStore`): it survives
+ * reloads within the tab but is cleared when the tab closes. It is never
+ * persisted to disk, exported, or logged.
+ */
+const AIKeyModal: React.FC = () => {
+  const isOpen = useGameStore((s) => s.aiKeyModalOpen) ?? false;
+  if (!isOpen) return null;
+  return <AIKeyModalContent />;
+};
+
+export default AIKeyModal;

--- a/packages/app/src/components/AISettingsSection.tsx
+++ b/packages/app/src/components/AISettingsSection.tsx
@@ -1,0 +1,121 @@
+import { useState } from 'react';
+import { useGameStore } from '../store/gameStore';
+import { DEFAULT_AI_CONFIG } from '../ai';
+import type { AIConfig, AIContextPreset } from '../ai';
+
+/** A boolean context toggle exposed in the Custom preset. */
+const CUSTOM_TOGGLES: { key: keyof AIConfig; label: string }[] = [
+  { key: 'includeMoveHistory', label: 'Move history' },
+  { key: 'includeGameMetrics', label: 'Game metrics' },
+  { key: 'includeStrategyGuidance', label: 'Strategy guidance' },
+  { key: 'includeHeuristicScores', label: 'Heuristic scores' },
+  { key: 'includeSeenDrawPileCards', label: 'Seen stock cards' },
+  { key: 'includeReasoningTrail', label: 'AI reasoning trail' },
+];
+
+const PRESETS: { value: AIContextPreset; label: string }[] = [
+  { value: 'minimal', label: 'Minimal' },
+  { value: 'standard', label: 'Standard' },
+  { value: 'detailed', label: 'Detailed' },
+  { value: 'custom', label: 'Custom' },
+];
+
+/**
+ * AISettingsSection — collapsible AI advisor settings, rendered inside the
+ * ControlPanel. Controls the context preset, the hidden-card fairness toggle,
+ * the per-field toggles (Custom preset), and access to the API key modal.
+ */
+const AISettingsSection: React.FC = () => {
+  const aiConfig = useGameStore((s) => s.aiConfig) ?? DEFAULT_AI_CONFIG;
+  const setAIConfig = useGameStore((s) => s.setAIConfig);
+  const setAIKeyModalOpen = useGameStore((s) => s.setAIKeyModalOpen);
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div data-testid="ai-settings-section" className="bg-indigo-50 rounded p-2">
+      <button
+        data-testid="ai-settings-toggle-btn"
+        onClick={() => setExpanded((v) => !v)}
+        className="w-full flex items-center justify-between text-xs font-semibold text-indigo-800"
+        aria-expanded={expanded}
+      >
+        <span>⚙️ AI Settings</span>
+        <span>{expanded ? '▲' : '▼'}</span>
+      </button>
+
+      {expanded && (
+        <div className="mt-2 space-y-2">
+          {/* Context preset */}
+          <div>
+            <label
+              htmlFor="ai-preset-select"
+              className="block text-[11px] font-semibold text-gray-600 mb-0.5"
+            >
+              Context detail
+            </label>
+            <select
+              id="ai-preset-select"
+              data-testid="ai-preset-select"
+              value={aiConfig.preset}
+              onChange={(e) => setAIConfig({ preset: e.target.value as AIContextPreset })}
+              className="w-full border border-gray-300 rounded px-2 py-1 text-xs bg-white"
+            >
+              {PRESETS.map((p) => (
+                <option key={p.value} value={p.value}>
+                  {p.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Hidden-card fairness toggle */}
+          <label className="flex items-center gap-2 text-[11px] text-gray-700">
+            <input
+              data-testid="ai-see-hidden-toggle"
+              type="checkbox"
+              checked={aiConfig.seeHiddenCards}
+              onChange={(e) => setAIConfig({ seeHiddenCards: e.target.checked })}
+            />
+            <span>AI sees hidden cards</span>
+          </label>
+          <p className="text-[10px] text-gray-500 -mt-1">
+            Off = fair advisor (counts only). On = solver (sees every card).
+          </p>
+
+          {/* Per-field toggles (Custom preset only) */}
+          {aiConfig.preset === 'custom' && (
+            <div className="space-y-1 border-t border-indigo-200 pt-2">
+              {CUSTOM_TOGGLES.map(({ key, label }) => (
+                <label key={key} className="flex items-center gap-2 text-[11px] text-gray-700">
+                  <input
+                    data-testid={`ai-toggle-${key}`}
+                    type="checkbox"
+                    checked={Boolean(aiConfig[key])}
+                    onChange={(e) => setAIConfig({ [key]: e.target.checked } as Partial<AIConfig>)}
+                  />
+                  <span>{label}</span>
+                </label>
+              ))}
+            </div>
+          )}
+
+          {/* Model + key */}
+          <div className="border-t border-indigo-200 pt-2">
+            <p className="text-[10px] text-gray-500 mb-1">
+              Model: <code className="text-[10px]">{aiConfig.model}</code>
+            </p>
+            <button
+              data-testid="ai-key-settings-btn"
+              onClick={() => setAIKeyModalOpen(true)}
+              className="w-full bg-indigo-200 hover:bg-indigo-300 text-indigo-900 font-semibold py-1.5 px-2 rounded text-xs"
+            >
+              🔑 API Key &amp; Model
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AISettingsSection;

--- a/packages/app/src/components/ActivityLog.tsx
+++ b/packages/app/src/components/ActivityLog.tsx
@@ -138,6 +138,7 @@ const ActivityLog: React.FC = () => {
                 {[...visibleLogs].reverse().map((move, index) => {
                   const isAutoPlayEvent = move.type.startsWith('autoplay_');
                   const isDeadendOrLoop = move.type === 'autoplay_deadend' || move.type === 'autoplay_loop_detected';
+                  const isAIMove = typeof move.aiReasoning === 'string';
                   return (
                     <div
                       key={`${move.timestamp}-${index}`}
@@ -147,10 +148,28 @@ const ActivityLog: React.FC = () => {
                           ? 'bg-red-50 border-red-300 text-red-900 font-semibold'
                           : isAutoPlayEvent
                           ? 'bg-amber-50 border-amber-300 text-amber-900 font-semibold'
+                          : isAIMove
+                          ? 'bg-indigo-50 border-indigo-300 text-indigo-900'
                           : 'bg-white border-gray-200 hover:bg-gray-100'
                       }`}
                     >
-                      {formatMove(move)}
+                      <div>
+                        {isAIMove && <span className="mr-1" aria-label="AI move">🤖</span>}
+                        {formatMove(move)}
+                      </div>
+                      {isAIMove && (
+                        <div
+                          data-testid="activity-log-ai-reasoning"
+                          className="mt-1 pl-4 text-[11px] italic text-indigo-700 whitespace-pre-wrap break-words"
+                        >
+                          {move.aiConfidence !== undefined && (
+                            <span className="not-italic font-semibold">
+                              [{Math.round(move.aiConfidence * 100)}%]{' '}
+                            </span>
+                          )}
+                          {move.aiReasoning}
+                        </div>
+                      )}
                     </div>
                   );
                 })}

--- a/packages/app/src/components/ControlPanel.tsx
+++ b/packages/app/src/components/ControlPanel.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'react';
 import { useGameStore } from '../store/gameStore';
 import type { Difficulty } from '../types';
+import AISettingsSection from './AISettingsSection';
 
 /**
  * ControlPanel component - Main game controls and settings
@@ -12,11 +13,14 @@ import type { Difficulty } from '../types';
  * - Toggle features (valid moves, god mode, auto-play)
  */
 const ControlPanel: React.FC = () => {
-  const { exportGameState, importGameState, initializeGame, toggleValidMoves, toggleGodMode, toggleAutoPlay, setDifficulty, startReplay } = useGameStore();
+  const { exportGameState, importGameState, initializeGame, toggleValidMoves, toggleGodMode, toggleAutoPlay, setDifficulty, startReplay, askAIForMove, toggleAIAutoPlay } = useGameStore();
   const showValidMoves = useGameStore((state) => state.showValidMoves);
   const godMode = useGameStore((state) => state.godMode);
   const autoPlayEnabled = useGameStore((state) => state.autoPlayEnabled);
   const replayMode = useGameStore((state) => state.replayMode);
+  const aiThinking = useGameStore((state) => state.aiThinking);
+  const aiAutoPlay = useGameStore((state) => state.aiAutoPlay);
+  const gameWon = useGameStore((state) => state.gameWon);
   const moveCount = useGameStore((state) => state.moveHistory.length);
   const difficulty = useGameStore((state) => state.difficulty);
   const perceivedDifficulty = useGameStore((state) => state.perceivedDifficulty);
@@ -230,15 +234,53 @@ const ControlPanel: React.FC = () => {
         <button
           data-testid="auto-play-btn"
           onClick={toggleAutoPlay}
-          disabled={replayMode}
+          disabled={replayMode || aiAutoPlay}
           className={`w-full font-semibold py-2 px-4 rounded transition-colors text-sm ${
             autoPlayEnabled
               ? 'bg-amber-600 hover:bg-amber-700 text-white'
               : 'bg-gray-300 hover:bg-gray-400 text-gray-700'
-          } ${replayMode ? 'opacity-50 cursor-not-allowed' : ''}`}
+          } ${replayMode || aiAutoPlay ? 'opacity-50 cursor-not-allowed' : ''}`}
         >
           {autoPlayEnabled ? '⏸️' : '▶️'} Auto Play
         </button>
+
+        <div className="border-t border-gray-300 my-2"></div>
+
+        <button
+          data-testid="ask-ai-btn"
+          onClick={() => { void askAIForMove(); }}
+          disabled={replayMode || autoPlayEnabled || gameWon || aiThinking || aiAutoPlay}
+          className={`w-full font-semibold py-2 px-4 rounded transition-colors text-sm ${
+            aiThinking && !aiAutoPlay
+              ? 'bg-indigo-400 text-white cursor-wait'
+              : 'bg-indigo-600 hover:bg-indigo-700 text-white'
+          } ${
+            replayMode || autoPlayEnabled || gameWon || aiAutoPlay
+              ? 'opacity-50 cursor-not-allowed'
+              : ''
+          }`}
+          title="Ask an LLM for the next best move"
+        >
+          {aiThinking && !aiAutoPlay ? '🤖 Thinking…' : '🤖 Ask AI'}
+        </button>
+
+        <button
+          data-testid="ai-auto-play-btn"
+          onClick={toggleAIAutoPlay}
+          disabled={replayMode || autoPlayEnabled || gameWon}
+          className={`w-full font-semibold py-2 px-4 rounded transition-colors text-sm ${
+            aiAutoPlay
+              ? 'bg-indigo-700 hover:bg-indigo-800 text-white'
+              : 'bg-gray-300 hover:bg-gray-400 text-gray-700'
+          } ${
+            replayMode || autoPlayEnabled || gameWon ? 'opacity-50 cursor-not-allowed' : ''
+          }`}
+          title="Let the AI keep playing the whole game move-by-move"
+        >
+          {aiAutoPlay ? '⏹️ Stop AI Auto' : '🤖 AI Auto-Play'}
+        </button>
+
+        <AISettingsSection />
       </div>
 
       <input

--- a/packages/app/src/components/GameBoard.tsx
+++ b/packages/app/src/components/GameBoard.tsx
@@ -6,6 +6,8 @@ import FoundationPile from './FoundationPile';
 import TableauColumn from './TableauColumn';
 import ControlPanel from './ControlPanel';
 import ActivityLog from './ActivityLog';
+import AIAdvisorPanel from './AIAdvisorPanel';
+import AIKeyModal from './AIKeyModal';
 import WinModal from './WinModal';
 import ReplayControls from './ReplayControls';
 import { shouldReduceMotion as checkReducedMotion } from '../utils/motion';
@@ -34,13 +36,15 @@ const GameBoard: React.FC = () => {
   return (
     <div data-testid="game-board" className="min-h-screen bg-gradient-to-br from-green-700 via-green-600 to-green-800">
       <WinModal />
-      
+      <AIKeyModal />
+
       {/* Desktop: side panels, Mobile: stacked layout */}
       <div className="flex flex-col lg:flex-row lg:items-start gap-4 p-2 sm:p-4 lg:p-6">
-        
-        {/* Left Panel - Activity Log (desktop: left side, mobile: top) */}
-        <div className="lg:sticky lg:top-4 lg:w-80 flex-shrink-0 order-2 lg:order-1">
+
+        {/* Left Panel - Activity Log + AI Advisor (desktop: left side, mobile: top) */}
+        <div className="lg:sticky lg:top-4 lg:w-80 flex-shrink-0 order-2 lg:order-1 flex flex-col gap-4">
           <ActivityLog />
+          <AIAdvisorPanel />
         </div>
 
         {/* Center - Game Area */}

--- a/packages/app/src/store/aiAdvisor.test.ts
+++ b/packages/app/src/store/aiAdvisor.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Integration tests for the AI Move Advisor store actions, driven through a
+ * deterministic stub provider (no network, no API key).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { useGameStore } from './gameStore';
+import { createStubProvider, setProviderOverride } from '../ai';
+import type { AIMoveDecision } from '../ai';
+
+/** Install a stub provider that returns `decision`. */
+function useStub(decision: AIMoveDecision | (() => never)): void {
+  if (typeof decision === 'function') {
+    setProviderOverride(createStubProvider(decision));
+  } else {
+    setProviderOverride(createStubProvider(() => decision));
+  }
+}
+
+describe('AI Move Advisor store actions', () => {
+  beforeEach(() => {
+    // Deterministic, reproducible deal.
+    useGameStore.getState().initializeGame(3, 42);
+  });
+
+  afterEach(() => {
+    setProviderOverride(null);
+  });
+
+  it('applies the AI-chosen move and records the decision', async () => {
+    useStub({ moveIndex: 0, reasoning: 'Open the game by drawing.', confidence: 0.8 });
+
+    const before = useGameStore.getState().moveHistory.length;
+    await useGameStore.getState().askAIForMove();
+    const state = useGameStore.getState();
+
+    expect(state.moveHistory.length).toBeGreaterThan(before);
+    expect(state.aiThinking).toBe(false);
+    expect(state.aiError).toBeUndefined();
+    expect(state.aiDecisionLog).toHaveLength(1);
+    expect(state.aiDecisionLog?.[0].reasoning).toBe('Open the game by drawing.');
+    expect(state.aiDecisionLog?.[0].confidence).toBeCloseTo(0.8);
+  });
+
+  it('annotates the resulting move-history entry with the reasoning', async () => {
+    useStub({ moveIndex: 0, reasoning: 'Strategic draw.', confidence: 0.7 });
+
+    const before = useGameStore.getState().moveHistory.length;
+    await useGameStore.getState().askAIForMove();
+
+    const newEntry = useGameStore.getState().moveHistory[before];
+    expect(newEntry.aiReasoning).toBe('Strategic draw.');
+    expect(newEntry.aiConfidence).toBeCloseTo(0.7);
+  });
+
+  it('records an error and applies no move when the provider fails', async () => {
+    useStub(() => {
+      throw new Error('model exploded');
+    });
+
+    const before = useGameStore.getState().moveHistory.length;
+    await useGameStore.getState().askAIForMove();
+    const state = useGameStore.getState();
+
+    expect(state.aiError).toContain('model exploded');
+    expect(state.aiThinking).toBe(false);
+    expect(state.moveHistory.length).toBe(before);
+    expect(state.aiDecisionLog ?? []).toHaveLength(0);
+  });
+
+  it('rejects an out-of-range move index without touching the board', async () => {
+    useStub({ moveIndex: 999, reasoning: 'invalid', confidence: 1 });
+
+    const before = useGameStore.getState().moveHistory.length;
+    await useGameStore.getState().askAIForMove();
+    const state = useGameStore.getState();
+
+    expect(state.aiError).toBeTruthy();
+    expect(state.moveHistory.length).toBe(before);
+  });
+
+  it('clears the thinking flag after completing', async () => {
+    useStub({ moveIndex: 0, reasoning: 'go', confidence: 0.5 });
+    await useGameStore.getState().askAIForMove();
+    expect(useGameStore.getState().aiThinking).toBe(false);
+    expect(useGameStore.getState().aiThinkingSince).toBeUndefined();
+  });
+
+  it('clearAIError clears the last error', async () => {
+    useStub(() => {
+      throw new Error('boom');
+    });
+    await useGameStore.getState().askAIForMove();
+    expect(useGameStore.getState().aiError).toBeTruthy();
+
+    useGameStore.getState().clearAIError();
+    expect(useGameStore.getState().aiError).toBeUndefined();
+  });
+});
+
+describe('AI auto-play', () => {
+  beforeEach(() => {
+    useGameStore.getState().initializeGame(3, 42);
+  });
+
+  afterEach(() => {
+    setProviderOverride(null);
+    // Ensure no auto-play loop leaks into the next test.
+    if (useGameStore.getState().aiAutoPlay) {
+      useGameStore.getState().toggleAIAutoPlay();
+    }
+  });
+
+  it('engages and disengages auto-play', () => {
+    useStub({ moveIndex: 0, reasoning: 'go', confidence: 0.5 });
+
+    useGameStore.getState().toggleAIAutoPlay();
+    expect(useGameStore.getState().aiAutoPlay).toBe(true);
+
+    useGameStore.getState().toggleAIAutoPlay();
+    expect(useGameStore.getState().aiAutoPlay).toBe(false);
+  });
+
+  it('refuses to start once the game is won', () => {
+    useGameStore.setState({ gameWon: true });
+    useGameStore.getState().toggleAIAutoPlay();
+    expect(useGameStore.getState().aiAutoPlay).toBeFalsy();
+    expect(useGameStore.getState().aiError).toBeTruthy();
+  });
+
+  it('stops and flags a loop when the board position repeats', () => {
+    useGameStore.setState({ aiAutoPlay: true, aiError: undefined });
+    const store = useGameStore.getState();
+
+    // First call records the position; a second call on the same position
+    // detects the repeat. (If the hash was already seen, the first call
+    // detects it — either way auto-play halts with a loop error.)
+    store.continueAIAutoPlay();
+    if (useGameStore.getState().aiAutoPlay) {
+      store.continueAIAutoPlay();
+    }
+
+    expect(useGameStore.getState().aiAutoPlay).toBe(false);
+    expect(useGameStore.getState().aiError).toMatch(/loop/i);
+  });
+
+  it('stops auto-play when a provider error occurs', async () => {
+    useStub(() => {
+      throw new Error('provider down');
+    });
+    useGameStore.setState({ aiAutoPlay: true });
+    await useGameStore.getState().askAIForMove();
+
+    expect(useGameStore.getState().aiAutoPlay).toBe(false);
+    expect(useGameStore.getState().aiError).toContain('provider down');
+  });
+});
+
+describe('setAIConfig', () => {
+  beforeEach(() => {
+    useGameStore.getState().initializeGame(3, 42);
+  });
+
+  it('applies a named preset bundle', () => {
+    useGameStore.getState().setAIConfig({ preset: 'minimal' });
+    const config = useGameStore.getState().aiConfig!;
+    expect(config.preset).toBe('minimal');
+    expect(config.includeMoveHistory).toBe(false);
+    expect(config.includeGameMetrics).toBe(false);
+  });
+
+  it('switches to the custom preset when a toggle is changed directly', () => {
+    useGameStore.getState().setAIConfig({ preset: 'standard' });
+    useGameStore.getState().setAIConfig({ includeHeuristicScores: true });
+    const config = useGameStore.getState().aiConfig!;
+    expect(config.preset).toBe('custom');
+    expect(config.includeHeuristicScores).toBe(true);
+  });
+
+  it('keeps provider, model and seeHiddenCards when applying a preset', () => {
+    useGameStore.getState().setAIConfig({ model: 'gemini-2.5-flash', seeHiddenCards: true });
+    useGameStore.getState().setAIConfig({ preset: 'detailed' });
+    const config = useGameStore.getState().aiConfig!;
+    expect(config.model).toBe('gemini-2.5-flash');
+    expect(config.seeHiddenCards).toBe(true);
+  });
+
+  it('preserves the AI config across a new game', () => {
+    useGameStore.getState().setAIConfig({ model: 'gemini-2.5-pro' });
+    useGameStore.getState().initializeGame(2);
+    expect(useGameStore.getState().aiConfig?.model).toBe('gemini-2.5-pro');
+  });
+});

--- a/packages/app/src/store/gameStore.ts
+++ b/packages/app/src/store/gameStore.ts
@@ -9,7 +9,9 @@ import {
   getPerceivedDifficulty,
   getCompletionProgress,
   getValidTableauDestinations,
+  GameEngine,
 } from '@chayuto/solitaire-core';
+import type { MoveCommand } from '@chayuto/solitaire-core';
 import {
   hasAnyValidDestination as hasAnyValidDestinationHelper,
   hasAnyValidMoves,
@@ -20,6 +22,47 @@ import { uiToCore } from '../adapters/coreAdapter';
 import { initialGameConfig } from './urlConfig';
 import { DEFAULT_DIFFICULTY, TABLEAU_COLUMNS, AUTOPLAY_TIMING, AUTOPLAY_LOOP_DETECTION } from '../constants';
 import { collectPossibleMoves, scoreMoves, filterLoopingMoves } from '../autoplay';
+import {
+  AIError,
+  AI_DECISION_LOG_LIMIT,
+  AI_AUTO_MOVE_DELAY,
+  AI_AUTO_HISTORY_LIMIT,
+  DEFAULT_AI_CONFIG,
+  applyPreset,
+  buildContext,
+  buildSystemInstruction,
+  describeMoveCommand,
+  getEffectiveKey,
+  getProvider,
+} from '../ai';
+import type { AIConfig, AIDecisionRecord } from '../ai';
+
+/** Shared core engine instance — used for legal-move generation by the AI advisor. */
+const engine = new GameEngine();
+
+/**
+ * Abort controller for the in-flight AI request, kept at module scope because
+ * an `AbortController` is not serializable into Zustand state.
+ */
+let aiAbortController: AbortController | null = null;
+
+/**
+ * Board-state hashes seen during the current AI auto-play run, for loop
+ * detection. Reset each time AI auto-play is engaged.
+ */
+let aiAutoStateHistory: string[] = [];
+
+/** Keys in {@link AIConfig} that a context preset controls. */
+const AI_TOGGLE_KEYS: readonly (keyof AIConfig)[] = [
+  'includeMoveHistory',
+  'moveHistoryLimit',
+  'includeGameMetrics',
+  'includeStrategyGuidance',
+  'includeHeuristicScores',
+  'includeSeenDrawPileCards',
+  'includeReasoningTrail',
+  'reasoningTrailLimit',
+];
 
 /**
  * GameStore interface extending GameState with action methods
@@ -53,6 +96,24 @@ interface GameStore extends GameState {
   stepBackward: () => void;
   setReplaySpeed: (speed: number) => void;
   goToReplayIndex: (index: number) => void;
+  // --- AI Move Advisor ---
+  /** Apply a core {@link MoveCommand} through the normal move pathway. */
+  applyMoveCommand: (command: MoveCommand) => void;
+  /** Ask the configured LLM for the next best move and apply it. */
+  askAIForMove: () => Promise<void>;
+  /** Toggle AI auto-play: the LLM keeps playing move-by-move until the game
+   *  ends, a loop is detected, an error occurs, or the user stops it. */
+  toggleAIAutoPlay: () => void;
+  /** Internal: schedule the next AI auto-play move (with loop detection). */
+  continueAIAutoPlay: () => void;
+  /** Cancel an in-flight AI request. */
+  cancelAIRequest: () => void;
+  /** Update the AI advisor configuration (partial patch). */
+  setAIConfig: (patch: Partial<AIConfig>) => void;
+  /** Clear the last AI advisor error message. */
+  clearAIError: () => void;
+  /** Open or close the API key modal. */
+  setAIKeyModalOpen: (open: boolean) => void;
 }
 
 /**
@@ -125,6 +186,13 @@ const initializeGameState = (
     replayIndex: 0,
     replayPaused: false,
     replaySpeed: 1000, // 1 second per move
+    aiConfig: DEFAULT_AI_CONFIG,
+    aiThinking: false,
+    aiAutoPlay: false,
+    aiThinkingSince: undefined,
+    aiError: undefined,
+    aiDecisionLog: [],
+    aiKeyModalOpen: false,
   };
 
   // Calculate perceived difficulty after initialState is created
@@ -139,7 +207,12 @@ export const useGameStore = create<GameStore>((set, get) => ({
   ...initializeGameState(initialGameConfig.difficulty, initialGameConfig.seed),
   initializeGame: (difficulty?: Difficulty, seed?: number) => {
     const currentDifficulty = difficulty ?? get().difficulty ?? 3;
-    set(initializeGameState(currentDifficulty, seed));
+    // A new game invalidates any in-flight AI request.
+    aiAbortController?.abort();
+    aiAbortController = null;
+    // The AI config is a session-level preference — preserve it across games.
+    const preservedConfig = get().aiConfig ?? DEFAULT_AI_CONFIG;
+    set({ ...initializeGameState(currentDifficulty, seed), aiConfig: preservedConfig });
   },
   setDifficulty: (difficulty: Difficulty) => set({ difficulty }),
   
@@ -982,5 +1055,263 @@ export const useGameStore = create<GameStore>((set, get) => ({
       ...newState,
       completionProgress,
     });
+  },
+
+  // -------------------------------------------------------------------------
+  // AI Move Advisor
+  // -------------------------------------------------------------------------
+
+  applyMoveCommand: (command: MoveCommand) => {
+    // Translates a core MoveCommand into the store's existing move actions, so
+    // an AI-chosen move is recorded, flips cards, updates progress and triggers
+    // auto-complete exactly like a human move.
+    switch (command.type) {
+      case 'draw_card':
+      case 'recycle_stock':
+        // The store's drawCard recycles the waste when the stock is empty.
+        get().drawCard();
+        break;
+      case 'tableau_to_tableau':
+        if (command.from?.column === undefined || command.to?.column === undefined) return;
+        get().selectCard('tableau', command.from.column, command.from.cardIndex);
+        get().moveCardToTableau(command.to.column);
+        break;
+      case 'tableau_to_foundation':
+        if (command.from?.column === undefined || !command.to?.suit) return;
+        get().selectCard('tableau', command.from.column, command.from.cardIndex);
+        get().moveCardToFoundation(command.to.suit);
+        break;
+      case 'discard_to_tableau':
+        if (command.to?.column === undefined) return;
+        get().selectCard('discard');
+        get().moveCardToTableau(command.to.column);
+        break;
+      case 'discard_to_foundation':
+        if (!command.to?.suit) return;
+        get().selectCard('discard');
+        get().moveCardToFoundation(command.to.suit);
+        break;
+      case 'flip_card':
+        // Flips are produced automatically by other moves; nothing to do.
+        break;
+    }
+  },
+
+  askAIForMove: async () => {
+    const state = get();
+
+    // --- Guards ---
+    if (state.aiThinking) {
+      return; // a request is already in flight
+    }
+    if (state.gameWon) {
+      set({ aiError: 'The game is already won.', aiAutoPlay: false });
+      return;
+    }
+    if (state.replayMode) {
+      set({ aiError: 'Cannot ask the AI while in replay mode.', aiAutoPlay: false });
+      return;
+    }
+    if (state.autoPlayEnabled) {
+      set({ aiError: 'Cannot ask the AI while auto-play is running.', aiAutoPlay: false });
+      return;
+    }
+
+    const config = state.aiConfig ?? DEFAULT_AI_CONFIG;
+
+    // Resolve the provider.
+    let provider;
+    try {
+      provider = getProvider(config.provider);
+    } catch (err) {
+      set({
+        aiError: err instanceof AIError ? err.message : 'AI provider configuration error.',
+        aiAutoPlay: false,
+      });
+      return;
+    }
+
+    // Resolve the API key. No key => prompt for one instead of erroring.
+    const apiKey = provider.requiresKey ? getEffectiveKey(config.provider) : '';
+    if (provider.requiresKey && !apiKey) {
+      set({ aiError: undefined, aiKeyModalOpen: true, aiAutoPlay: false });
+      return;
+    }
+
+    // Generate the legal moves the AI must choose from.
+    const coreState = uiToCore(state);
+    const legalMoves = engine.getLegalMoves(coreState);
+    if (legalMoves.length === 0) {
+      set({
+        aiError: 'No legal moves are available — try drawing or starting a new game.',
+        aiAutoPlay: false,
+      });
+      return;
+    }
+
+    const context = buildContext(state, legalMoves, config, state.aiDecisionLog ?? []);
+    const systemInstruction = buildSystemInstruction(config);
+
+    // --- Begin the request ---
+    aiAbortController = new AbortController();
+    set({ aiThinking: true, aiThinkingSince: Date.now(), aiError: undefined });
+
+    try {
+      const decision = await provider.suggestMove({
+        apiKey: apiKey ?? '',
+        model: config.model,
+        systemInstruction,
+        context,
+        signal: aiAbortController.signal,
+      });
+
+      // Defensive: the provider already range-checked moveIndex, but never
+      // index a move list with an unverified value.
+      if (decision.moveIndex < 0 || decision.moveIndex >= legalMoves.length) {
+        throw new AIError('bad_response', 'AI chose a move outside the legal set.');
+      }
+      const command = legalMoves[decision.moveIndex];
+
+      // Re-validate against the *current* state before applying. The board is
+      // locked while aiThinking, so this should always pass.
+      if (!engine.canApplyMove(uiToCore(get()), command)) {
+        throw new AIError('bad_response', 'The chosen move is no longer valid.');
+      }
+
+      // Apply the move, then annotate the new move-history entry with the
+      // AI's reasoning so the Activity Log can surface it.
+      const beforeLen = get().moveHistory.length;
+      get().applyMoveCommand(command);
+      const afterMoves = get().moveHistory;
+      if (afterMoves.length > beforeLen) {
+        const annotated = [...afterMoves];
+        annotated[beforeLen] = {
+          ...annotated[beforeLen],
+          aiReasoning: decision.reasoning,
+          aiConfidence: decision.confidence,
+        };
+        set({ moveHistory: annotated });
+      }
+
+      // Record the decision (drives the advisor panel + the reasoning trail).
+      const record: AIDecisionRecord = {
+        timestamp: Date.now(),
+        moveType: command.type,
+        describe: describeMoveCommand(command, state),
+        reasoning: decision.reasoning,
+        confidence: decision.confidence,
+        alternativeDescribe:
+          decision.alternativeMoveIndex !== undefined
+            ? describeMoveCommand(legalMoves[decision.alternativeMoveIndex], state)
+            : undefined,
+        model: config.model,
+      };
+      const aiDecisionLog = [...(get().aiDecisionLog ?? []), record].slice(
+        -AI_DECISION_LOG_LIMIT,
+      );
+      set({ aiThinking: false, aiThinkingSince: undefined, aiDecisionLog, aiError: undefined });
+
+      // If AI auto-play is engaged, queue the next move.
+      if (get().aiAutoPlay) {
+        get().continueAIAutoPlay();
+      }
+    } catch (err) {
+      // A user-initiated cancel is not an error worth surfacing.
+      if (err instanceof AIError && err.kind === 'aborted') {
+        set({ aiThinking: false, aiThinkingSince: undefined, aiError: undefined });
+        return;
+      }
+      const message =
+        err instanceof AIError
+          ? err.message
+          : err instanceof Error
+            ? err.message
+            : 'Unexpected AI error.';
+      // Any error stops AI auto-play — never hammer the API on failure.
+      set({ aiThinking: false, aiThinkingSince: undefined, aiError: message, aiAutoPlay: false });
+    } finally {
+      aiAbortController = null;
+    }
+  },
+
+  toggleAIAutoPlay: () => {
+    const state = get();
+    if (state.aiAutoPlay) {
+      // Stop: abort any in-flight request so it halts immediately.
+      aiAbortController?.abort();
+      set({ aiAutoPlay: false });
+      return;
+    }
+    // Start.
+    if (state.gameWon) {
+      set({ aiError: 'The game is already won.' });
+      return;
+    }
+    if (state.replayMode || state.autoPlayEnabled) {
+      set({ aiError: 'Stop replay / auto-play before starting AI auto-play.' });
+      return;
+    }
+    aiAutoStateHistory = [];
+    set({ aiAutoPlay: true, aiError: undefined });
+    void get().askAIForMove();
+  },
+
+  continueAIAutoPlay: () => {
+    const state = get();
+    if (!state.aiAutoPlay) return;
+
+    // Stop cleanly when the game is won.
+    if (state.gameWon) {
+      set({ aiAutoPlay: false });
+      return;
+    }
+
+    // Loop detection: if the board returns to a previously seen position the
+    // AI is cycling — stop rather than burn API calls forever.
+    const hash = hashGameState(uiToCore(state));
+    if (aiAutoStateHistory.includes(hash)) {
+      set({
+        aiAutoPlay: false,
+        aiError: 'AI auto-play stopped: the board returned to an earlier position (loop).',
+      });
+      return;
+    }
+    aiAutoStateHistory = [...aiAutoStateHistory, hash].slice(-AI_AUTO_HISTORY_LIMIT);
+
+    setTimeout(() => {
+      if (get().aiAutoPlay && !get().aiThinking) {
+        void get().askAIForMove();
+      }
+    }, AI_AUTO_MOVE_DELAY);
+  },
+
+  cancelAIRequest: () => {
+    aiAbortController?.abort();
+    // Clear the thinking state immediately for responsive UI; the in-flight
+    // promise's catch handler will also run and is a no-op for 'aborted'.
+    set({ aiThinking: false, aiThinkingSince: undefined });
+  },
+
+  setAIConfig: (patch: Partial<AIConfig>) => {
+    const current = get().aiConfig ?? DEFAULT_AI_CONFIG;
+    let next: AIConfig = { ...current, ...patch };
+
+    if (patch.preset !== undefined && patch.preset !== 'custom') {
+      // Switching to a named preset applies its whole toggle bundle.
+      next = applyPreset(next, patch.preset);
+    } else if (patch.preset === undefined && AI_TOGGLE_KEYS.some((k) => k in patch)) {
+      // Changing an individual toggle moves the config into 'custom' mode.
+      next.preset = 'custom';
+    }
+
+    set({ aiConfig: next });
+  },
+
+  clearAIError: () => {
+    set({ aiError: undefined });
+  },
+
+  setAIKeyModalOpen: (open: boolean) => {
+    set({ aiKeyModalOpen: open });
   },
 }));

--- a/packages/app/src/testBridge.ts
+++ b/packages/app/src/testBridge.ts
@@ -20,6 +20,8 @@
 
 import { useGameStore } from './store/gameStore';
 import { scenarios, scenarioNames, isScenarioName } from './testScenarios';
+import { createStubProvider, DEFAULT_AI_CONFIG, setProviderOverride } from './ai';
+import type { AIConfig, StubDecisionFn } from './ai';
 import type { Card, Difficulty, GameState, Suit } from './types';
 
 /** Compact, token-efficient game snapshot for agents. */
@@ -50,6 +52,26 @@ export interface GameSummary {
 export interface NewGameOptions {
   seed?: number;
   difficulty?: Difficulty;
+}
+
+/** Compact AI-advisor state snapshot for agents/tests. */
+export interface AIBridgeState {
+  /** Whether a suggestion request is currently in flight. */
+  thinking: boolean;
+  /** Whether the AI is auto-playing the whole game. */
+  autoPlay: boolean;
+  /** Last error message, or `null`. */
+  error: string | null;
+  /** Configured model id. */
+  model: string;
+  /** Active context preset. */
+  preset: string;
+  /** Whether the AI is allowed to see hidden cards. */
+  seeHiddenCards: boolean;
+  /** Number of decisions recorded so far. */
+  decisionCount: number;
+  /** The most recent decision, or `null`. */
+  lastDecision: { describe: string; reasoning: string; confidence: number } | null;
 }
 
 /** The `window.__solitaire` control surface. */
@@ -102,6 +124,27 @@ export interface SolitaireTestBridge {
    * the `testScenarios` module. Returns `false` for an unknown name.
    */
   loadScenario: (name: string) => boolean;
+
+  // --- AI Move Advisor ---
+  /** Compact AI-advisor state snapshot. */
+  getAIState: () => AIBridgeState;
+  /**
+   * Ask the AI advisor for a move. Resolves once the move is applied or the
+   * request fails (inspect `getAIState().error`).
+   */
+  askAI: () => Promise<void>;
+  /** Toggle AI auto-play (the AI keeps playing the whole game move-by-move). */
+  toggleAIAutoPlay: () => void;
+  /** Cancel an in-flight AI request. */
+  cancelAI: () => void;
+  /** Patch the AI advisor configuration (provider, model, preset, toggles). */
+  setAIConfig: (patch: Partial<AIConfig>) => void;
+  /**
+   * Install a deterministic AI provider stub — no network, no API key — for
+   * tests, or pass `null` to restore the real provider. The stub function
+   * receives the built context and returns the decision to apply.
+   */
+  setAIProviderStub: (decide: StubDecisionFn | null) => void;
 }
 
 declare global {
@@ -179,7 +222,7 @@ export function installTestBridge(): void {
   }
 
   const bridge: SolitaireTestBridge = {
-    version: 2,
+    version: 3,
     getState: () => useGameStore.getState(),
     getSummary: () => buildSummary(useGameStore.getState()),
     newGame: (options) =>
@@ -199,6 +242,31 @@ export function installTestBridge(): void {
     loadScenario: (name) =>
       isScenarioName(name) &&
       useGameStore.getState().importGameState(JSON.stringify(scenarios[name]())),
+
+    getAIState: () => {
+      const state = useGameStore.getState();
+      const config = state.aiConfig ?? DEFAULT_AI_CONFIG;
+      const log = state.aiDecisionLog ?? [];
+      const last = log[log.length - 1];
+      return {
+        thinking: state.aiThinking ?? false,
+        autoPlay: state.aiAutoPlay ?? false,
+        error: state.aiError ?? null,
+        model: config.model,
+        preset: config.preset,
+        seeHiddenCards: config.seeHiddenCards,
+        decisionCount: log.length,
+        lastDecision: last
+          ? { describe: last.describe, reasoning: last.reasoning, confidence: last.confidence }
+          : null,
+      };
+    },
+    askAI: () => useGameStore.getState().askAIForMove(),
+    toggleAIAutoPlay: () => useGameStore.getState().toggleAIAutoPlay(),
+    cancelAI: () => useGameStore.getState().cancelAIRequest(),
+    setAIConfig: (patch) => useGameStore.getState().setAIConfig(patch),
+    setAIProviderStub: (decide) =>
+      setProviderOverride(decide ? createStubProvider(decide) : null),
   };
 
   window.__solitaire = bridge;

--- a/packages/app/src/types/index.ts
+++ b/packages/app/src/types/index.ts
@@ -1,3 +1,5 @@
+import type { AIConfig, AIDecisionRecord } from '../ai/types';
+
 export type Suit = 'hearts' | 'diamonds' | 'clubs' | 'spades';
 
 export type Rank = 'A' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | 'J' | 'Q' | 'K';
@@ -37,6 +39,10 @@ export interface Move {
     columnIndex?: number;
     suit?: Suit;
   };
+  /** Reasoning text, set when this move was chosen by the AI Move Advisor. */
+  aiReasoning?: string;
+  /** AI self-rated confidence (0-1), set when this move was AI-chosen. */
+  aiConfidence?: number;
 }
 
 export interface GameState {
@@ -80,4 +86,15 @@ export interface GameState {
   replayIndex: number; // Current index in move history during replay
   replayPaused: boolean; // True when replay is paused
   replaySpeed: number; // Speed of replay in ms per move (default 1000)
+
+  // --- AI Move Advisor ---
+  // Optional, like the other supplemental UI fields above: the store always
+  // populates them, but lightweight GameState fixtures need not.
+  aiConfig?: AIConfig; // User-configurable AI advisor settings (persists across new games)
+  aiThinking?: boolean; // True while an AI move suggestion is in flight
+  aiAutoPlay?: boolean; // True while the AI is auto-playing the whole game move-by-move
+  aiThinkingSince?: number; // Timestamp the in-flight request started (for the elapsed counter)
+  aiError?: string; // Last AI advisor error message, shown until the next request
+  aiDecisionLog?: AIDecisionRecord[]; // History of AI decisions (most recent last)
+  aiKeyModalOpen?: boolean; // True when the API key modal is open
 }

--- a/packages/app/src/vite-env.d.ts
+++ b/packages/app/src/vite-env.d.ts
@@ -2,3 +2,8 @@
 
 declare const __BUILD_TIME__: string
 declare const __COMMIT_HASH__: string
+/**
+ * Dev-only Gemini API key, injected from the repo-root `.env` by Vite.
+ * Empty string in production builds. See `vite.config.ts`.
+ */
+declare const __DEV_GEMINI_KEY__: string

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vitest/config'
+import { loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import { execSync } from 'child_process'
+import { resolve } from 'path'
 
 // Get build info
 const getBuildInfo = () => {
@@ -14,18 +16,31 @@ const getBuildInfo = () => {
 }
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react()],
-  base: '/',
-  define: {
-    __BUILD_TIME__: JSON.stringify(getBuildInfo().buildTime),
-    __COMMIT_HASH__: JSON.stringify(getBuildInfo().commitHash),
-  },
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    setupFiles: './src/test/setup.ts',
-    css: true,
-    exclude: ['e2e/**', 'node_modules/**'],
-  },
+export default defineConfig(({ mode }) => {
+  // Load env vars from the repo root (.env is two levels up from packages/app).
+  // The empty prefix loads ALL vars, including the non-VITE_-prefixed GEMINI_API_KEY.
+  const rootEnv = loadEnv(mode, resolve(__dirname, '../..'), '')
+
+  // Dev-only convenience: in `pnpm dev` the AI Move Advisor is pre-filled with
+  // this local key, so a developer needn't paste one. It is injected ONLY in
+  // development — a production build always receives an empty string, so the
+  // key is never embedded in shipped code and prod users must paste their own.
+  const devGeminiKey = mode === 'development' ? (rootEnv.GEMINI_API_KEY ?? '') : ''
+
+  return {
+    plugins: [react()],
+    base: '/',
+    define: {
+      __BUILD_TIME__: JSON.stringify(getBuildInfo().buildTime),
+      __COMMIT_HASH__: JSON.stringify(getBuildInfo().commitHash),
+      __DEV_GEMINI_KEY__: JSON.stringify(devGeminiKey),
+    },
+    test: {
+      globals: true,
+      environment: 'jsdom',
+      setupFiles: './src/test/setup.ts',
+      css: true,
+      exclude: ['e2e/**', 'node_modules/**'],
+    },
+  }
 })


### PR DESCRIPTION
## Summary

Adds an **AI Move Advisor**: a player can ask an LLM (Google Gemini / Gemma) for the next best move, plus an **AI Auto-Play** mode where the LLM plays the whole game move-by-move.

## How it works

- New provider-abstracted AI module (`packages/app/src/ai`): Gemini/Gemma via the REST API, a context builder with configurable verbosity presets (Minimal / Standard / Detailed / Custom), decision-schema validation, and session-scoped API key storage.
- The LLM is given a structured game snapshot plus a **numbered list of legal moves** and must return its choice as an **index into that list** — it is structurally impossible for it to pick an illegal move. The decision is re-validated against current state before being applied.
- AI moves apply automatically; every AI action and its reasoning are logged — `moveHistory` reasoning annotation, the AI Advisor panel, and the Activity Log (🤖 badge + confidence + reasoning).
- AI Auto-Play loops move-by-move with hash-based loop detection; it stops on a win, an error, a repeated board position, or a user request.

## UX

- `Ask AI` and `AI Auto-Play` buttons in the control panel.
- AI Advisor panel with a live elapsed-time counter and Cancel/Stop (the default model is a thinking model and can take a couple of minutes).
- API key modal — the key is stored in `sessionStorage` only, sent only to the provider, never persisted or exported.
- Context-settings section: preset selector, hidden-card fairness toggle, per-field toggles.

## Key handling

- The key is supplied by the user at play time via the modal.
- For local development only, `pnpm dev` pre-fills from a repo-root `.env` `GEMINI_API_KEY` (injected dev-mode only — production builds always get an empty string; verified absent from the bundle). `.env` is git-ignored; `.env.example` documents it.

## Tests

- 80 unit tests (key store, JSON extraction, decision validation, context builder, move descriptions, the Gemini provider against a mocked `fetch`, and store integration via a deterministic stub provider).
- 7 E2E specs covering the advisor, error handling, the key modal, settings, and auto-play.
- Test bridge gains `askAI`, `toggleAIAutoPlay`, `getAIState`, `setAIConfig`, `setAIProviderStub` (deterministic, network-free E2E).
- Lint, typecheck, full unit suite, E2E, and production build all pass locally; the provider was also verified against the live model end-to-end.

## Test plan

- [ ] CI green (lint, test, build, e2e)
- [ ] Manual: `pnpm dev`, click `Ask AI` and `AI Auto-Play`