### PR TITLE
feat: Parallel Window button to run sessions side by side

### DIFF
--- a/packages/app/e2e/smoke.spec.ts
+++ b/packages/app/e2e/smoke.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { tableauFingerprint } from './helpers';
 
 /**
  * Smoke tests — verify the game loads and all major areas render correctly.
@@ -45,5 +46,32 @@ test.describe('Smoke Tests', () => {
     await expect(page.getByTestId('control-panel')).toBeVisible();
     await expect(page.getByTestId('new-game-btn')).toBeVisible();
     await expect(page.getByTestId('move-counter')).toBeVisible();
+  });
+
+  test('Parallel Window opens an independent session with the same board', async ({
+    page,
+    context,
+  }) => {
+    await page.goto('/?seed=99&difficulty=2');
+    await expect(page.getByTestId('game-board')).toBeVisible();
+
+    const popupPromise = context.waitForEvent('page');
+    await page.getByTestId('parallel-session-btn').click();
+    const popup = await popupPromise;
+
+    await expect(popup.getByTestId('game-board')).toBeVisible();
+    await popup.waitForFunction(() => typeof window.__solitaire !== 'undefined');
+
+    // The new window carries the seed, deals the same board...
+    expect(popup.url()).toContain('seed=99');
+    expect(await tableauFingerprint(popup)).toEqual(await tableauFingerprint(page));
+
+    // ...but is an independent session.
+    const originalId = await page.evaluate(() => window.__solitaire!.getSummary().gameSessionId);
+    const popupId = await popup.evaluate(() => window.__solitaire!.getSummary().gameSessionId);
+    expect(popupId).toBeTruthy();
+    expect(popupId).not.toBe(originalId);
+
+    await popup.close();
   });
 });

--- a/packages/app/src/components/ControlPanel.tsx
+++ b/packages/app/src/components/ControlPanel.tsx
@@ -23,6 +23,7 @@ const ControlPanel: React.FC = () => {
   const aiAutoPlay = useGameStore((state) => state.aiAutoPlay);
   const gameWon = useGameStore((state) => state.gameWon);
   const gameSessionId = useGameStore((state) => state.gameSessionId);
+  const seed = useGameStore((state) => state.seed);
   const moveCount = useGameStore((state) => state.moveHistory.length);
   const difficulty = useGameStore((state) => state.difficulty);
   const perceivedDifficulty = useGameStore((state) => state.perceivedDifficulty);
@@ -69,6 +70,24 @@ const ControlPanel: React.FC = () => {
   const handleNewGame = () => {
     initializeGame();
     setMessage({ type: 'success', text: 'New game started!' });
+    setTimeout(() => setMessage(null), 3000);
+  };
+
+  /**
+   * Open an independent game session in a new window — same seed (so the same
+   * board, when seeded) and difficulty — for running models in parallel. The
+   * new window gets its own session id; the API key carries over via the
+   * copied sessionStorage.
+   */
+  const handleParallelSession = () => {
+    const params = new URLSearchParams();
+    if (seed !== undefined) params.set('seed', String(seed));
+    params.set('difficulty', String(difficulty));
+    window.open(`${window.location.pathname}?${params.toString()}`, '_blank');
+    setMessage({
+      type: 'success',
+      text: seed !== undefined ? 'Parallel session opened (same board).' : 'Parallel session opened.',
+    });
     setTimeout(() => setMessage(null), 3000);
   };
 
@@ -168,7 +187,16 @@ const ControlPanel: React.FC = () => {
         >
           New Game
         </button>
-        
+
+        <button
+          data-testid="parallel-session-btn"
+          onClick={handleParallelSession}
+          className="w-full bg-teal-600 hover:bg-teal-700 text-white font-semibold py-2 px-4 rounded transition-colors text-sm"
+          title="Open an independent session in a new window (same board) to run models in parallel"
+        >
+          🔀 Parallel Window
+        </button>
+
         <button
           data-testid="import-btn"
           onClick={handleImport}


### PR DESCRIPTION
## Summary

Adds a control-panel button, **🔀 Parallel Window**, that opens an independent game session in a new browser window.

## How it works

- The button opens a new window at the app URL with the current game's `seed` and `difficulty` as query parameters.
- The new window deals the **same board** (when the current game is seeded) but is a **fully independent session** — it gets its own `gameSessionId`.
- This lets several models run in parallel on the same deal (or just parallelizes data collection). The API key carries over to the new window via the copied `sessionStorage`.

## Tests

- New E2E (smoke): clicking the button opens a popup that carries the seed, deals an identical board (tableau fingerprint matches), and has a distinct session id.
- Lint, typecheck, 246 unit tests, the E2E suite, and the production build pass locally.

## Test plan

- [ ] CI green (lint, test, build, e2e)