### PR TITLE
feat: dismissable win modal with an Export AI Log button

### DIFF
--- a/packages/app/e2e/user-journey.spec.ts
+++ b/packages/app/e2e/user-journey.spec.ts
@@ -52,4 +52,23 @@ test.describe('User journey: winning the game', () => {
     expect(s.foundationTotal).toBe(0);
     expect(s.tableauSizes).toEqual([1, 2, 3, 4, 5, 6, 7]);
   });
+
+  test('the win modal can be dismissed without starting a new game', async ({ page }) => {
+    await page.goto('/');
+    await waitForGame(page);
+    await loadScenario(page, 'oneMoveFromWinning');
+
+    await page.getByTestId('card-spades-K').click();
+    await page.getByTestId('foundation-spades').click();
+    await expect(page.getByTestId('win-modal')).toBeVisible();
+
+    // Closing the modal hides it but does NOT reset the game, so the won
+    // game (and its AI log) can still be exported.
+    await page.getByTestId('win-modal-close-btn').click();
+    await expect(page.getByTestId('win-modal')).toBeHidden();
+
+    const s = await summary(page);
+    expect(s.gameWon).toBe(true);
+    expect(s.foundationTotal).toBe(52);
+  });
 });

--- a/packages/app/src/adapters/coreAdapter.ts
+++ b/packages/app/src/adapters/coreAdapter.ts
@@ -89,6 +89,7 @@ export function coreToUI(coreState: CoreGameState, existingUIState: UIGameState)
     seed: existingUIState.seed,
     gameSessionId: existingUIState.gameSessionId,
     gameStartedAt: existingUIState.gameStartedAt,
+    winModalDismissed: existingUIState.winModalDismissed,
     showValidMoves: existingUIState.showValidMoves,
     godMode: existingUIState.godMode,
     autoPlayEnabled: existingUIState.autoPlayEnabled,
@@ -122,6 +123,7 @@ export function getDefaultUIFields(): Pick<
   | 'seed'
   | 'gameSessionId'
   | 'gameStartedAt'
+  | 'winModalDismissed'
   | 'showValidMoves'
   | 'godMode'
   | 'autoPlayEnabled'
@@ -146,6 +148,7 @@ export function getDefaultUIFields(): Pick<
     seed: undefined,
     gameSessionId: undefined,
     gameStartedAt: undefined,
+    winModalDismissed: false,
     showValidMoves: false,
     godMode: false,
     autoPlayEnabled: false,

--- a/packages/app/src/components/AISettingsSection.tsx
+++ b/packages/app/src/components/AISettingsSection.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useGameStore } from '../store/gameStore';
 import { DEFAULT_AI_CONFIG } from '../ai';
+import { downloadJson, gameIdTag } from '../utils/download';
 import type { AIConfig, AIContextPreset } from '../ai';
 
 /** A boolean context toggle exposed in the Custom preset. */
