### PR TITLE
fix: honor rate-limit retry delay; badge every line of an AI move

### DIFF
--- a/packages/app/src/ai/constants.ts
+++ b/packages/app/src/ai/constants.ts
@@ -57,6 +57,16 @@ export const AI_RETRY_MAX_DELAY = 30_000;
  */
 export const AI_AUTO_RETRY_COOLDOWN = 12_000;
 
+/**
+ * Fallback wait (ms) after an HTTP 429 when the response carries no
+ * `RetryInfo`. Long enough to clear a per-minute rate-limit window — a short
+ * retry would just hit the limit again.
+ */
+export const AI_RATE_LIMIT_FALLBACK_DELAY = 35_000;
+
+/** Hard cap (ms) on any server-suggested retry delay, against bogus values. */
+export const AI_RETRY_DELAY_CAP = 120_000;
+
 /** Sampling temperature for move suggestions — low, for consistent advice. */
 export const AI_TEMPERATURE = 0.3;
 

--- a/packages/app/src/ai/providers/GeminiProvider.test.ts
+++ b/packages/app/src/ai/providers/GeminiProvider.test.ts
@@ -107,13 +107,41 @@ describe('geminiProvider.suggestMove', () => {
     });
   });
 
-  it('maps HTTP 429 to a rate_limited error', async () => {
+  it('maps HTTP 429 to a rate_limited error with a fallback retry delay', async () => {
     vi.mocked(fetch).mockResolvedValue(
       mockResponse(429, { error: { code: 429, message: 'Quota exceeded' } }),
     );
-    await expect(geminiProvider.suggestMove(request)).rejects.toMatchObject({
-      kind: 'rate_limited',
-    });
+    try {
+      await geminiProvider.suggestMove(request);
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(AIError);
+      expect((err as AIError).kind).toBe('rate_limited');
+      // No RetryInfo => a fallback delay long enough to clear a 1-minute window.
+      expect((err as AIError).retryAfterMs).toBeGreaterThanOrEqual(30_000);
+    }
+  });
+
+  it('honors the RetryInfo retry delay on a 429', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse(429, {
+        error: {
+          code: 429,
+          status: 'RESOURCE_EXHAUSTED',
+          message: 'Quota exceeded',
+          details: [
+            { '@type': 'type.googleapis.com/google.rpc.RetryInfo', retryDelay: '42s' },
+          ],
+        },
+      }),
+    );
+    try {
+      await geminiProvider.suggestMove(request);
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect((err as AIError).kind).toBe('rate_limited');
+      expect((err as AIError).retryAfterMs).toBe(42_000);
+    }
   });
 
   it('maps HTTP 404 to a config error', async () => {

--- a/packages/app/src/ai/providers/GeminiProvider.ts
+++ b/packages/app/src/ai/providers/GeminiProvider.ts
@@ -17,7 +17,12 @@
  * @module ai/providers/GeminiProvider
  */
 
-import { AI_REQUEST_TIMEOUT_MS, AI_TEMPERATURE, GEMINI_API_BASE } from '../constants';
+import {
+  AI_RATE_LIMIT_FALLBACK_DELAY,
+  AI_REQUEST_TIMEOUT_MS,
+  AI_TEMPERATURE,
+  GEMINI_API_BASE,
+} from '../constants';
 import { parseDecision } from '../decision/schema';
 import { recordAIInteraction } from '../interactionLog';
 import { uuidv7 } from '../uuid';
@@ -45,7 +50,26 @@ interface GeminiResponse {
   }[];
   promptFeedback?: { blockReason?: string };
   usageMetadata?: GeminiUsage;
-  error?: { code?: number; message?: string; status?: string };
+  error?: { code?: number; message?: string; status?: string; details?: unknown[] };
+}
+
+/**
+ * Extract a server-suggested retry delay (ms) from an error body's
+ * `RetryInfo` detail (a protobuf Duration string like `"57s"`).
+ */
+function extractRetryDelayMs(body: GeminiResponse | null): number | undefined {
+  const details = body?.error?.details;
+  if (!Array.isArray(details)) return undefined;
+  for (const detail of details) {
+    if (detail && typeof detail === 'object' && 'retryDelay' in detail) {
+      const raw = (detail as { retryDelay?: unknown }).retryDelay;
+      if (typeof raw === 'string') {
+        const match = /^([\d.]+)s$/.exec(raw.trim());
+        if (match) return Math.round(parseFloat(match[1]) * 1000);
+      }
+    }
+  }
+  return undefined;
 }
 
 /** Map a non-OK HTTP response to a typed {@link AIError}. */
@@ -54,7 +78,14 @@ function errorFromHttp(status: number, body: GeminiResponse | null): AIError {
   const lower = message.toLowerCase();
 
   if (status === 429) {
-    return new AIError('rate_limited', 'Gemini rate limit reached. Wait a moment and try again.');
+    // Honor the server's RetryInfo; otherwise wait long enough to clear a
+    // per-minute window (a short retry would just hit the limit again).
+    const retryAfterMs = extractRetryDelayMs(body) ?? AI_RATE_LIMIT_FALLBACK_DELAY;
+    return new AIError(
+      'rate_limited',
+      `Gemini rate limit reached (retry in ~${Math.round(retryAfterMs / 1000)}s).`,
+      retryAfterMs,
+    );
   }
   if (status === 401 || status === 403) {
     return new AIError('invalid_key', 'Gemini rejected the API key. Check that it is valid.');

--- a/packages/app/src/ai/retry.test.ts
+++ b/packages/app/src/ai/retry.test.ts
@@ -122,6 +122,25 @@ describe('suggestMoveWithRetry', () => {
     expect(onRetry.mock.calls[0][0]).toMatchObject({ attempt: 1, maxAttempts: 4 });
   });
 
+  it('waits the server-suggested delay instead of its own backoff', async () => {
+    vi.useFakeTimers();
+    const suggestMove = vi
+      .fn()
+      .mockRejectedValueOnce(new AIError('rate_limited', 'limited', 57_000))
+      .mockResolvedValueOnce(DECISION);
+    const onRetry = vi.fn();
+
+    const promise = suggestMoveWithRetry(fakeProvider(suggestMove), REQUEST, {
+      maxAttempts: 4,
+      onRetry,
+    });
+    await vi.advanceTimersByTimeAsync(120_000);
+
+    await expect(promise).resolves.toBe(DECISION);
+    // The retry waited ~57s (the server's RetryInfo), not the ~2s backoff.
+    expect(onRetry.mock.calls[0][0].delayMs).toBeGreaterThanOrEqual(57_000);
+  });
+
   it('gives up after the maximum number of attempts', async () => {
     vi.useFakeTimers();
     const suggestMove = vi.fn().mockRejectedValue(new AIError('unavailable', 'down'));

--- a/packages/app/src/ai/retry.ts
+++ b/packages/app/src/ai/retry.ts
@@ -8,7 +8,7 @@
  * @module ai/retry
  */
 
-import { AI_RETRY_BASE_DELAY, AI_RETRY_MAX_DELAY } from './constants';
+import { AI_RETRY_BASE_DELAY, AI_RETRY_DELAY_CAP, AI_RETRY_MAX_DELAY } from './constants';
 import { AIError, type AIErrorKind, type AIMoveDecision, type AIProvider, type AIRequest } from './types';
 
 /**
@@ -122,8 +122,14 @@ export async function suggestMoveWithRetry(
       if (err instanceof AIError && err.kind === 'aborted') throw err;
       if (!isRetryableAIError(err) || attempt >= maxAttempts) throw err;
 
-      const delayMs = backoffDelay(attempt);
-      onRetry?.({ attempt, maxAttempts, error: err as AIError, delayMs });
+      const aiErr = err as AIError;
+      // Honor a server-suggested delay (e.g. a 429 RetryInfo) when present;
+      // otherwise fall back to exponential backoff.
+      const delayMs =
+        aiErr.retryAfterMs !== undefined
+          ? Math.min(aiErr.retryAfterMs, AI_RETRY_DELAY_CAP) + Math.floor(Math.random() * 500)
+          : backoffDelay(attempt);
+      onRetry?.({ attempt, maxAttempts, error: aiErr, delayMs });
       await abortableSleep(delayMs, signal);
     }
   }

--- a/packages/app/src/ai/types.ts
+++ b/packages/app/src/ai/types.ts
@@ -239,11 +239,17 @@ export type AIErrorKind =
 export class AIError extends Error {
   /** The categorized failure mode. */
   readonly kind: AIErrorKind;
+  /**
+   * Server-suggested wait before retrying, in ms (e.g. from a 429 `RetryInfo`).
+   * When set, the retry logic waits this long instead of its own backoff.
+   */
+  readonly retryAfterMs?: number;
 
-  constructor(kind: AIErrorKind, message: string) {
+  constructor(kind: AIErrorKind, message: string, retryAfterMs?: number) {
     super(message);
     this.name = 'AIError';
     this.kind = kind;
+    this.retryAfterMs = retryAfterMs;
   }
 }
 

--- a/packages/app/src/components/ActivityLog.tsx
+++ b/packages/app/src/components/ActivityLog.tsx
@@ -146,7 +146,7 @@ const ActivityLog: React.FC = () => {
                 {[...visibleLogs].reverse().map((move, index) => {
                   const isAutoPlayEvent = move.type.startsWith('autoplay_');
                   const isDeadendOrLoop = move.type === 'autoplay_deadend' || move.type === 'autoplay_loop_detected';
-                  const isAIMove = typeof move.aiReasoning === 'string';
+                  const isAIMove = move.aiMove === true || typeof move.aiReasoning === 'string';
                   return (
                     <div
                       key={`${move.timestamp}-${index}`}

--- a/packages/app/src/components/ReplayControls.tsx
+++ b/packages/app/src/components/ReplayControls.tsx
@@ -36,7 +36,8 @@ const ReplayControls: React.FC = () => {
 
   // The move that was just applied at the current replay position.
   const currentMove = replayIndex > 0 ? moveHistory[replayIndex - 1] : undefined;
-  const currentIsAIMove = typeof currentMove?.aiReasoning === 'string';
+  const currentIsAIMove =
+    currentMove?.aiMove === true || typeof currentMove?.aiReasoning === 'string';
 
   const handleProgressClick = (e: React.MouseEvent<HTMLDivElement>) => {
     const rect = e.currentTarget.getBoundingClientRect();

--- a/packages/app/src/store/gameStore.ts
+++ b/packages/app/src/store/gameStore.ts
@@ -1258,13 +1258,17 @@ export const useGameStore = create<GameStore>((set, get) => ({
         throw new AIError('bad_response', 'The chosen move is no longer valid.');
       }
 
-      // Apply the move, then annotate the new move-history entry with the
-      // AI's reasoning so the Activity Log can surface it.
+      // Apply the move, then annotate the new move-history entries: every
+      // entry of the move is flagged as an AI move (so a multi-card move
+      // reads as one AI action, not a mix), and the lead entry carries the
+      // reasoning the Activity Log surfaces.
       const beforeLen = get().moveHistory.length;
       get().applyMoveCommand(command);
       const afterMoves = get().moveHistory;
       if (afterMoves.length > beforeLen) {
-        const annotated = [...afterMoves];
+        const annotated = afterMoves.map((move, i) =>
+          i < beforeLen ? move : { ...move, aiMove: true },
+        );
         annotated[beforeLen] = {
           ...annotated[beforeLen],
           aiReasoning: decision.reasoning,
@@ -1343,17 +1347,23 @@ export const useGameStore = create<GameStore>((set, get) => ({
       // run. The retries above are already exhausted, so cool down and
       // re-attempt the move. LLM endpoints are not always stable.
       if (get().aiAutoPlay && isTransientAIError(err)) {
+        // Honor a server-suggested wait (e.g. a 429 RetryInfo) so auto-play
+        // does not re-attempt before a rate-limit window has cleared.
+        const cooldownMs =
+          err instanceof AIError && err.retryAfterMs !== undefined
+            ? err.retryAfterMs
+            : AI_AUTO_RETRY_COOLDOWN;
         set({
           aiThinking: false,
           aiThinkingSince: undefined,
           aiStatus: undefined,
-          aiError: `${message} Auto-play retries in ${Math.round(AI_AUTO_RETRY_COOLDOWN / 1000)}s.`,
+          aiError: `${message} Auto-play retries in ${Math.round(cooldownMs / 1000)}s.`,
         });
         setTimeout(() => {
           if (get().aiAutoPlay && !get().aiThinking) {
             void get().askAIForMove();
           }
-        }, AI_AUTO_RETRY_COOLDOWN);
+        }, cooldownMs);
         return;
       }
 

--- a/packages/app/src/types/index.ts
+++ b/packages/app/src/types/index.ts
@@ -39,9 +39,11 @@ export interface Move {
     columnIndex?: number;
     suit?: Suit;
   };
-  /** Reasoning text, set when this move was chosen by the AI Move Advisor. */
+  /** True when this entry is part of a move the AI Move Advisor made. */
+  aiMove?: boolean;
+  /** Reasoning text, set on the lead entry of an AI-chosen move. */
   aiReasoning?: string;
-  /** AI self-rated confidence (0-1), set when this move was AI-chosen. */
+  /** AI self-rated confidence (0-1), set on the lead entry of an AI-chosen move. */
   aiConfidence?: number;
 }
 


### PR DESCRIPTION
## Summary

Two fixes prompted by an unattended auto-play run.

## Rate-limit retry delay

A 429 ("rate limit reached") was retried after a fixed ~12s — far too short for a per-minute rate-limit window, so the retry just hit the limit again ("Auto-play retries in 12s" churning).

The provider now reads the **`RetryInfo` retry delay** from the 429 response (a protobuf duration like `"42s"`), or falls back to ~35s when none is given. That delay (`AIError.retryAfterMs`) is honored by both the in-call retry backoff and the AI auto-play cooldown — and the "retries in Ns" message shows the real wait. So a rate-limited run waits out the window once and resumes, instead of hammering.

## AI-move badge on every line

A multi-card AI move (e.g. moving a `6H-5S-4H` sequence) is logged as one entry per card, but only the lead entry carried the 🤖 badge — so the other lines looked like separate, non-AI moves. Every entry of an AI move is now flagged (`aiMove`), so a multi-card move reads as a single AI action in the activity log and the replay view. The reasoning text still appears once, on the lead entry.

## Tests

- New: provider honors a 429 `RetryInfo` delay (and a fallback); the retry waits the server-suggested delay rather than its own backoff.
- Lint, typecheck, 248 unit tests, 51 E2E, and the production build pass locally.

## Test plan

- [ ] CI green (lint, test, build, e2e)