### PR TITLE
feat: game id in title, build commit in logs and exports

### DIFF
--- a/packages/app/e2e/ai-advisor.spec.ts
+++ b/packages/app/e2e/ai-advisor.spec.ts
@@ -15,6 +15,8 @@ test.describe('AI Move Advisor', () => {
 
     await expect(page.getByTestId('ai-advisor-panel')).toBeVisible();
     await expect(page.getByTestId('ask-ai-btn')).toBeVisible();
+    // The title shows a short game id for traceability.
+    await expect(page.getByTestId('game-id')).toContainText('Game #');
   });
 
   test('asks the AI, applies the chosen move, and logs the reasoning', async ({ page }) => {
@@ -149,6 +151,7 @@ test.describe('AI Move Advisor', () => {
     );
     expect(exported.seed).toBe(7);
     expect(exported.gameSessionId).toBeTruthy();
+    expect(exported.appCommit).toBeTruthy();
     expect(exported.aiConfig?.model).toBeTruthy();
     expect(exported.aiDecisionLog).toHaveLength(1);
     expect(exported.aiDecisionLog[0].reasoning).toContain('export-log check');
@@ -191,6 +194,8 @@ test.describe('AI Move Advisor', () => {
     );
     expect(exported.count).toBeGreaterThanOrEqual(1);
     expect(exported.interactions[0].requestId).toBeTruthy();
+    expect(exported.appCommit).toBeTruthy();
+    expect(exported.interactions[0].appCommit).toBeTruthy();
   });
 
   test('replay surfaces which moves were made by the AI', async ({ page }) => {

--- a/packages/app/src/ai/interactionLog.test.ts
+++ b/packages/app/src/ai/interactionLog.test.ts
@@ -38,9 +38,12 @@ describe('interactionLog', () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
-  it('records and returns an interaction', () => {
+  it('records an interaction, stamped with the build commit', () => {
     recordAIInteraction(base);
-    expect(getAIInteractions()).toEqual([base]);
+    const stored = getAIInteractions();
+    expect(stored).toHaveLength(1);
+    expect(stored[0]).toMatchObject(base);
+    expect(stored[0].appCommit).toBeTruthy();
   });
 
   it('getLastAIInteraction returns the most recent entry', () => {
@@ -76,13 +79,16 @@ describe('interactionLog', () => {
     expect(getLastAIInteraction()?.timestamp).toBe(AI_INTERACTION_LOG_LIMIT + 24);
   });
 
-  it('exportAIInteractions returns JSON with a count and the entries', () => {
+  it('exportAIInteractions returns JSON with metadata and the entries', () => {
     recordAIInteraction(base);
     const parsed = JSON.parse(exportAIInteractions());
     expect(parsed.count).toBe(1);
     expect(parsed.interactions).toHaveLength(1);
     expect(parsed.interactions[0].requestId).toBe('req-abcdef12');
     expect(typeof parsed.exportedAt).toBe('string');
+    // The export is stamped with the build commit for traceability.
+    expect(typeof parsed.appCommit).toBe('string');
+    expect(typeof parsed.appBuildTime).toBe('string');
   });
 
   it('clearAIInteractions empties the buffer', () => {

--- a/packages/app/src/ai/interactionLog.ts
+++ b/packages/app/src/ai/interactionLog.ts
@@ -10,6 +10,7 @@
  * @module ai/interactionLog
  */
 
+import { APP_BUILD_TIME, APP_COMMIT } from '../buildInfo';
 import { AI_INTERACTION_LOG_LIMIT } from './constants';
 import type { AIErrorKind, AIMoveDecision } from './types';
 
@@ -29,6 +30,8 @@ export interface AIInteraction {
   provider: string;
   /** Model id. */
   model: string;
+  /** Git commit hash of the build that produced this interaction. */
+  appCommit?: string;
   /** Deal seed of the game, when one was used. */
   seed?: number;
   /** Turn index within the game (move-history length at request time). */
@@ -65,7 +68,11 @@ const buffer: AIInteraction[] = [];
 
 /** Record an interaction: append to the ring buffer and log a console summary. */
 export function recordAIInteraction(entry: AIInteraction): void {
-  buffer.push(entry);
+  // Stamp the build commit so a harvested row traces back to its code revision.
+  const stamped: AIInteraction = entry.appCommit
+    ? entry
+    : { ...entry, appCommit: APP_COMMIT };
+  buffer.push(stamped);
   if (buffer.length > AI_INTERACTION_LOG_LIMIT) buffer.shift();
 
   const seconds = (entry.durationMs / 1000).toFixed(1);
@@ -105,6 +112,8 @@ export function exportAIInteractions(): string {
   return JSON.stringify(
     {
       exportedAt: new Date().toISOString(),
+      appCommit: APP_COMMIT,
+      appBuildTime: APP_BUILD_TIME,
       count: buffer.length,
       interactions: buffer,
     },

--- a/packages/app/src/buildInfo.ts
+++ b/packages/app/src/buildInfo.ts
@@ -1,0 +1,16 @@
+/**
+ * Build metadata, injected at build time by Vite (see `vite.config.ts`).
+ *
+ * Used to stamp exported data so a harvested log or save can be traced back to
+ * the exact code revision that produced it.
+ *
+ * @module buildInfo
+ */
+
+/** Short git commit hash of the running build (`unknown` if unavailable). */
+export const APP_COMMIT: string =
+  typeof __COMMIT_HASH__ === 'string' ? __COMMIT_HASH__ : 'unknown';
+
+/** ISO timestamp of when the running build was produced. */
+export const APP_BUILD_TIME: string =
+  typeof __BUILD_TIME__ === 'string' ? __BUILD_TIME__ : 'unknown';

--- a/packages/app/src/components/AISettingsSection.tsx
+++ b/packages/app/src/components/AISettingsSection.tsx
@@ -30,6 +30,7 @@ const AISettingsSection: React.FC = () => {
   const setAIConfig = useGameStore((s) => s.setAIConfig);
   const setAIKeyModalOpen = useGameStore((s) => s.setAIKeyModalOpen);
   const exportAIInteractions = useGameStore((s) => s.exportAIInteractions);
+  const gameSessionId = useGameStore((s) => s.gameSessionId);
   const [expanded, setExpanded] = useState(false);
 
   /** Download the full LLM interaction log as a JSON file. */
@@ -39,7 +40,8 @@ const AISettingsSection: React.FC = () => {
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = url;
-    link.download = `solitaire-ai-log-${Date.now()}.json`;
+    const idTag = gameSessionId ? `${gameSessionId.slice(-6)}-` : '';
+    link.download = `solitaire-ai-log-${idTag}${Date.now()}.json`;
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);

--- a/packages/app/src/components/ControlPanel.tsx
+++ b/packages/app/src/components/ControlPanel.tsx
@@ -21,6 +21,7 @@ const ControlPanel: React.FC = () => {
   const aiThinking = useGameStore((state) => state.aiThinking);
   const aiAutoPlay = useGameStore((state) => state.aiAutoPlay);
   const gameWon = useGameStore((state) => state.gameWon);
+  const gameSessionId = useGameStore((state) => state.gameSessionId);
   const moveCount = useGameStore((state) => state.moveHistory.length);
   const difficulty = useGameStore((state) => state.difficulty);
   const perceivedDifficulty = useGameStore((state) => state.perceivedDifficulty);
@@ -34,7 +35,8 @@ const ControlPanel: React.FC = () => {
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = url;
-    link.download = `solitaire-game-${Date.now()}.json`;
+    const idTag = gameSessionId ? `${gameSessionId.slice(-6)}-` : '';
+    link.download = `solitaire-game-${idTag}${Date.now()}.json`;
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);

--- a/packages/app/src/components/GameBoard.tsx
+++ b/packages/app/src/components/GameBoard.tsx
@@ -1,5 +1,6 @@
 import { motion } from 'framer-motion';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
+import { useGameStore } from '../store/gameStore';
 import DrawPile from './DrawPile';
 import DiscardPile from './DiscardPile';
 import FoundationPile from './FoundationPile';
@@ -15,6 +16,19 @@ import { shouldReduceMotion as checkReducedMotion } from '../utils/motion';
 const GameBoard: React.FC = () => {
   // Check for reduced motion preference
   const shouldReduceMotion = useMemo(() => checkReducedMotion(), []);
+
+  // Short game identifier: the seed (when the deal was seeded) and the last 6
+  // characters of the session UUID. Shown under the title and in the tab.
+  const gameSessionId = useGameStore((s) => s.gameSessionId);
+  const seed = useGameStore((s) => s.seed);
+  const shortId = gameSessionId ? gameSessionId.slice(-6) : null;
+  const gameLabel = shortId
+    ? `#${shortId}${seed !== undefined ? ` · seed ${seed}` : ''}`
+    : null;
+
+  useEffect(() => {
+    document.title = gameLabel ? `Solitaire ${gameLabel}` : 'Solitaire';
+  }, [gameLabel]);
 
   // Deal animation variants for tableau columns
   const dealVariants = shouldReduceMotion ? undefined : {
@@ -50,15 +64,25 @@ const GameBoard: React.FC = () => {
         {/* Center - Game Area */}
         <div className="flex-1 min-w-0 order-1 lg:order-2">
           <div className="max-w-5xl mx-auto">
-            <motion.h1 
-              className="text-2xl sm:text-3xl lg:text-4xl font-bold text-white text-center mb-4 lg:mb-6"
+            <motion.div
+              className="text-center mb-4 lg:mb-6"
               initial={shouldReduceMotion ? {} : { opacity: 0, y: -20 }}
               animate={shouldReduceMotion ? {} : { opacity: 1, y: 0 }}
               transition={{ duration: 0.5 }}
             >
-              Solitaire
-            </motion.h1>
-            
+              <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-white">
+                Solitaire
+              </h1>
+              {gameLabel && (
+                <p
+                  data-testid="game-id"
+                  className="text-xs sm:text-sm font-mono text-green-200/80 mt-0.5"
+                >
+                  Game {gameLabel}
+                </p>
+              )}
+            </motion.div>
+
             {/* Replay Controls */}
             <ReplayControls />
             

--- a/packages/app/src/store/gameStore.ts
+++ b/packages/app/src/store/gameStore.ts
@@ -45,6 +45,7 @@ import {
   uuidv7,
 } from '../ai';
 import type { AIConfig, AIDecisionRecord } from '../ai';
+import { APP_BUILD_TIME, APP_COMMIT } from '../buildInfo';
 
 /** Shared core engine instance — used for legal-move generation by the AI advisor. */
 const engine = new GameEngine();
@@ -602,7 +603,13 @@ export const useGameStore = create<GameStore>((set, get) => ({
       // complete record of how the AI played, for replay and benchmarking.
       aiDecisionLog: state.aiDecisionLog,
     };
-    return JSON.stringify(exportState, null, 2);
+    // Stamp the build commit so an exported game traces back to its code
+    // revision (the GameState fields are unchanged for import compatibility).
+    return JSON.stringify(
+      { ...exportState, appCommit: APP_COMMIT, appBuildTime: APP_BUILD_TIME },
+      null,
+      2,
+    );
   },
   
   importGameState: (jsonString: string) => {


### PR DESCRIPTION
## Summary

Adds traceability to harvested data, exports, and the UI.

## Game id in the title

The title now shows a short game id — the last 6 characters of the session UUID, plus the seed when the deal was seeded (e.g. `Game #a1b2c3 · seed 7`). The browser tab title carries it too, so screenshots and tabs are identifiable.

## Build commit in the logs and exports

- Every logged LLM interaction is stamped with the build's git commit hash.
- The interaction-log export and the game export both carry `appCommit` and `appBuildTime`, so any harvested file traces back to the exact code revision that produced it.
- (The UI footer already showed the commit; this extends it into the data pipeline.)

## Game id in export filenames

Downloaded files now include the game id: `solitaire-game-<id>-<timestamp>.json` and `solitaire-ai-log-<id>-<timestamp>.json`.

## Tests

- Updated unit tests for the commit-stamping and export envelope.
- E2E asserts the title shows a game id and that exports carry `appCommit`.
- Lint, typecheck, 245 unit tests, the full E2E suite, and the production build pass locally (production bundle verified free of the dev key).

## Test plan

- [ ] CI green (lint, test, build, e2e)