@@ -35,17 +36,10 @@ const AISettingsSection: React.FC = () => {
 
   /** Download the full LLM interaction log as a JSON file. */
   const handleExportAILog = () => {
-    const json = exportAIInteractions();
-    const blob = new Blob([json], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    const idTag = gameSessionId ? `${gameSessionId.slice(-6)}-` : '';
-    link.download = `solitaire-ai-log-${idTag}${Date.now()}.json`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
+    downloadJson(
+      `solitaire-ai-log-${gameIdTag(gameSessionId)}${Date.now()}.json`,
+      exportAIInteractions(),
+    );
   };
 
   return (

--- a/packages/app/src/components/ControlPanel.tsx
+++ b/packages/app/src/components/ControlPanel.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'react';
 import { useGameStore } from '../store/gameStore';
 import type { Difficulty } from '../types';
+import { downloadJson, gameIdTag } from '../utils/download';
 import AISettingsSection from './AISettingsSection';
 
 /**
@@ -30,18 +31,7 @@ const ControlPanel: React.FC = () => {
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
 
   const handleExport = () => {
-    const jsonState = exportGameState();
-    const blob = new Blob([jsonState], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    const idTag = gameSessionId ? `${gameSessionId.slice(-6)}-` : '';
-    link.download = `solitaire-game-${idTag}${Date.now()}.json`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
-    
+    downloadJson(`solitaire-game-${gameIdTag(gameSessionId)}${Date.now()}.json`, exportGameState());
     setMessage({ type: 'success', text: 'Game exported successfully!' });
     setTimeout(() => setMessage(null), 3000);
   };

--- a/packages/app/src/components/WinModal.tsx
+++ b/packages/app/src/components/WinModal.tsx
@@ -1,35 +1,37 @@
 import { motion, AnimatePresence } from 'framer-motion';
 import { useGameStore } from '../store/gameStore';
 import { shouldReduceMotion as checkReducedMotion } from '../utils/motion';
+import { downloadJson, gameIdTag } from '../utils/download';
 import { useMemo } from 'react';
 
 const WinModal: React.FC = () => {
   const gameWon = useGameStore(state => state.gameWon);
+  const winModalDismissed = useGameStore(state => state.winModalDismissed) ?? false;
   const initializeGame = useGameStore(state => state.initializeGame);
+  const dismissWinModal = useGameStore(state => state.dismissWinModal);
   const exportGameState = useGameStore(state => state.exportGameState);
+  const exportAIInteractions = useGameStore(state => state.exportAIInteractions);
+  const gameSessionId = useGameStore(state => state.gameSessionId);
   const moveHistory = useGameStore(state => state.moveHistory);
   const difficulty = useGameStore(state => state.difficulty);
   const perceivedDifficulty = useGameStore(state => state.perceivedDifficulty);
   const shouldReduceMotion = useMemo(() => checkReducedMotion(), []);
 
-  if (!gameWon) return null;
+  const showModal = gameWon && !winModalDismissed;
+  if (!showModal) return null;
 
   // Calculate statistics
   const totalMoves = moveHistory.length;
   const difficultyLabels = ['Very Easy', 'Easy', 'Normal', 'Hard', 'Very Hard'];
   const difficultyLabel = difficultyLabels[difficulty - 1] || 'Normal';
+  const idTag = gameIdTag(gameSessionId);
 
-  const handleExport = () => {
-    const jsonState = exportGameState();
-    const blob = new Blob([jsonState], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = `solitaire-win-${Date.now()}.json`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
+  const handleExportGame = () => {
+    downloadJson(`solitaire-win-${idTag}${Date.now()}.json`, exportGameState());
+  };
+
+  const handleExportAILog = () => {
+    downloadJson(`solitaire-ai-log-${idTag}${Date.now()}.json`, exportAIInteractions());
   };
 
   const backdropVariants = shouldReduceMotion ? undefined : {
@@ -38,13 +40,13 @@ const WinModal: React.FC = () => {
   };
 
   const modalVariants = shouldReduceMotion ? undefined : {
-    hidden: { 
-      opacity: 0, 
+    hidden: {
+      opacity: 0,
       scale: 0.8,
       y: -50,
     },
-    visible: { 
-      opacity: 1, 
+    visible: {
+      opacity: 1,
       scale: 1,
       y: 0,
       transition: {
@@ -69,7 +71,7 @@ const WinModal: React.FC = () => {
 
   return (
     <AnimatePresence>
-      {gameWon && (
+      {showModal && (
         <motion.div
           className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm"
           variants={backdropVariants}
@@ -79,11 +81,22 @@ const WinModal: React.FC = () => {
         >
           <motion.div
             data-testid="win-modal"
-            className="bg-white rounded-2xl shadow-2xl p-6 sm:p-8 max-w-md w-full text-center"
+            className="relative bg-white rounded-2xl shadow-2xl p-6 sm:p-8 max-w-md w-full text-center"
             variants={modalVariants}
             initial="hidden"
             animate="visible"
           >
+            {/* Dismiss without starting a new game, so the won game can still
+                be exported from the controls. */}
+            <button
+              data-testid="win-modal-close-btn"
+              onClick={dismissWinModal}
+              className="absolute top-3 right-3 text-gray-400 hover:text-gray-700 text-2xl leading-none"
+              aria-label="Close"
+            >
+              ✕
+            </button>
+
             <motion.div
               className="text-6xl mb-4"
               variants={celebrationVariants}
@@ -91,11 +104,11 @@ const WinModal: React.FC = () => {
             >
               🎉
             </motion.div>
-            
+
             <h2 className="text-3xl sm:text-4xl font-bold text-gray-800 mb-4">
               Congratulations!
             </h2>
-            
+
             <p className="text-lg text-gray-600 mb-6">
               You've successfully completed the game! All cards are in the foundations.
             </p>
@@ -103,17 +116,17 @@ const WinModal: React.FC = () => {
             {/* Game Statistics */}
             <div className="bg-gray-50 rounded-lg p-4 mb-6 space-y-3">
               <h3 className="text-xl font-semibold text-gray-800 mb-3">Game Statistics</h3>
-              
+
               <div className="flex justify-between items-center">
                 <span className="text-gray-600">Total Moves:</span>
                 <span className="text-xl font-bold text-green-600">{totalMoves}</span>
               </div>
-              
+
               <div className="flex justify-between items-center">
                 <span className="text-gray-600">Difficulty:</span>
                 <span className="text-lg font-semibold text-gray-800">{difficultyLabel}</span>
               </div>
-              
+
               {perceivedDifficulty !== undefined && (
                 <div className="flex justify-between items-center">
                   <span className="text-gray-600">Board Difficulty:</span>
@@ -122,20 +135,37 @@ const WinModal: React.FC = () => {
               )}
             </div>
 
-            <div className="flex flex-col sm:flex-row gap-3 justify-center">
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
               <button
-                onClick={handleExport}
-                className="px-6 py-3 bg-purple-600 hover:bg-purple-700 text-white font-semibold rounded-lg shadow-md transition-colors duration-200"
+                data-testid="win-export-game-btn"
+                onClick={handleExportGame}
+                className="px-4 py-3 bg-purple-600 hover:bg-purple-700 text-white font-semibold rounded-lg shadow-md transition-colors duration-200 text-sm"
               >
                 Export Game
               </button>
               <button
+                data-testid="win-export-ai-log-btn"
+                onClick={handleExportAILog}
+                className="px-4 py-3 bg-indigo-600 hover:bg-indigo-700 text-white font-semibold rounded-lg shadow-md transition-colors duration-200 text-sm"
+              >
+                Export AI Log
+              </button>
+              <button
+                data-testid="win-new-game-btn"
                 onClick={() => initializeGame()}
-                className="px-6 py-3 bg-green-600 hover:bg-green-700 text-white font-semibold rounded-lg shadow-md transition-colors duration-200"
+                className="px-4 py-3 bg-green-600 hover:bg-green-700 text-white font-semibold rounded-lg shadow-md transition-colors duration-200 text-sm"
               >
                 New Game
               </button>
             </div>
+
+            <button
+              data-testid="win-dismiss-btn"
+              onClick={dismissWinModal}
+              className="mt-3 text-sm text-gray-500 hover:text-gray-700 underline"
+            >
+              Close and keep this game
+            </button>
           </motion.div>
         </motion.div>
       )}

--- a/packages/app/src/store/gameStore.ts
+++ b/packages/app/src/store/gameStore.ts
@@ -126,6 +126,8 @@ interface GameStore extends GameState {
   setAIKeyModalOpen: (open: boolean) => void;
   /** Serialize the full LLM interaction log to a JSON string for export. */
   exportAIInteractions: () => string;
+  /** Dismiss the win modal without starting a new game. */
+  dismissWinModal: () => void;
 }
 
 /**
@@ -194,6 +196,7 @@ const initializeGameState = (
     gameSessionId: uuidv7(),
     gameStartedAt: Date.now(),
     gameWon: false,
+    winModalDismissed: false,
     initialBoardSetup,
     perceivedDifficulty: undefined, // Will be calculated below
     completionProgress: 0, // Start at 0% completion
@@ -1453,4 +1456,8 @@ export const useGameStore = create<GameStore>((set, get) => ({
   },
 
   exportAIInteractions: () => serializeAIInteractions(),
+
+  dismissWinModal: () => {
+    set({ winModalDismissed: true });
+  },
 }));

--- a/packages/app/src/types/index.ts
+++ b/packages/app/src/types/index.ts
@@ -72,6 +72,7 @@ export interface GameState {
   gameSessionId?: string; // UUIDv7 identifying this game session (new id per new game)
   gameStartedAt?: number; // Timestamp the session's deal was created
   gameWon: boolean; // True when all cards are in foundations
+  winModalDismissed?: boolean; // True when the user closed the win modal without starting a new game
   initialBoardSetup?: {
     drawPile: Card[];
     discardPile: Card[];

--- a/packages/app/src/utils/download.ts
+++ b/packages/app/src/utils/download.ts
@@ -1,0 +1,23 @@
+/**
+ * Browser file-download helper.
+ *
+ * @module utils/download
+ */
+
+/** Trigger a browser download of `content` as a JSON file named `filename`. */
+export function downloadJson(filename: string, content: string): void {
+  const blob = new Blob([content], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+/** Filename tag from a game session id: the last 6 chars, or empty. */
+export function gameIdTag(gameSessionId: string | undefined): string {
+  return gameSessionId ? `${gameSessionId.slice(-6)}-` : '';
+}


### PR DESCRIPTION
## Summary

The win modal previously offered only "Export Game" and "New Game" — so the only way to clear it was to start a new game, which resets the session and overrides the won game's data before its AI log can be exported.

## Changes

- **The win modal can be dismissed** without starting a new game — a close (✕) button and a "Close and keep this game" link, backed by a new `winModalDismissed` flag. The won game stays fully intact so it (and its AI log) can still be exported from the controls.
- **An "Export AI Log" button** is added to the win modal alongside "Export Game", so the just-won game's full interaction log can be saved in one click.
- Export filenames carry the game id, and the blob/anchor download code is now a shared `downloadJson` helper used by the ControlPanel, the AI settings section, and the win modal.

## Tests

- New E2E: the win modal can be dismissed without resetting the game (game stays won, exportable).
- Existing win-modal E2E ("New Game" still resets) unchanged and passing.
- Lint, typecheck, 246 unit tests, 50 E2E, and the production build pass locally.

## Test plan

- [ ] CI green (lint, test, build, e2e)