### PR TITLE
docs: rewrite README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,228 +1,85 @@
-# Solitaire Card Game
+# Solitaire
 
-A modern, interactive Solitaire (Klondike) card game built with React and TypeScript. Organized as a monorepo with reusable game logic libraries.
+Klondike Solitaire built with React and TypeScript. The repository is a pnpm
+monorepo: the game logic lives in standalone libraries and the web app
+consumes them.
 
-## 🎮 Features
+Live: https://chayuto.github.io/Solitaire/
 
-- Classic Klondike Solitaire gameplay
-- Smooth drag-and-drop card interactions
-- Save/Load game state functionality
-- Export game history and board setup
-- Responsive green felt-style game board
-- Built with modern React 19
-- Modular architecture with reusable game logic libraries
+## Features
 
-## 🛠️ Tech Stack
+- Classic Klondike Solitaire with click-to-move and drag-and-drop
+- Five difficulty levels and deterministic seeded deals
+- Move history, replay, save and load, and game state export
+- Heuristic auto-play and end-game auto-complete
+- AI Move Advisor: ask an LLM for the next best move, or let it auto-play the
+  whole game
 
-- **Frontend Framework**: React 19.2.0
-- **Language**: TypeScript 5.9
-- **Build Tool**: Vite 7.2
-- **State Management**: Zustand 5.0
-- **Styling**: Tailwind CSS 4.1
-- **Drag & Drop**: @dnd-kit/core 6.3
-- **Animations**: Framer Motion 12.23
-- **Testing**: Vitest 4.0 with React Testing Library
-- **Code Quality**: ESLint with TypeScript support
-- **Monorepo**: pnpm workspaces with 3 packages
+## Monorepo layout
 
-## 📦 Installation
+| Package | Description |
+| --- | --- |
+| `packages/core` | `@chayuto/solitaire-core`: framework-agnostic game engine, rules, and scoring. No runtime dependencies. |
+| `packages/mcts` | `@chayuto/solitaire-mcts`: Monte Carlo Tree Search solver. Depends on core. |
+| `packages/app` | React application that consumes both libraries. |
+
+## Requirements
+
+- Node 24 or newer
+- pnpm 11 or newer
+
+## Getting started
 
 ```bash
-# Install all workspace dependencies
 pnpm install
-
-# Build core library (required for first run)
-pnpm run build:libs
+pnpm run build:libs   # build core and mcts (required before the first app run)
+pnpm run dev          # start the app on http://localhost:5173
 ```
 
-## 🚀 Development
+## Scripts
 
-```bash
-# Start development server
-pnpm run dev
+| Command | Purpose |
+| --- | --- |
+| `pnpm run dev` | Start the app dev server |
+| `pnpm run build` | Production build of the app |
+| `pnpm run build:libs` | Build the core and mcts libraries |
+| `pnpm run lint` | Run ESLint |
+| `pnpm run test:run` | Run app unit tests once (Vitest) |
+| `pnpm run test:libs` | Run library unit tests |
+| `pnpm run test:e2e` | Run end-to-end tests (Playwright) |
+| `pnpm run typecheck` | Type-check every package |
 
-# Build all packages
-pnpm run build:all
+## AI Move Advisor
 
-# Build libraries only
-pnpm run build:libs
+The app can ask an LLM for the next best move. It sends the visible board and a
+list of legal moves; the model returns a chosen move and a reason, which is
+applied and recorded in the activity log. AI Auto-Play runs the model move by
+move until the game ends or a repeated position is detected.
 
-# Build app for production
-pnpm run build
+- Provide your own API key in the in-app key dialog. It is stored in
+  `sessionStorage` for the browser tab session only and is sent only to the
+  provider.
+- For local development, a `GEMINI_API_KEY` in a repo-root `.env` file is used
+  automatically (see `.env.example`). It is never included in a production
+  build.
+- The default provider is Google Gemini and the default model is
+  `gemma-4-31b-it`. Other Gemini and Gemma models can be selected.
 
-# Preview production build
-pnpm run preview
+## Testing
 
-# Run tests for all packages
-pnpm run test:libs
+Unit tests run with Vitest and end-to-end tests with Playwright. The app is
+instrumented for deterministic UI testing:
 
-# Type check all packages
-pnpm run typecheck
-```
+- Seeded deals via the `?seed=N` query parameter, with optional
+  `&difficulty=1..5`, reproduce an identical game every run.
+- A typed `window.__solitaire` bridge introspects and drives the game without
+  simulating pointer input.
+- Every card, pile, and control carries a `data-testid`.
 
-## 🌐 Deployment
+## Deployment
 
-The app is automatically deployed to GitHub Pages on every push to the `main` branch.
+Pushes to `main` are built and deployed to GitHub Pages by the deploy workflow.
 
-**Live URL**: <https://chayuto.github.io/Solitaire/>
+## License
 
