### PR TITLE
feat: AI advisor resilience, diagnostics, and richer logging

### DIFF
--- a/packages/app/e2e/ai-advisor.spec.ts
+++ b/packages/app/e2e/ai-advisor.spec.ts
@@ -130,6 +130,73 @@ test.describe('AI Move Advisor', () => {
     expect(await page.getByTestId('activity-log-ai-reasoning').count()).toBeGreaterThanOrEqual(2);
   });
 
+  test('exports the AI decision log, seed and config for repeatability', async ({ page }) => {
+    await page.goto('/?seed=7');
+    await waitForGame(page);
+
+    await page.evaluate(() => {
+      window.__solitaire!.setAIProviderStub(() => ({
+        moveIndex: 0,
+        reasoning: 'E2E stub: export-log check.',
+        confidence: 0.6,
+      }));
+    });
+    await page.getByTestId('ask-ai-btn').click();
+    await page.waitForFunction(() => window.__solitaire!.getAIState().decisionCount === 1);
+
+    const exported = JSON.parse(
+      await page.evaluate(() => window.__solitaire!.exportState()),
+    );
+    expect(exported.seed).toBe(7);
+    expect(exported.aiConfig?.model).toBeTruthy();
+    expect(exported.aiDecisionLog).toHaveLength(1);
+    expect(exported.aiDecisionLog[0].reasoning).toContain('export-log check');
+    const aiMove = exported.moveHistory.find(
+      (m: { aiReasoning?: string }) => m.aiReasoning,
+    );
+    expect(aiMove?.aiReasoning).toContain('export-log check');
+  });
+
+  test('records time/token diagnostics for AI calls', async ({ page }) => {
+    await page.goto('/?seed=1');
+    await waitForGame(page);
+
+    await page.evaluate(() => {
+      window.__solitaire!.setAIProviderStub(() => ({
+        moveIndex: 0,
+        reasoning: 'E2E stub: diagnostics.',
+        confidence: 1,
+      }));
+    });
+    await page.getByTestId('ask-ai-btn').click();
+    await page.waitForFunction(() => window.__solitaire!.getAIState().decisionCount === 1);
+
+    const diagnostics = await page.evaluate(() => window.__solitaire!.getAIDiagnostics());
+    expect(diagnostics.length).toBeGreaterThanOrEqual(1);
+    expect(diagnostics[diagnostics.length - 1].outcome).toBe('success');
+  });
+
+  test('replay surfaces which moves were made by the AI', async ({ page }) => {
+    await page.goto('/?seed=1');
+    await waitForGame(page);
+
+    await page.evaluate(() => {
+      window.__solitaire!.setAIProviderStub(() => ({
+        moveIndex: 0,
+        reasoning: 'E2E stub: replay reasoning.',
+        confidence: 0.7,
+      }));
+    });
+    await page.getByTestId('ask-ai-btn').click();
+    await page.waitForFunction(() => window.__solitaire!.getAIState().decisionCount === 1);
+
+    await page.getByTestId('replay-btn').click();
+    await page.getByTestId('replay-forward-btn').click();
+
+    await expect(page.getByTestId('replay-current-move')).toBeVisible();
+    await expect(page.getByTestId('replay-ai-reasoning')).toContainText('replay reasoning');
+  });
+
   test('respects the chosen move index from the stub', async ({ page }) => {
     await page.goto('/?seed=1');
     await waitForGame(page);

--- a/packages/app/e2e/test-bridge.spec.ts
+++ b/packages/app/e2e/test-bridge.spec.ts
@@ -57,6 +57,7 @@ test.describe('window.__solitaire test bridge', () => {
         'draw',
         'exportState',
         'findCard',
+        'getAIDiagnostics',
         'getAIState',
         'getState',
         'getSummary',

--- a/packages/app/src/adapters/coreAdapter.ts
+++ b/packages/app/src/adapters/coreAdapter.ts
@@ -86,6 +86,7 @@ export function coreToUI(coreState: CoreGameState, existingUIState: UIGameState)
     
     // Preserve UI-specific fields from existing state
     selectedCard: existingUIState.selectedCard,
+    seed: existingUIState.seed,
     showValidMoves: existingUIState.showValidMoves,
     godMode: existingUIState.godMode,
     autoPlayEnabled: existingUIState.autoPlayEnabled,
@@ -101,6 +102,8 @@ export function coreToUI(coreState: CoreGameState, existingUIState: UIGameState)
     aiThinking: existingUIState.aiThinking,
     aiAutoPlay: existingUIState.aiAutoPlay,
     aiThinkingSince: existingUIState.aiThinkingSince,
+    aiStatus: existingUIState.aiStatus,
+    aiRetryCount: existingUIState.aiRetryCount,
     aiError: existingUIState.aiError,
     aiDecisionLog: existingUIState.aiDecisionLog,
     aiKeyModalOpen: existingUIState.aiKeyModalOpen,
@@ -114,6 +117,7 @@ export function coreToUI(coreState: CoreGameState, existingUIState: UIGameState)
 export function getDefaultUIFields(): Pick<
   UIGameState,
   | 'selectedCard'
+  | 'seed'
   | 'showValidMoves'
   | 'godMode'
   | 'autoPlayEnabled'
@@ -127,12 +131,15 @@ export function getDefaultUIFields(): Pick<
   | 'aiThinking'
   | 'aiAutoPlay'
   | 'aiThinkingSince'
+  | 'aiStatus'
+  | 'aiRetryCount'
   | 'aiError'
   | 'aiDecisionLog'
   | 'aiKeyModalOpen'
 > {
   return {
     selectedCard: undefined,
+    seed: undefined,
     showValidMoves: false,
     godMode: false,
     autoPlayEnabled: false,
@@ -146,6 +153,8 @@ export function getDefaultUIFields(): Pick<
     aiThinking: false,
     aiAutoPlay: false,
     aiThinkingSince: undefined,
+    aiStatus: undefined,
+    aiRetryCount: 0,
     aiError: undefined,
     aiDecisionLog: [],
     aiKeyModalOpen: false,

--- a/packages/app/src/ai/constants.ts
+++ b/packages/app/src/ai/constants.ts
@@ -27,6 +27,26 @@ export const AI_AUTO_MOVE_DELAY = 800;
 /** Board-state hashes retained for AI auto-play loop detection. */
 export const AI_AUTO_HISTORY_LIMIT = 60;
 
+/**
+ * How many times a single move request is attempted before giving up. LLM
+ * endpoints are not perfectly stable; transient failures are retried with
+ * exponential backoff (see `ai/retry`).
+ */
+export const AI_RETRY_MAX_ATTEMPTS = 4;
+
+/** Base backoff delay (ms) before the first retry. Doubles each attempt. */
+export const AI_RETRY_BASE_DELAY = 2000;
+
+/** Maximum backoff delay (ms) between retries. */
+export const AI_RETRY_MAX_DELAY = 30_000;
+
+/**
+ * Cooldown (ms) before AI auto-play re-attempts a move after a request
+ * exhausted its retries with a transient (infrastructure) error. Auto-play
+ * keeps going rather than stopping on a flaky API.
+ */
+export const AI_AUTO_RETRY_COOLDOWN = 12_000;
+
 /** Sampling temperature for move suggestions — low, for consistent advice. */
 export const AI_TEMPERATURE = 0.3;
 

--- a/packages/app/src/ai/context/buildContext.test.ts
+++ b/packages/app/src/ai/context/buildContext.test.ts
@@ -61,6 +61,9 @@ describe('buildContext', () => {
     expect(ctx.drawPileCount).toBe(1);
     expect(ctx.tableau[0].faceDownCount).toBe(1);
     expect(ctx.tableau[0].faceUp).toEqual(['8H']);
+    // Columns carry an explicit 1-based number.
+    expect(ctx.tableau[0].column).toBe(1);
+    expect(ctx.tableau[6].column).toBe(7);
     expect(ctx.legalMoves).toHaveLength(2);
     expect(ctx.legalMoves[0].index).toBe(0);
     expect(ctx.legalMoves[1].index).toBe(1);

--- a/packages/app/src/ai/context/buildContext.ts
+++ b/packages/app/src/ai/context/buildContext.ts
@@ -125,10 +125,13 @@ export function buildContext(
   }
 
   // --- Tableau ---
-  const tableau = state.tableau.map((column) => {
+  // Each column carries an explicit 1-based `column` number so the model
+  // refers to columns the same way the move descriptions and UI do.
+  const tableau = state.tableau.map((column, index) => {
     const faceDown = column.filter((c) => !c.faceUp);
     const faceUp = column.filter((c) => c.faceUp);
     const col: AIMoveContext['tableau'][number] = {
+      column: index + 1,
       faceDownCount: faceDown.length,
       faceUp: faceUp.map(cardShort),
     };
@@ -145,7 +148,9 @@ export function buildContext(
 
   const context: AIMoveContext = {
     notation:
-      'Cards: rank then suit (A 2-9 T J Q K; H D C S). Tableau columns and faceUp arrays are listed bottom-to-top.',
+      'Cards: rank then suit (A 2-9 T J Q K; H D C S). Tableau columns are ' +
+      'numbered 1 to 7 by their "column" field; faceUp arrays are bottom-to-top. ' +
+      'Always refer to columns by that 1-based number in your reasoning.',
     foundations,
     tableau,
     discardTop,

--- a/packages/app/src/ai/context/rulesPrimer.ts
+++ b/packages/app/src/ai/context/rulesPrimer.ts
@@ -13,6 +13,7 @@ export const RULES_PRIMER = `You are an expert Klondike Solitaire strategist act
 
 KLONDIKE SOLITAIRE RULES (this variant):
 - There are 7 tableau columns, 4 foundations (one per suit), a stock (draw) pile and a waste (discard) pile.
+- Tableau columns are numbered 1 to 7. Always refer to a column by that 1-based number, never 0-based.
 - Foundations are built UP by suit, starting from the Ace: A, 2, 3, ... up to King.
 - Tableau columns are built DOWN in alternating colors (red on black, black on red). Example: a black 7 can go on a red 8.
 - Only a King (or a valid sequence headed by a King) may be moved onto an EMPTY tableau column.

--- a/packages/app/src/ai/diagnostics.test.ts
+++ b/packages/app/src/ai/diagnostics.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for AI request diagnostics (time / token logging).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  recordAIDiagnostics,
+  getAIDiagnostics,
+  getLastAIDiagnostics,
+  clearAIDiagnostics,
+  type AIDiagnostics,
+} from './diagnostics';
+
+const success: AIDiagnostics = {
+  timestamp: 1,
+  model: 'gemma-4-31b-it',
+  outcome: 'success',
+  durationMs: 61_000,
+  promptTokens: 620,
+  thoughtTokens: 1840,
+  outputTokens: 42,
+  totalTokens: 2502,
+};
+
+describe('diagnostics', () => {
+  beforeEach(() => {
+    clearAIDiagnostics();
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('records and returns an entry', () => {
+    recordAIDiagnostics(success);
+    expect(getAIDiagnostics()).toEqual([success]);
+  });
+
+  it('getLastAIDiagnostics returns the most recent entry', () => {
+    expect(getLastAIDiagnostics()).toBeNull();
+    recordAIDiagnostics(success);
+    recordAIDiagnostics({ ...success, timestamp: 2 });
+    expect(getLastAIDiagnostics()?.timestamp).toBe(2);
+  });
+
+  it('logs token usage to the console for a success', () => {
+    const info = vi.mocked(console.info);
+    recordAIDiagnostics(success);
+    expect(info).toHaveBeenCalled();
+    expect(info.mock.calls.some((c) => String(c[0]).includes('total=2502'))).toBe(true);
+  });
+
+  it('logs a warning for an error outcome', () => {
+    const warn = vi.mocked(console.warn);
+    recordAIDiagnostics({
+      timestamp: 3,
+      model: 'gemma-4-31b-it',
+      outcome: 'error',
+      durationMs: 1200,
+      errorKind: 'unavailable',
+    });
+    expect(warn).toHaveBeenCalled();
+    expect(warn.mock.calls.some((c) => String(c[0]).includes('unavailable'))).toBe(true);
+  });
+
+  it('caps the ring buffer at 100 entries', () => {
+    for (let i = 0; i < 130; i++) {
+      recordAIDiagnostics({ ...success, timestamp: i });
+    }
+    const entries = getAIDiagnostics();
+    expect(entries).toHaveLength(100);
+    // Oldest entries were dropped; the newest is retained.
+    expect(entries[entries.length - 1].timestamp).toBe(129);
+    expect(entries[0].timestamp).toBe(30);
+  });
+
+  it('clearAIDiagnostics empties the buffer', () => {
+    recordAIDiagnostics(success);
+    clearAIDiagnostics();
+    expect(getAIDiagnostics()).toEqual([]);
+  });
+});

--- a/packages/app/src/ai/diagnostics.ts
+++ b/packages/app/src/ai/diagnostics.ts
@@ -1,0 +1,76 @@
+/**
+ * Diagnostic logging for AI requests: time taken and token usage.
+ *
+ * For now this is backend-only. Each API call appends a structured entry to an
+ * in-memory ring buffer and writes a line to the console. There is no UI
+ * surface yet; the buffer is readable via the test bridge (`getAIDiagnostics`).
+ * One entry corresponds to one API call (a move that was retried produces one
+ * entry per attempt).
+ *
+ * @module ai/diagnostics
+ */
+
+import type { AIErrorKind } from './types';
+
+/** A single AI API-call diagnostic record. */
+export interface AIDiagnostics {
+  /** When the call finished. */
+  timestamp: number;
+  /** Model that handled (or was meant to handle) the call. */
+  model: string;
+  /** Whether the call succeeded. */
+  outcome: 'success' | 'error';
+  /** Wall-clock duration of the call, in ms. */
+  durationMs: number;
+  /** Prompt (input) tokens, when reported by the provider. */
+  promptTokens?: number;
+  /** Thinking tokens, when reported (thinking models only). */
+  thoughtTokens?: number;
+  /** Output (answer) tokens, when reported. */
+  outputTokens?: number;
+  /** Total billed tokens, when reported. */
+  totalTokens?: number;
+  /** Failure category, for `error` outcomes. */
+  errorKind?: AIErrorKind;
+}
+
+/** Maximum diagnostic entries retained in memory. */
+const MAX_ENTRIES = 100;
+
+const buffer: AIDiagnostics[] = [];
+
+/** Record a diagnostic entry: append to the ring buffer and log to the console. */
+export function recordAIDiagnostics(entry: AIDiagnostics): void {
+  buffer.push(entry);
+  if (buffer.length > MAX_ENTRIES) buffer.shift();
+
+  const seconds = (entry.durationMs / 1000).toFixed(1);
+  if (entry.outcome === 'success') {
+    console.info(
+      `[AI] ${entry.model} ok in ${seconds}s · tokens` +
+        ` prompt=${entry.promptTokens ?? '?'}` +
+        ` thoughts=${entry.thoughtTokens ?? '?'}` +
+        ` output=${entry.outputTokens ?? '?'}` +
+        ` total=${entry.totalTokens ?? '?'}`,
+    );
+  } else {
+    console.warn(
+      `[AI] ${entry.model} failed (${entry.errorKind ?? 'error'}) after ${seconds}s`,
+    );
+  }
+}
+
+/** A snapshot of the diagnostic ring buffer, most recent last. */
+export function getAIDiagnostics(): readonly AIDiagnostics[] {
+  return [...buffer];
+}
+
+/** The most recent diagnostic entry, or `null`. */
+export function getLastAIDiagnostics(): AIDiagnostics | null {
+  return buffer.length > 0 ? buffer[buffer.length - 1] : null;
+}
+
+/** Clear the diagnostic ring buffer (used by tests). */
+export function clearAIDiagnostics(): void {
+  buffer.length = 0;
+}

--- a/packages/app/src/ai/index.ts
+++ b/packages/app/src/ai/index.ts
@@ -14,7 +14,29 @@ export {
   AI_DECISION_LOG_LIMIT,
   AI_AUTO_MOVE_DELAY,
   AI_AUTO_HISTORY_LIMIT,
+  AI_RETRY_MAX_ATTEMPTS,
+  AI_AUTO_RETRY_COOLDOWN,
 } from './constants';
+
+// Retry / resilience
+export {
+  suggestMoveWithRetry,
+  isRetryableAIError,
+  isTransientAIError,
+  backoffDelay,
+  RETRYABLE_ERROR_KINDS,
+  TRANSIENT_ERROR_KINDS,
+} from './retry';
+export type { RetryInfo, SuggestMoveRetryOptions } from './retry';
+
+// Diagnostics
+export {
+  recordAIDiagnostics,
+  getAIDiagnostics,
+  getLastAIDiagnostics,
+  clearAIDiagnostics,
+} from './diagnostics';
+export type { AIDiagnostics } from './diagnostics';
 
 // Configuration / presets
 export { DEFAULT_AI_CONFIG, PRESET_FIELDS, applyPreset } from './context/presets';

--- a/packages/app/src/ai/providers/GeminiProvider.ts
+++ b/packages/app/src/ai/providers/GeminiProvider.ts
@@ -19,12 +19,21 @@
 
 import { AI_REQUEST_TIMEOUT_MS, AI_TEMPERATURE, GEMINI_API_BASE } from '../constants';
 import { parseDecision } from '../decision/schema';
+import { recordAIDiagnostics } from '../diagnostics';
 import { AIError, type AIMoveDecision, type AIProvider, type AIRequest } from '../types';
 
 /** Shape of a single content part in a Gemini API response. */
 interface GeminiPart {
   text?: string;
   thought?: boolean;
+}
+
+/** Token-usage block from a Gemini response. */
+interface GeminiUsage {
+  promptTokenCount?: number;
+  candidatesTokenCount?: number;
+  thoughtsTokenCount?: number;
+  totalTokenCount?: number;
 }
 
 /** Minimal shape of the Gemini `generateContent` response we rely on. */
@@ -34,6 +43,7 @@ interface GeminiResponse {
     finishReason?: string;
   }[];
   promptFeedback?: { blockReason?: string };
+  usageMetadata?: GeminiUsage;
   error?: { code?: number; message?: string; status?: string };
 }
 
@@ -108,12 +118,7 @@ export const geminiProvider: AIProvider = {
   displayName: 'Google Gemini / Gemma',
   requiresKey: true,
   defaultModel: 'gemma-4-31b-it',
-  availableModels: [
-    'gemma-4-31b-it',
-    'gemma-4-26b-a4b-it',
-    'gemini-2.5-flash',
-    'gemini-2.5-pro',
-  ],
+  availableModels: ['gemma-4-31b-it', 'gemma-4-26b-a4b-it', 'gemini-3.1-flash-lite'],
   apiKeyUrl: 'https://aistudio.google.com/apikey',
 
   async suggestMove(request: AIRequest): Promise<AIMoveDecision> {
@@ -121,73 +126,99 @@ export const geminiProvider: AIProvider = {
       throw new AIError('no_key', 'No Gemini API key configured.');
     }
 
-    // Single user message: system instruction + game context + (output rules
-    // are already inside the system instruction).
-    const prompt =
-      `${request.systemInstruction}\n\n` +
-      `CURRENT GAME (JSON):\n${JSON.stringify(request.context)}\n\n` +
-      'Now choose the best move and reply with only the JSON object.';
-
-    const body = {
-      contents: [{ role: 'user', parts: [{ text: prompt }] }],
-      generationConfig: { temperature: AI_TEMPERATURE },
-    };
-
-    // Combine our timeout with any caller-supplied abort signal.
-    const controller = new AbortController();
-    let timedOut = false;
-    const timer = setTimeout(() => {
-      timedOut = true;
-      controller.abort();
-    }, AI_REQUEST_TIMEOUT_MS);
-    const onParentAbort = () => controller.abort();
-    request.signal?.addEventListener('abort', onParentAbort);
-
-    const url =
-      `${GEMINI_API_BASE}/models/${encodeURIComponent(request.model)}:generateContent` +
-      `?key=${encodeURIComponent(request.apiKey)}`;
-
-    let response: Response;
+    const startedAt = Date.now();
     try {
-      response = await fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-        signal: controller.signal,
-      });
-    } catch (err) {
-      if (err instanceof DOMException && err.name === 'AbortError') {
-        throw new AIError(
-          timedOut ? 'timeout' : 'aborted',
-          timedOut
-            ? `The model did not respond within ${Math.round(AI_REQUEST_TIMEOUT_MS / 1000)}s.`
-            : 'The AI request was cancelled.',
-        );
+      // Single user message: system instruction + game context (the output
+      // rules are already inside the system instruction).
+      const prompt =
+        `${request.systemInstruction}\n\n` +
+        `CURRENT GAME (JSON):\n${JSON.stringify(request.context)}\n\n` +
+        'Now choose the best move and reply with only the JSON object.';
+
+      const body = {
+        contents: [{ role: 'user', parts: [{ text: prompt }] }],
+        generationConfig: { temperature: AI_TEMPERATURE },
+      };
+
+      // Combine our timeout with any caller-supplied abort signal.
+      const controller = new AbortController();
+      let timedOut = false;
+      const timer = setTimeout(() => {
+        timedOut = true;
+        controller.abort();
+      }, AI_REQUEST_TIMEOUT_MS);
+      const onParentAbort = () => controller.abort();
+      request.signal?.addEventListener('abort', onParentAbort);
+
+      const url =
+        `${GEMINI_API_BASE}/models/${encodeURIComponent(request.model)}:generateContent` +
+        `?key=${encodeURIComponent(request.apiKey)}`;
+
+      let response: Response;
+      try {
+        response = await fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+          signal: controller.signal,
+        });
+      } catch (err) {
+        if (err instanceof DOMException && err.name === 'AbortError') {
+          throw new AIError(
+            timedOut ? 'timeout' : 'aborted',
+            timedOut
+              ? `The model did not respond within ${Math.round(AI_REQUEST_TIMEOUT_MS / 1000)}s.`
+              : 'The AI request was cancelled.',
+          );
+        }
+        throw new AIError('network', 'Could not reach Gemini. Check your network connection.');
+      } finally {
+        clearTimeout(timer);
+        request.signal?.removeEventListener('abort', onParentAbort);
       }
-      throw new AIError('network', 'Could not reach Gemini. Check your network connection.');
-    } finally {
-      clearTimeout(timer);
-      request.signal?.removeEventListener('abort', onParentAbort);
-    }
 
-    let data: GeminiResponse | null;
-    try {
-      data = (await response.json()) as GeminiResponse;
-    } catch {
-      data = null;
-    }
+      let data: GeminiResponse | null;
+      try {
+        data = (await response.json()) as GeminiResponse;
+      } catch {
+        data = null;
+      }
 
-    if (!response.ok) {
-      throw errorFromHttp(response.status, data);
-    }
-    if (!data) {
-      throw new AIError('bad_response', 'Gemini returned a response that was not JSON.');
-    }
-    if (data.error) {
-      throw errorFromHttp(data.error.code ?? 500, data);
-    }
+      if (!response.ok) {
+        throw errorFromHttp(response.status, data);
+      }
+      if (!data) {
+        throw new AIError('bad_response', 'Gemini returned a response that was not JSON.');
+      }
+      if (data.error) {
+        throw errorFromHttp(data.error.code ?? 500, data);
+      }
 
-    const text = extractAnswerText(data);
-    return parseDecision(text, request.context.legalMoves.length);
+      const text = extractAnswerText(data);
+      const decision = parseDecision(text, request.context.legalMoves.length);
+
+      // Diagnostics: time taken and token cost for this API call.
+      const usage = data.usageMetadata;
+      recordAIDiagnostics({
+        timestamp: Date.now(),
+        model: request.model,
+        outcome: 'success',
+        durationMs: Date.now() - startedAt,
+        promptTokens: usage?.promptTokenCount,
+        thoughtTokens: usage?.thoughtsTokenCount,
+        outputTokens: usage?.candidatesTokenCount,
+        totalTokens: usage?.totalTokenCount,
+      });
+      return decision;
+    } catch (err) {
+      recordAIDiagnostics({
+        timestamp: Date.now(),
+        model: request.model,
+        outcome: 'error',
+        durationMs: Date.now() - startedAt,
+        errorKind: err instanceof AIError ? err.kind : 'network',
+      });
+      throw err;
+    }
   },
 };

--- a/packages/app/src/ai/providers/stubProvider.ts
+++ b/packages/app/src/ai/providers/stubProvider.ts
@@ -8,7 +8,8 @@
  * @module ai/providers/stubProvider
  */
 
-import type { AIMoveContext, AIMoveDecision, AIProvider } from '../types';
+import { recordAIDiagnostics } from '../diagnostics';
+import { AIError, type AIMoveContext, type AIMoveDecision, type AIProvider } from '../types';
 
 /** A function that turns a game context into a decision. */
 export type StubDecisionFn = (
@@ -37,7 +38,26 @@ export function createStubProvider(decide?: StubDecisionFn): AIProvider {
     availableModels: ['stub'],
     apiKeyUrl: '',
     async suggestMove(request): Promise<AIMoveDecision> {
-      return fn(request.context);
+      const startedAt = Date.now();
+      try {
+        const decision = await fn(request.context);
+        recordAIDiagnostics({
+          timestamp: Date.now(),
+          model: request.model,
+          outcome: 'success',
+          durationMs: Date.now() - startedAt,
+        });
+        return decision;
+      } catch (err) {
+        recordAIDiagnostics({
+          timestamp: Date.now(),
+          model: request.model,
+          outcome: 'error',
+          durationMs: Date.now() - startedAt,
+          errorKind: err instanceof AIError ? err.kind : 'bad_response',
+        });
+        throw err;
+      }
     },
   };
 }

--- a/packages/app/src/ai/retry.test.ts
+++ b/packages/app/src/ai/retry.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for retry-with-backoff of AI move requests.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  backoffDelay,
+  isRetryableAIError,
+  isTransientAIError,
+  suggestMoveWithRetry,
+} from './retry';
+import { AI_RETRY_MAX_DELAY } from './constants';
+import { AIError, type AIMoveContext, type AIMoveDecision, type AIProvider, type AIRequest } from './types';
+
+const DECISION: AIMoveDecision = { moveIndex: 0, reasoning: 'ok', confidence: 1 };
+
+const CONTEXT: AIMoveContext = {
+  notation: '',
+  foundations: { hearts: null, diamonds: null, clubs: null, spades: null },
+  tableau: [],
+  discardTop: null,
+  drawPileCount: 0,
+  canRecycleStock: false,
+  legalMoves: [{ index: 0, type: 'draw_card', describe: 'Draw' }],
+};
+
+const REQUEST: AIRequest = {
+  apiKey: '',
+  model: 'fake',
+  systemInstruction: '',
+  context: CONTEXT,
+};
+
+/** A provider whose `suggestMove` is the supplied mock. */
+function fakeProvider(suggestMove: AIProvider['suggestMove']): AIProvider {
+  return {
+    id: 'fake',
+    displayName: 'Fake',
+    requiresKey: false,
+    defaultModel: 'fake',
+    availableModels: ['fake'],
+    apiKeyUrl: '',
+    suggestMove,
+  };
+}
+
+describe('backoffDelay', () => {
+  it('grows with the attempt number', () => {
+    expect(backoffDelay(1)).toBeLessThan(backoffDelay(3));
+  });
+
+  it('is capped at the maximum delay', () => {
+    expect(backoffDelay(20)).toBeLessThanOrEqual(AI_RETRY_MAX_DELAY + 500);
+  });
+});
+
+describe('isRetryableAIError / isTransientAIError', () => {
+  it('classifies retryable errors', () => {
+    expect(isRetryableAIError(new AIError('network', ''))).toBe(true);
+    expect(isRetryableAIError(new AIError('unavailable', ''))).toBe(true);
+    expect(isRetryableAIError(new AIError('bad_response', ''))).toBe(true);
+    expect(isRetryableAIError(new AIError('invalid_key', ''))).toBe(false);
+    expect(isRetryableAIError(new Error('plain'))).toBe(false);
+  });
+
+  it('classifies transient (infrastructure) errors', () => {
+    expect(isTransientAIError(new AIError('timeout', ''))).toBe(true);
+    expect(isTransientAIError(new AIError('rate_limited', ''))).toBe(true);
+    // bad_response is retryable but not "transient": auto-play stops on it.
+    expect(isTransientAIError(new AIError('bad_response', ''))).toBe(false);
+    expect(isTransientAIError(new AIError('invalid_key', ''))).toBe(false);
+  });
+});
+
+describe('suggestMoveWithRetry', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns the decision on a first-attempt success', async () => {
+    const suggestMove = vi.fn().mockResolvedValue(DECISION);
+    const result = await suggestMoveWithRetry(fakeProvider(suggestMove), REQUEST, {
+      maxAttempts: 4,
+    });
+    expect(result).toBe(DECISION);
+    expect(suggestMove).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry a non-retryable error', async () => {
+    const suggestMove = vi.fn().mockRejectedValue(new AIError('invalid_key', 'bad key'));
+    await expect(
+      suggestMoveWithRetry(fakeProvider(suggestMove), REQUEST, { maxAttempts: 4 }),
+    ).rejects.toMatchObject({ kind: 'invalid_key' });
+    expect(suggestMove).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry an aborted request', async () => {
+    const suggestMove = vi.fn().mockRejectedValue(new AIError('aborted', 'cancelled'));
+    await expect(
+      suggestMoveWithRetry(fakeProvider(suggestMove), REQUEST, { maxAttempts: 4 }),
+    ).rejects.toMatchObject({ kind: 'aborted' });
+    expect(suggestMove).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a transient failure and then succeeds', async () => {
+    vi.useFakeTimers();
+    const suggestMove = vi
+      .fn()
+      .mockRejectedValueOnce(new AIError('unavailable', 'down'))
+      .mockResolvedValueOnce(DECISION);
+    const onRetry = vi.fn();
+
+    const promise = suggestMoveWithRetry(fakeProvider(suggestMove), REQUEST, {
+      maxAttempts: 4,
+      onRetry,
+    });
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    await expect(promise).resolves.toBe(DECISION);
+    expect(suggestMove).toHaveBeenCalledTimes(2);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onRetry.mock.calls[0][0]).toMatchObject({ attempt: 1, maxAttempts: 4 });
+  });
+
+  it('gives up after the maximum number of attempts', async () => {
+    vi.useFakeTimers();
+    const suggestMove = vi.fn().mockRejectedValue(new AIError('unavailable', 'down'));
+
+    const promise = suggestMoveWithRetry(fakeProvider(suggestMove), REQUEST, {
+      maxAttempts: 3,
+    });
+    const assertion = expect(promise).rejects.toMatchObject({ kind: 'unavailable' });
+    await vi.advanceTimersByTimeAsync(120_000);
+    await assertion;
+
+    expect(suggestMove).toHaveBeenCalledTimes(3);
+  });
+
+  it('stops retrying when the signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const suggestMove = vi.fn().mockResolvedValue(DECISION);
+
+    await expect(
+      suggestMoveWithRetry(fakeProvider(suggestMove), REQUEST, {
+        maxAttempts: 4,
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ kind: 'aborted' });
+    expect(suggestMove).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/ai/retry.ts
+++ b/packages/app/src/ai/retry.ts
@@ -1,0 +1,131 @@
+/**
+ * Retry-with-backoff for AI move requests.
+ *
+ * LLM endpoints are not perfectly stable: transient failures (network errors,
+ * timeouts, rate limits, 5xx responses, the occasional unparseable answer) are
+ * retried with exponential backoff before the error is surfaced.
+ *
+ * @module ai/retry
+ */
+
+import { AI_RETRY_BASE_DELAY, AI_RETRY_MAX_DELAY } from './constants';
+import { AIError, type AIErrorKind, type AIMoveDecision, type AIProvider, type AIRequest } from './types';
+
+/**
+ * Error kinds worth retrying within a single request. Includes `bad_response`
+ * because a (non-deterministic) model sometimes returns unusable output that a
+ * fresh generation fixes.
+ */
+export const RETRYABLE_ERROR_KINDS: ReadonlySet<AIErrorKind> = new Set<AIErrorKind>([
+  'network',
+  'timeout',
+  'rate_limited',
+  'unavailable',
+  'bad_response',
+]);
+
+/**
+ * Transient *infrastructure* errors. AI auto-play keeps going through these
+ * (it cools down and re-attempts) rather than stopping. `bad_response` is
+ * deliberately excluded: a model that cannot follow the format is a capability
+ * problem, not a flaky-network problem, so auto-play stops on it.
+ */
+export const TRANSIENT_ERROR_KINDS: ReadonlySet<AIErrorKind> = new Set<AIErrorKind>([
+  'network',
+  'timeout',
+  'rate_limited',
+  'unavailable',
+]);
+
+/** Whether an error should be retried within a single request. */
+export function isRetryableAIError(err: unknown): boolean {
+  return err instanceof AIError && RETRYABLE_ERROR_KINDS.has(err.kind);
+}
+
+/** Whether an error is a transient infrastructure failure (auto-play survives it). */
+export function isTransientAIError(err: unknown): boolean {
+  return err instanceof AIError && TRANSIENT_ERROR_KINDS.has(err.kind);
+}
+
+/** Exponential backoff (with jitter) before retry attempt `attempt` (1-based). */
+export function backoffDelay(attempt: number): number {
+  const exponential = AI_RETRY_BASE_DELAY * 2 ** (attempt - 1);
+  const capped = Math.min(exponential, AI_RETRY_MAX_DELAY);
+  return capped + Math.floor(Math.random() * 500);
+}
+
+/** A sleep that rejects with an aborted {@link AIError} if `signal` fires. */
+function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new AIError('aborted', 'The AI request was cancelled.'));
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new AIError('aborted', 'The AI request was cancelled.'));
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+/** Details of a retry, passed to the {@link SuggestMoveRetryOptions.onRetry} callback. */
+export interface RetryInfo {
+  /** The attempt that just failed (1-based). */
+  attempt: number;
+  /** Total attempts that will be made. */
+  maxAttempts: number;
+  /** The failure being retried. */
+  error: AIError;
+  /** Delay before the next attempt, in ms. */
+  delayMs: number;
+}
+
+/** Options for {@link suggestMoveWithRetry}. */
+export interface SuggestMoveRetryOptions {
+  /** Maximum number of attempts (>= 1). */
+  maxAttempts: number;
+  /** Abort signal — cancels both the request and any pending backoff. */
+  signal?: AbortSignal;
+  /** Invoked after each failed-but-retryable attempt, before the backoff wait. */
+  onRetry?: (info: RetryInfo) => void;
+}
+
+/**
+ * Call `provider.suggestMove`, retrying transient failures with exponential
+ * backoff. Non-retryable errors (and `aborted`) are thrown immediately.
+ *
+ * @throws {AIError} the last failure if every attempt fails.
+ */
+export async function suggestMoveWithRetry(
+  provider: AIProvider,
+  request: AIRequest,
+  options: SuggestMoveRetryOptions,
+): Promise<AIMoveDecision> {
+  const { maxAttempts, signal, onRetry } = options;
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    if (signal?.aborted) {
+      throw new AIError('aborted', 'The AI request was cancelled.');
+    }
+    try {
+      return await provider.suggestMove(request);
+    } catch (err) {
+      lastError = err;
+      // Never retry a cancellation or a non-retryable error.
+      if (err instanceof AIError && err.kind === 'aborted') throw err;
+      if (!isRetryableAIError(err) || attempt >= maxAttempts) throw err;
+
+      const delayMs = backoffDelay(attempt);
+      onRetry?.({ attempt, maxAttempts, error: err as AIError, delayMs });
+      await abortableSleep(delayMs, signal);
+    }
+  }
+
+  throw lastError;
+}

--- a/packages/app/src/ai/types.ts
+++ b/packages/app/src/ai/types.ts
@@ -33,7 +33,7 @@ export type AIContextPreset = 'minimal' | 'standard' | 'detailed' | 'custom';
 export interface AIConfig {
   /** Which LLM provider to use. */
   provider: AIProviderId;
-  /** Provider-specific model id, e.g. `gemini-2.5-flash`. */
+  /** Provider-specific model id, e.g. `gemma-4-31b-it`. */
   model: string;
   /** Active context preset. */
   preset: AIContextPreset;
@@ -88,6 +88,8 @@ export interface AILegalMove {
 
 /** One tableau column, as presented to the LLM. */
 export interface AITableauColumn {
+  /** 1-based column number (1 to 7) — matches the numbering used everywhere else. */
+  column: number;
   /** Number of face-down (hidden) cards at the bottom of the column. */
   faceDownCount: number;
   /** Face-up cards, bottom-to-top, in card shorthand (e.g. `["KS","QH"]`). */
@@ -228,7 +230,11 @@ export class AIError extends Error {
 // Store-side records
 // ---------------------------------------------------------------------------
 
-/** A record of one AI decision, kept in the store's `aiDecisionLog`. */
+/**
+ * A record of one AI decision, kept in the store's `aiDecisionLog` and included
+ * in an exported game. Carries enough detail (the choice, the reasoning, the
+ * cost, the alternatives) to serve as a row in a future benchmarking dataset.
+ */
 export interface AIDecisionRecord {
   /** When the decision was applied. */
   timestamp: number;
@@ -244,4 +250,20 @@ export interface AIDecisionRecord {
   alternativeDescribe?: string;
   /** Model that produced the decision. */
   model: string;
+  /** Index the model chose, within the legal-move list it was shown. */
+  moveIndex?: number;
+  /** Number of legal moves the model chose from. */
+  legalMoveCount?: number;
+  /** Wall-clock time for the move, including retries, in ms. */
+  durationMs?: number;
+  /** Retries performed before the move succeeded. */
+  retries?: number;
+  /** Prompt (input) tokens, when the provider reported usage. */
+  promptTokens?: number;
+  /** Thinking tokens, when reported (thinking models only). */
+  thoughtTokens?: number;
+  /** Output (answer) tokens, when reported. */
+  outputTokens?: number;
+  /** Total billed tokens, when reported. */
+  totalTokens?: number;
 }

--- a/packages/app/src/components/AIAdvisorPanel.tsx
+++ b/packages/app/src/components/AIAdvisorPanel.tsx
@@ -26,6 +26,8 @@ const AIAdvisorPanel: React.FC = () => {
   const aiThinking = useGameStore((s) => s.aiThinking) ?? false;
   const aiAutoPlay = useGameStore((s) => s.aiAutoPlay) ?? false;
   const aiThinkingSince = useGameStore((s) => s.aiThinkingSince);
+  const aiStatus = useGameStore((s) => s.aiStatus);
+  const aiRetryCount = useGameStore((s) => s.aiRetryCount) ?? 0;
   const aiError = useGameStore((s) => s.aiError);
   const aiDecisionLog = useGameStore((s) => s.aiDecisionLog);
   const cancelAIRequest = useGameStore((s) => s.cancelAIRequest);
@@ -96,7 +98,7 @@ const AIAdvisorPanel: React.FC = () => {
             <div className="flex items-center gap-2">
               <span className="inline-block w-4 h-4 border-2 border-indigo-500 border-t-transparent rounded-full animate-spin" />
               <span className="text-sm font-semibold text-indigo-800">
-                {aiAutoPlay ? 'Auto-playing…' : 'Thinking…'}
+                {aiAutoPlay ? 'Auto-playing...' : 'Thinking...'}
               </span>
               <span
                 data-testid="ai-elapsed"
@@ -106,9 +108,23 @@ const AIAdvisorPanel: React.FC = () => {
               </span>
             </div>
             <p className="text-xs text-indigo-700 mt-2">
-              A thinking model can take a while — up to ~{Math.round(timeoutSeconds / 60)} minutes
-              on a hard board. The board is locked until it answers.
+              A thinking model can take a while, up to about{' '}
+              {Math.round(timeoutSeconds / 60)} minutes on a hard board. The board is
+              locked until it answers.
             </p>
+            {aiRetryCount > 0 && (
+              <p
+                data-testid="ai-retry-count"
+                className="text-xs font-semibold text-amber-700 mt-2"
+              >
+                Retries this request: {aiRetryCount}
+              </p>
+            )}
+            {aiStatus && (
+              <p data-testid="ai-status" className="text-xs text-amber-700 mt-1">
+                {aiStatus}
+              </p>
+            )}
             <button
               data-testid="ai-cancel-btn"
               onClick={aiAutoPlay ? toggleAIAutoPlay : cancelAIRequest}

--- a/packages/app/src/components/AIKeyModal.tsx
+++ b/packages/app/src/components/AIKeyModal.tsx
@@ -98,8 +98,8 @@ const AIKeyModalContent: React.FC = () => {
         </datalist>
         <p className="text-xs text-gray-500 mb-4">
           Default <code>gemma-4-31b-it</code> is a thinking model — a suggestion can take
-          up to ~3 minutes. Pick a faster model (e.g. <code>gemini-2.5-flash</code>) for
-          quicker, lower-quality advice.
+          up to ~3 minutes. Pick a faster model (e.g.{' '}
+          <code>gemini-3.1-flash-lite</code>) for quicker, lower-quality advice.
         </p>
 
         {/* API key */}

--- a/packages/app/src/components/ActivityLog.tsx
+++ b/packages/app/src/components/ActivityLog.tsx
@@ -1,10 +1,18 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useGameStore } from '../store/gameStore';
 import type { Move, Card } from '../types';
 
 const ActivityLog: React.FC = () => {
   const moveHistory = useGameStore((state) => state.moveHistory);
   const [isMinimized, setIsMinimized] = useState(false);
+  // The scrollable entries container. Newest entries render at the top, so we
+  // scroll back to the top whenever a move lands to keep the latest visible.
+  const entriesRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (entriesRef.current) {
+      entriesRef.current.scrollTop = 0;
+    }
+  }, [moveHistory.length]);
   // "Clear View" hides the log until the next move arrives. Remembering the
   // history length at clear time keeps visibleLogs a pure derivation of
   // moveHistory, rather than mirroring it into state via a setState-in-effect.
@@ -130,7 +138,7 @@ const ActivityLog: React.FC = () => {
           </div>
 
           {/* Log Display */}
-          <div data-testid="activity-log-entries" className="h-48 lg:h-96 overflow-y-auto p-3 bg-gray-50">
+          <div ref={entriesRef} data-testid="activity-log-entries" className="h-48 lg:h-96 overflow-y-auto p-3 bg-gray-50">
             {visibleLogs.length === 0 ? (
               <p className="text-gray-500 text-center text-sm mt-8">No activities yet</p>
             ) : (

--- a/packages/app/src/components/ReplayControls.tsx
+++ b/packages/app/src/components/ReplayControls.tsx
@@ -1,4 +1,5 @@
 import { useGameStore } from '../store/gameStore';
+import { summarizeHistoryMove } from '../ai';
 
 /**
  * ReplayControls component - Controls for replay mode
@@ -32,6 +33,10 @@ const ReplayControls: React.FC = () => {
   const progressPercentage = totalMoves > 0 ? (replayIndex / totalMoves) * 100 : 0;
   const isAtStart = replayIndex === 0;
   const isAtEnd = replayIndex >= totalMoves;
+
+  // The move that was just applied at the current replay position.
+  const currentMove = replayIndex > 0 ? moveHistory[replayIndex - 1] : undefined;
+  const currentIsAIMove = typeof currentMove?.aiReasoning === 'string';
 
   const handleProgressClick = (e: React.MouseEvent<HTMLDivElement>) => {
     const rect = e.currentTarget.getBoundingClientRect();
@@ -79,6 +84,40 @@ const ReplayControls: React.FC = () => {
           />
         </div>
       </div>
+
+      {/* Current move, with the AI marker and reasoning when AI-played */}
+      {currentMove && (
+        <div
+          data-testid="replay-current-move"
+          className={`mb-3 text-sm rounded p-2 border ${
+            currentIsAIMove
+              ? 'bg-indigo-50 border-indigo-300'
+              : 'bg-gray-50 border-gray-200'
+          }`}
+        >
+          <div className={currentIsAIMove ? 'text-indigo-900' : 'text-gray-800'}>
+            {currentIsAIMove && (
+              <span className="mr-1" aria-label="AI move">
+                🤖
+              </span>
+            )}
+            {summarizeHistoryMove(currentMove)}
+          </div>
+          {currentIsAIMove && (
+            <div
+              data-testid="replay-ai-reasoning"
+              className="mt-1 text-xs italic text-indigo-700"
+            >
+              {currentMove.aiConfidence !== undefined && (
+                <span className="not-italic font-semibold">
+                  [{Math.round(currentMove.aiConfidence * 100)}%]{' '}
+                </span>
+              )}
+              {currentMove.aiReasoning}
+            </div>
+          )}
+        </div>
+      )}
 
       {/* Control Buttons */}
       <div className="flex items-center justify-center gap-2 mb-3">

--- a/packages/app/src/store/aiAdvisor.test.ts
+++ b/packages/app/src/store/aiAdvisor.test.ts
@@ -3,9 +3,9 @@
  * deterministic stub provider (no network, no API key).
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { useGameStore } from './gameStore';
-import { createStubProvider, setProviderOverride } from '../ai';
+import { AIError, createStubProvider, setProviderOverride } from '../ai';
 import type { AIMoveDecision } from '../ai';
 
 /** Install a stub provider that returns `decision`. */
@@ -144,15 +144,37 @@ describe('AI auto-play', () => {
     expect(useGameStore.getState().aiError).toMatch(/loop/i);
   });
 
-  it('stops auto-play when a provider error occurs', async () => {
+  it('stops auto-play when a non-transient provider error occurs', async () => {
     useStub(() => {
-      throw new Error('provider down');
+      throw new AIError('invalid_key', 'bad key');
     });
     useGameStore.setState({ aiAutoPlay: true });
     await useGameStore.getState().askAIForMove();
 
     expect(useGameStore.getState().aiAutoPlay).toBe(false);
-    expect(useGameStore.getState().aiError).toContain('provider down');
+    expect(useGameStore.getState().aiError).toContain('bad key');
+  });
+
+  it('keeps auto-play going through a transient error', async () => {
+    vi.useFakeTimers();
+    useStub(() => {
+      throw new AIError('unavailable', 'Gemini temporarily unavailable.');
+    });
+    useGameStore.setState({ aiAutoPlay: true });
+
+    const promise = useGameStore.getState().askAIForMove();
+    // Advance past the in-call retry backoffs (~15s) but not as far as the
+    // auto-play re-attempt cooldown (~12s after the failure), so we observe
+    // the post-failure state cleanly.
+    await vi.advanceTimersByTimeAsync(20_000);
+    await promise;
+
+    // A transient failure must NOT stop auto-play: it schedules a re-attempt.
+    expect(useGameStore.getState().aiAutoPlay).toBe(true);
+    expect(useGameStore.getState().aiError).toMatch(/retr/i);
+
+    vi.useRealTimers();
+    useGameStore.getState().toggleAIAutoPlay(); // stop the loop + pending timer
   });
 });
 
@@ -178,16 +200,16 @@ describe('setAIConfig', () => {
   });
 
   it('keeps provider, model and seeHiddenCards when applying a preset', () => {
-    useGameStore.getState().setAIConfig({ model: 'gemini-2.5-flash', seeHiddenCards: true });
+    useGameStore.getState().setAIConfig({ model: 'gemini-3.1-flash-lite', seeHiddenCards: true });
     useGameStore.getState().setAIConfig({ preset: 'detailed' });
     const config = useGameStore.getState().aiConfig!;
-    expect(config.model).toBe('gemini-2.5-flash');
+    expect(config.model).toBe('gemini-3.1-flash-lite');
     expect(config.seeHiddenCards).toBe(true);
   });
 
   it('preserves the AI config across a new game', () => {
-    useGameStore.getState().setAIConfig({ model: 'gemini-2.5-pro' });
+    useGameStore.getState().setAIConfig({ model: 'gemma-4-26b-a4b-it' });
     useGameStore.getState().initializeGame(2);
-    expect(useGameStore.getState().aiConfig?.model).toBe('gemini-2.5-pro');
+    expect(useGameStore.getState().aiConfig?.model).toBe('gemma-4-26b-a4b-it');
   });
 });

--- a/packages/app/src/store/gameStore.ts
+++ b/packages/app/src/store/gameStore.ts
@@ -27,13 +27,18 @@ import {
   AI_DECISION_LOG_LIMIT,
   AI_AUTO_MOVE_DELAY,
   AI_AUTO_HISTORY_LIMIT,
+  AI_AUTO_RETRY_COOLDOWN,
+  AI_RETRY_MAX_ATTEMPTS,
   DEFAULT_AI_CONFIG,
   applyPreset,
   buildContext,
   buildSystemInstruction,
   describeMoveCommand,
   getEffectiveKey,
+  getLastAIDiagnostics,
   getProvider,
+  isTransientAIError,
+  suggestMoveWithRetry,
 } from '../ai';
 import type { AIConfig, AIDecisionRecord } from '../ai';
 
@@ -178,6 +183,7 @@ const initializeGameState = (
     autoPlayInProgress: false,
     autoPlayStateHistory: [],
     difficulty,
+    seed,
     gameWon: false,
     initialBoardSetup,
     perceivedDifficulty: undefined, // Will be calculated below
@@ -190,6 +196,8 @@ const initializeGameState = (
     aiThinking: false,
     aiAutoPlay: false,
     aiThinkingSince: undefined,
+    aiStatus: undefined,
+    aiRetryCount: 0,
     aiError: undefined,
     aiDecisionLog: [],
     aiKeyModalOpen: false,
@@ -567,6 +575,11 @@ export const useGameStore = create<GameStore>((set, get) => ({
       autoPlayEnabled: state.autoPlayEnabled,
       autoPlayInProgress: state.autoPlayInProgress,
       difficulty: state.difficulty,
+      // Deal seed and AI config travel with the save so an exported game is
+      // repeatable (re-deal the same board) and self-describing (which model
+      // and settings played it).
+      seed: state.seed,
+      aiConfig: state.aiConfig,
       gameWon: state.gameWon,
       initialBoardSetup: state.initialBoardSetup,
       perceivedDifficulty: state.perceivedDifficulty,
@@ -575,6 +588,9 @@ export const useGameStore = create<GameStore>((set, get) => ({
       replayIndex: state.replayIndex,
       replayPaused: state.replayPaused,
       replaySpeed: state.replaySpeed,
+      // The AI decision log travels with the save so an exported game is a
+      // complete record of how the AI played, for replay and benchmarking.
+      aiDecisionLog: state.aiDecisionLog,
     };
     return JSON.stringify(exportState, null, 2);
   },
@@ -623,6 +639,8 @@ export const useGameStore = create<GameStore>((set, get) => ({
         autoPlayEnabled: importedState.autoPlayEnabled,
         autoPlayInProgress: false,
         difficulty: importedState.difficulty,
+        seed: importedState.seed,
+        aiConfig: importedState.aiConfig ?? get().aiConfig ?? DEFAULT_AI_CONFIG,
         gameWon: false, // Always set to false to allow replay even for won games
         initialBoardSetup: importedState.initialBoardSetup,
         perceivedDifficulty,
@@ -631,8 +649,11 @@ export const useGameStore = create<GameStore>((set, get) => ({
         replayIndex: 0,
         replayPaused: false,
         replaySpeed: importedState.replaySpeed ?? 1000,
+        // Restore the AI decision log if the save carries one (older saves
+        // and non-AI games simply have none).
+        aiDecisionLog: importedState.aiDecisionLog ?? [],
       });
-      
+
       return true;
     } catch (error) {
       console.error('Error importing game state:', error);
@@ -1154,16 +1175,40 @@ export const useGameStore = create<GameStore>((set, get) => ({
 
     // --- Begin the request ---
     aiAbortController = new AbortController();
-    set({ aiThinking: true, aiThinkingSince: Date.now(), aiError: undefined });
+    const requestStartedAt = Date.now();
+    set({
+      aiThinking: true,
+      aiThinkingSince: requestStartedAt,
+      aiStatus: undefined,
+      aiRetryCount: 0,
+      aiError: undefined,
+    });
 
     try {
-      const decision = await provider.suggestMove({
-        apiKey: apiKey ?? '',
-        model: config.model,
-        systemInstruction,
-        context,
-        signal: aiAbortController.signal,
-      });
+      // Retry transient failures (flaky network, rate limits, 5xx responses,
+      // the occasional unparseable answer) with exponential backoff.
+      const decision = await suggestMoveWithRetry(
+        provider,
+        {
+          apiKey: apiKey ?? '',
+          model: config.model,
+          systemInstruction,
+          context,
+          signal: aiAbortController.signal,
+        },
+        {
+          maxAttempts: AI_RETRY_MAX_ATTEMPTS,
+          signal: aiAbortController.signal,
+          onRetry: ({ attempt, maxAttempts, error, delayMs }) => {
+            set({
+              aiRetryCount: attempt,
+              aiStatus:
+                `${error.message} Retrying ${attempt + 1}/${maxAttempts} ` +
+                `in ${Math.round(delayMs / 1000)}s.`,
+            });
+          },
+        },
+      );
 
       // Defensive: the provider already range-checked moveIndex, but never
       // index a move list with an unverified value.
@@ -1193,7 +1238,10 @@ export const useGameStore = create<GameStore>((set, get) => ({
         set({ moveHistory: annotated });
       }
 
-      // Record the decision (drives the advisor panel + the reasoning trail).
+      // Record the decision. This drives the advisor panel and the reasoning
+      // trail, is exported with the game, and carries enough cost/choice
+      // detail to serve as a benchmarking dataset row.
+      const diag = getLastAIDiagnostics();
       const record: AIDecisionRecord = {
         timestamp: Date.now(),
         moveType: command.type,
@@ -1205,11 +1253,32 @@ export const useGameStore = create<GameStore>((set, get) => ({
             ? describeMoveCommand(legalMoves[decision.alternativeMoveIndex], state)
             : undefined,
         model: config.model,
+        moveIndex: decision.moveIndex,
+        legalMoveCount: legalMoves.length,
+        durationMs: Date.now() - requestStartedAt,
+        retries: get().aiRetryCount ?? 0,
+        promptTokens: diag?.promptTokens,
+        thoughtTokens: diag?.thoughtTokens,
+        outputTokens: diag?.outputTokens,
+        totalTokens: diag?.totalTokens,
       };
       const aiDecisionLog = [...(get().aiDecisionLog ?? []), record].slice(
         -AI_DECISION_LOG_LIMIT,
       );
-      set({ aiThinking: false, aiThinkingSince: undefined, aiDecisionLog, aiError: undefined });
+      set({
+        aiThinking: false,
+        aiThinkingSince: undefined,
+        aiStatus: undefined,
+        aiDecisionLog,
+        aiError: undefined,
+      });
+
+      // Diagnostic: total time for this move, including any retries.
+      const retries = get().aiRetryCount ?? 0;
+      console.info(
+        `[AI] move applied in ${((Date.now() - requestStartedAt) / 1000).toFixed(1)}s` +
+          (retries > 0 ? ` after ${retries} retr${retries === 1 ? 'y' : 'ies'}` : ''),
+      );
 
       // If AI auto-play is engaged, queue the next move.
       if (get().aiAutoPlay) {
@@ -1218,7 +1287,12 @@ export const useGameStore = create<GameStore>((set, get) => ({
     } catch (err) {
       // A user-initiated cancel is not an error worth surfacing.
       if (err instanceof AIError && err.kind === 'aborted') {
-        set({ aiThinking: false, aiThinkingSince: undefined, aiError: undefined });
+        set({
+          aiThinking: false,
+          aiThinkingSince: undefined,
+          aiStatus: undefined,
+          aiError: undefined,
+        });
         return;
       }
       const message =
@@ -1227,8 +1301,33 @@ export const useGameStore = create<GameStore>((set, get) => ({
           : err instanceof Error
             ? err.message
             : 'Unexpected AI error.';
-      // Any error stops AI auto-play — never hammer the API on failure.
-      set({ aiThinking: false, aiThinkingSince: undefined, aiError: message, aiAutoPlay: false });
+
+      // In auto-play, a transient (infrastructure) failure must not stop the
+      // run. The retries above are already exhausted, so cool down and
+      // re-attempt the move. LLM endpoints are not always stable.
+      if (get().aiAutoPlay && isTransientAIError(err)) {
+        set({
+          aiThinking: false,
+          aiThinkingSince: undefined,
+          aiStatus: undefined,
+          aiError: `${message} Auto-play retries in ${Math.round(AI_AUTO_RETRY_COOLDOWN / 1000)}s.`,
+        });
+        setTimeout(() => {
+          if (get().aiAutoPlay && !get().aiThinking) {
+            void get().askAIForMove();
+          }
+        }, AI_AUTO_RETRY_COOLDOWN);
+        return;
+      }
+
+      // Otherwise stop: a non-transient error, or a manual single request.
+      set({
+        aiThinking: false,
+        aiThinkingSince: undefined,
+        aiStatus: undefined,
+        aiError: message,
+        aiAutoPlay: false,
+      });
     } finally {
       aiAbortController = null;
     }

--- a/packages/app/src/testBridge.ts
+++ b/packages/app/src/testBridge.ts
@@ -20,8 +20,13 @@
 
 import { useGameStore } from './store/gameStore';
 import { scenarios, scenarioNames, isScenarioName } from './testScenarios';
-import { createStubProvider, DEFAULT_AI_CONFIG, setProviderOverride } from './ai';
-import type { AIConfig, StubDecisionFn } from './ai';
+import {
+  createStubProvider,
+  DEFAULT_AI_CONFIG,
+  getAIDiagnostics as readAIDiagnostics,
+  setProviderOverride,
+} from './ai';
+import type { AIConfig, AIDiagnostics, StubDecisionFn } from './ai';
 import type { Card, Difficulty, GameState, Suit } from './types';
 
 /** Compact, token-efficient game snapshot for agents. */
@@ -128,6 +133,8 @@ export interface SolitaireTestBridge {
   // --- AI Move Advisor ---
   /** Compact AI-advisor state snapshot. */
   getAIState: () => AIBridgeState;
+  /** Time/token diagnostics for recent AI API calls (most recent last). */
+  getAIDiagnostics: () => AIDiagnostics[];
   /**
    * Ask the AI advisor for a move. Resolves once the move is applied or the
    * request fails (inspect `getAIState().error`).
@@ -262,6 +269,7 @@ export function installTestBridge(): void {
       };
     },
     askAI: () => useGameStore.getState().askAIForMove(),
+    getAIDiagnostics: () => [...readAIDiagnostics()],
     toggleAIAutoPlay: () => useGameStore.getState().toggleAIAutoPlay(),
     cancelAI: () => useGameStore.getState().cancelAIRequest(),
     setAIConfig: (patch) => useGameStore.getState().setAIConfig(patch),

--- a/packages/app/src/types/index.ts
+++ b/packages/app/src/types/index.ts
@@ -68,6 +68,7 @@ export interface GameState {
   autoPlayInProgress: boolean;
   autoPlayStateHistory?: string[]; // Track recent game states for loop detection
   difficulty: Difficulty; // Game difficulty level (1=Very Easy, 2=Easy, 3=Normal, 4=Hard, 5=Very Hard)
+  seed?: number; // RNG seed for the deal, when one was used (enables a repeatable re-deal)
   gameWon: boolean; // True when all cards are in foundations
   initialBoardSetup?: {
     drawPile: Card[];
@@ -94,6 +95,8 @@ export interface GameState {
   aiThinking?: boolean; // True while an AI move suggestion is in flight
   aiAutoPlay?: boolean; // True while the AI is auto-playing the whole game move-by-move
   aiThinkingSince?: number; // Timestamp the in-flight request started (for the elapsed counter)
+  aiStatus?: string; // Soft status line shown while a request is in flight (e.g. retry progress)
+  aiRetryCount?: number; // Retries performed for the in-flight/last request
   aiError?: string; // Last AI advisor error message, shown until the next request
   aiDecisionLog?: AIDecisionRecord[]; // History of AI decisions (most recent last)
   aiKeyModalOpen?: boolean; // True when the API key modal is open


### PR DESCRIPTION
## Summary

Hardens the AI Move Advisor against unstable LLM endpoints and captures more data for replay and future benchmarking.

## Resilience

- Transient failures (network errors, timeouts, rate limits, 5xx responses, an unparseable answer) are retried with exponential backoff before an error is surfaced.
- AI auto-play no longer stops on a transient failure: it cools down and re-attempts the move, so a flaky API does not end the run. Non-transient errors (invalid key, misconfiguration) still stop it.

## Diagnostics

- Time taken and token usage are recorded per API call, to the console and an in-memory ring buffer readable via the test bridge (`getAIDiagnostics`).
- The advisor panel shows the retry count and retry status while a request is in flight.

## Logging, replay and export

- The activity log auto-scrolls so the newest entry stays visible.
- The replay controls show the current move and, for AI moves, the reasoning and confidence.
- Exported games now include the deck seed, the AI configuration, and the full AI decision log (chosen move, reasoning, confidence, duration, token cost), so a game is repeatable and self-describing.

## Other

- Models offered: `gemma-4-31b-it`, `gemma-4-26b-a4b-it`, `gemini-3.1-flash-lite`.
- The context payload now numbers tableau columns 1 to 7 explicitly, so the model's reasoning uses the same column numbers as the move log (previously the model sometimes used 0-based numbers, mismatching the log).
- Fixed an em-dash in the advisor waiting note.

## Tests

- New unit tests for retry/backoff and diagnostics; store tests for auto-play surviving a transient error.
- New E2E coverage for AI auto-play, the export contents, diagnostics, and replay AI markers.
- Lint, typecheck, 232 unit tests, the E2E suite, and the production build pass locally. The provider was also verified end to end against the live model.

## Test plan

- [ ] CI green (lint, test, build, e2e)