### PR TITLE
fix: AI owns every move during AI play; tab-title status flag

### DIFF
--- a/packages/app/src/components/GameBoard.tsx
+++ b/packages/app/src/components/GameBoard.tsx
@@ -26,9 +26,19 @@ const GameBoard: React.FC = () => {
     ? `#${shortId}${seed !== undefined ? ` · seed ${seed}` : ''}`
     : null;
 
+  // Tab-title status flag, so many unattended tabs can be triaged at a glance:
+  //  🏆 game won · ⚠️ AI stopped and needs attention · 🤖 AI auto-playing.
+  const gameWon = useGameStore((s) => s.gameWon);
+  const aiError = useGameStore((s) => s.aiError);
+  const aiThinking = useGameStore((s) => s.aiThinking);
+  const aiAutoPlay = useGameStore((s) => s.aiAutoPlay);
+  const aiStopped = Boolean(aiError) && !aiThinking && !aiAutoPlay;
+  const titlePrefix = gameWon ? '🏆 ' : aiStopped ? '⚠️ ' : aiAutoPlay ? '🤖 ' : '';
+
   useEffect(() => {
-    document.title = gameLabel ? `Solitaire ${gameLabel}` : 'Solitaire';
-  }, [gameLabel]);
+    const base = gameLabel ? `Solitaire ${gameLabel}` : 'Solitaire';
+    document.title = `${titlePrefix}${base}`;
+  }, [titlePrefix, gameLabel]);
 
   // Deal animation variants for tableau columns
   const dealVariants = shouldReduceMotion ? undefined : {

--- a/packages/app/src/store/aiAdvisor.test.ts
+++ b/packages/app/src/store/aiAdvisor.test.ts
@@ -13,6 +13,7 @@ import {
   setProviderOverride,
 } from '../ai';
 import type { AIMoveDecision } from '../ai';
+import { scenarios } from '../testScenarios';
 
 /** Install a stub provider that returns `decision`. */
 function useStub(decision: AIMoveDecision | (() => never)): void {
@@ -241,6 +242,30 @@ describe('setAIConfig', () => {
     useGameStore.getState().setAIConfig({ model: 'gemma-4-26b-a4b-it' });
     useGameStore.getState().initializeGame(2);
     expect(useGameStore.getState().aiConfig?.model).toBe('gemma-4-26b-a4b-it');
+  });
+});
+
+describe('heuristic auto-complete vs AI play', () => {
+  afterEach(() => {
+    useGameStore.setState({ autoPlayEnabled: false, aiAutoPlay: false, aiThinking: false });
+  });
+
+  it('does not let heuristic auto-complete hijack an AI-driven game', () => {
+    // An auto-completable board; without AI activity the heuristic engages.
+    useGameStore.getState().importGameState(JSON.stringify(scenarios.autoCompleteReady()));
+    useGameStore.setState({ aiAutoPlay: false, aiThinking: false });
+    useGameStore.getState().checkAndTriggerAutoComplete();
+    expect(useGameStore.getState().autoPlayEnabled).toBe(true);
+
+    // With AI play in progress, the heuristic must stand down.
+    useGameStore.getState().importGameState(JSON.stringify(scenarios.autoCompleteReady()));
+    useGameStore.setState({ autoPlayEnabled: false, aiAutoPlay: true });
+    useGameStore.getState().checkAndTriggerAutoComplete();
+    expect(useGameStore.getState().autoPlayEnabled).toBe(false);
+
+    useGameStore.setState({ aiAutoPlay: false, aiThinking: true });
+    useGameStore.getState().checkAndTriggerAutoComplete();
+    expect(useGameStore.getState().autoPlayEnabled).toBe(false);
   });
 });
 

--- a/packages/app/src/store/gameStore.ts
+++ b/packages/app/src/store/gameStore.ts
@@ -881,9 +881,12 @@ export const useGameStore = create<GameStore>((set, get) => ({
 
   checkAndTriggerAutoComplete: () => {
     const state = get();
-    
-    // Don't trigger if already won or if auto-play is already active
-    if (state.gameWon || state.autoPlayEnabled) {
+
+    // Don't trigger if already won, if auto-play is already active, or if the
+    // AI is driving the game. During AI play (a single Ask AI request or AI
+    // auto-play) the AI owns every move — the heuristic auto-complete must not
+    // hijack it, or AI auto-play stalls and end-game moves go unlogged.
+    if (state.gameWon || state.autoPlayEnabled || state.aiThinking || state.aiAutoPlay) {
       return;
     }
     


### PR DESCRIPTION
## Summary

Two related changes for unattended AI auto-play.

## Heuristic auto-complete no longer interferes with AI play

`checkAndTriggerAutoComplete` runs after every move and only checked `gameWon || autoPlayEnabled`. So when an AI move made the board auto-completable, the heuristic auto-play turned itself on and **hijacked the rest of the game** — AI auto-play then stalled on its next tick ("Cannot ask the AI while auto-play is running"), and the end-game moves were played by the heuristic and left unlogged as AI decisions.

This was confirmed in a real export: an AI move (with reasoning) was immediately followed by `autoplay_start` and then non-AI `tableau_to_foundation` moves.

Fix: `checkAndTriggerAutoComplete` now also stands down while `aiThinking` or `aiAutoPlay` is active. During AI play the AI owns every move, end to end — including the trivial end-game — and every move is logged.

## Tab-title status flag

For triaging many unattended auto-play tabs at a glance, the browser tab title is now prefixed with a status emoji:

- ⚠️ — AI stopped and needs attention (stuck loop, or a non-recoverable error)
- 🏆 — game won
- 🤖 — AI auto-playing

A plain title means idle. The flag clears on the next action or a new game.

## Tests

- New store test: the heuristic auto-complete fires for a human-driven auto-completable board but stands down when `aiAutoPlay`/`aiThinking` is set.
- Lint, typecheck, 246 unit tests, the full E2E suite, and the production build pass locally.

## Test plan

- [ ] CI green (lint, test, build, e2e)