-**Cost**: FREE - GitHub Pages is completely free for public repositories with unlimited bandwidth.
-
-The deployment workflow:
-
-1. Runs linting, tests, and builds the app
-2. Only deploys if all checks pass
-3. Updates the live site within 1-2 minutes
-
-To enable GitHub Pages after pushing:
-
-1. Go to your repository settings → Pages
-2. Set Source to "GitHub Actions"
-3. The site will deploy automatically on the next push to main
-
-## 🧪 Testing
-
-### Unit tests (Vitest)
-
-```bash
-# Run tests in watch mode
-pnpm test
-
-# Run tests once
-pnpm run test:run
-
-# Run tests with UI
-pnpm run test:ui
-
-# Generate coverage report
-pnpm run test:coverage
-```
-
-### End-to-end tests (Playwright)
-
-```bash
-# Run the full e2e suite (starts the dev server automatically)
-pnpm run test:e2e
-
-# Interactive UI mode
-pnpm --filter app test:e2e:ui
-```
-
-The app is instrumented for **high-fidelity, deterministic UI testing**:
-
-- **Seeded deals** — `?seed=42` (optionally `&difficulty=1..5`) reproduces an
-  identical game every run.
-- **`window.__solitaire` test bridge** — a typed API to introspect and drive the
-  game from automation without simulating pointer input.
-- **Stable selectors** — every card, pile and control carries a `data-testid`.
-- **Playwright MCP** — `.mcp.json` enables agent-driven browser testing and
-  visual debugging.
-
-See `.claude/skills/high-fidelity-frontend-testing/` for the full guide.
-
-## 🔍 Code Quality
-
-```bash
-# Run ESLint
-pnpm run lint
-```
-
-## 📁 Monorepo Structure
-
-This project uses pnpm workspaces with three packages:
-
-```
-packages/
-├── core/                      # @chayuto/solitaire-core (Game Logic Library)
-│   ├── src/
-│   │   ├── types/            # Core type definitions
-│   │   ├── utils/            # Card/deck utilities, validation, hashing
-│   │   ├── rules/            # Game rules (tableau, foundation, stock)
-│   │   ├── scoring/          # Difficulty and progress calculation
-│   │   ├── engine/           # Game engine
-│   │   └── index.ts          # Public API exports
-│   ├── tests/                # Core library tests
-│   └── package.json          # Library metadata (v0.1.0)
-│
-├── mcts/                      # @chayuto/solitaire-mcts (AI Solver Library)
-│   ├── src/                  # Monte Carlo Tree Search solver
-│   └── package.json          # Library metadata (v0.1.0)
-│
-└── app/                       # Main Application
-    ├── src/
-    │   ├── components/       # React components (Card, GameBoard, etc.)
-    │   ├── store/            # Zustand state management
-    │   │   ├── gameStore.ts  # Main game store (uses @chayuto/solitaire-core)
-    │   │   └── uiHelpers.ts  # UI-specific helpers
-    │   ├── adapters/         # Core↔UI state adapters
-    │   ├── constants/        # UI-specific constants
-    │   ├── types/            # UI-specific types
-    │   └── App.tsx           # Main App component
-    ├── public/               # Static assets
-    └── package.json          # App dependencies
-```
-
-### Package Relationships
-
-- **`@chayuto/solitaire-core`**: Pure game logic library (zero dependencies)
-  - Type-safe Klondike Solitaire engine
-  - Framework-agnostic, reusable in any JavaScript project
-  - ESM + CJS builds with TypeScript declarations
-
-- **`@chayuto/solitaire-mcts`**: AI solver library (depends on core)
-  - Monte Carlo Tree Search implementation
-  - Provides hint/solver functionality
-
-- **`app`**: React application (uses both libraries)
-  - UI components and user interactions
-  - State management with Zustand
-  - Imports game logic from `@chayuto/solitaire-core`
-
-**Recent Architecture Update (Nov 2025):** Extracted game logic into reusable libraries:
-- Created monorepo structure with pnpm workspaces
-- Extracted 800+ lines of pure game logic into `@chayuto/solitaire-core`
-- Removed duplicate helper functions (544 lines eliminated)
-- App now uses library for all game logic
-- See `/docs/internal/20251115_lib_v0_summary_index.md` for full planning docs
-
-## 🎯 Game Rules
-
-Classic Klondike Solitaire:
-- Move all cards to foundation piles (sorted by suit from Ace to King)
-- Tableau cards can be moved in descending order with alternating colors
-- Draw cards from the draw pile to the discard pile
-- Win by completing all four foundation piles
-
-## 💾 Save/Load System
-
-The game includes:
-- **Save State**: Export complete game state as JSON
-- **Load State**: Import previously saved game states
-- **Move History**: Track all moves made during the game
-- **Board Export**: Export initial board setup for replay
-
-## 📚 Documentation
-
-### Development Documentation
-- `/docs/internal/architecture.md` - Architecture overview and design patterns
-- `/docs/internal/20251114_deep_refactor_summary.md` - Refactoring details
-- `/docs/difficulty-system.md` - Difficulty system documentation
-
-### Task Reports
-See `/docs/reports/` for:
-- Project state documentation
-- Improvement suggestions
-- Coding agent task breakdowns
-- Development guidelines
-
-## 🤝 Contributing
-
-This is a solo development project. For improvements and extensions, see the task files in `/docs/reports/`.
-
-## 📄 License
-
-Private project
-
-## 👤 Author
-
-Solo developer project
+Private project.


### PR DESCRIPTION
Concise, accurate rewrite of the project README.

- Corrects the monorepo layout, requirements, and script table.
- Documents the AI Move Advisor, including how the API key is supplied and scoped.
- Drops stale version numbers and references to documents that are not in the repository.

Documentation-only change; CI does not run on Markdown-only changes.