### PR TITLE
fix: live AI metrics, session outcome record, pure-AI guard

### DIFF
--- a/packages/app/e2e/smoke.spec.ts
+++ b/packages/app/e2e/smoke.spec.ts
@@ -74,4 +74,27 @@ test.describe('Smoke Tests', () => {
 
     await popup.close();
   });
+
+  test('Parallel Window carries the board even for a fresh game with no URL seed', async ({
+    page,
+    context,
+  }) => {
+    // Regression: a normally-started game (no ?seed= param) used to have an
+    // undefined seed, so the Parallel Window opened a different random board.
+    await page.goto('/');
+    await expect(page.getByTestId('game-board')).toBeVisible();
+
+    const popupPromise = context.waitForEvent('page');
+    await page.getByTestId('parallel-session-btn').click();
+    const popup = await popupPromise;
+
+    await expect(popup.getByTestId('game-board')).toBeVisible();
+    await popup.waitForFunction(() => typeof window.__solitaire !== 'undefined');
+
+    // The fresh game still has a (generated) seed, and it travels to the popup.
+    expect(popup.url()).toContain('seed=');
+    expect(await tableauFingerprint(popup)).toEqual(await tableauFingerprint(page));
+
+    await popup.close();
+  });
 });

--- a/packages/app/src/ai/context/buildContext.test.ts
+++ b/packages/app/src/ai/context/buildContext.test.ts
@@ -87,10 +87,12 @@ describe('buildContext', () => {
     });
     const ctx = buildContext(state, LEGAL_MOVES, applyPreset(DEFAULT_AI_CONFIG, 'standard'));
 
+    // perceivedDifficulty is recomputed from the current board (all seven
+    // tableau columns empty here => -3 each, clamped to 0), not the static
+    // game-start value carried in state.perceivedDifficulty.
     expect(ctx.metrics).toEqual({
       completionProgress: 25,
-      perceivedDifficulty: 50,
-      moveCount: 2,
+      perceivedDifficulty: 0,
       difficulty: 3,
     });
     expect(ctx.recentMoves).toEqual(['draw 4C', 'draw 7S']);

--- a/packages/app/src/ai/context/buildContext.ts
+++ b/packages/app/src/ai/context/buildContext.ts
@@ -10,8 +10,10 @@
  */
 
 import type { MoveCommand } from '@chayuto/solitaire-core';
+import { getPerceivedDifficulty } from '@chayuto/solitaire-core';
 import type { GameState, Suit } from '../../types';
 import type { AIConfig, AIDecisionRecord, AILegalMove, AIMoveContext } from '../types';
+import { uiToCore } from '../../adapters/coreAdapter';
 import { cardShort } from '../cardNotation';
 import { describeMoveCommand, summarizeHistoryMove } from './describeMove';
 import { collectPossibleMoves, scoreMoves } from '../../autoplay';
@@ -161,10 +163,13 @@ export function buildContext(
 
   // --- Optional: game metrics ---
   if (config.includeGameMetrics) {
+    // `perceivedDifficulty` is recomputed from the *current* board, not the
+    // game-start value carried in `state.perceivedDifficulty` — a static figure
+    // repeated every turn carries no per-turn signal. `moveCount` is omitted
+    // here: it duplicates the interaction log's `turnIndex` exactly.
     context.metrics = {
       completionProgress: Math.round(state.completionProgress),
-      perceivedDifficulty: state.perceivedDifficulty,
-      moveCount: state.moveHistory.length,
+      perceivedDifficulty: getPerceivedDifficulty(uiToCore(state)),
       difficulty: state.difficulty,
     };
   }

--- a/packages/app/src/ai/context/rulesPrimer.ts
+++ b/packages/app/src/ai/context/rulesPrimer.ts
@@ -50,6 +50,14 @@ these three keys, in this order (no prose or markdown fences outside the object)
   progress, and the opportunities each legal move opens or closes.
 - strategic_plan: explain your plan and why the chosen move is best, given that analysis.
 - final_decision.move_index: the "index" of your chosen move from the legalMoves array.
-- final_decision.confidence: your confidence the move is best, a number from 0 to 1.
+- final_decision.confidence: a calibrated probability (0 to 1) that this move is
+  objectively the best one available — a genuine estimate, not a feeling. Use the
+  full range honestly:
+    1.0-0.9  forced, or clearly dominant — any other move would be a mistake.
+    0.9-0.7  strong — one plausible alternative exists, but this move is better.
+    0.7-0.5  a real toss-up between two or three reasonable moves.
+    0.5-0.3  a guess — the board is unclear or several moves look about equal.
+    below 0.3  little better than picking at random.
+  If you would not bet on the move, do not report high confidence.
 - final_decision.alternative_move_index: optional; the index of your second-choice move.
 Produce the keys in the order above: analyse the board first, then plan, then decide.`;

--- a/packages/app/src/ai/index.ts
+++ b/packages/app/src/ai/index.ts
@@ -38,7 +38,7 @@ export {
   clearAIInteractions,
   exportAIInteractions,
 } from './interactionLog';
-export type { AIInteraction } from './interactionLog';
+export type { AIInteraction, AISessionSummary } from './interactionLog';
 
 // Identifiers
 export { uuidv7 } from './uuid';

--- a/packages/app/src/ai/interactionLog.test.ts
+++ b/packages/app/src/ai/interactionLog.test.ts
@@ -91,6 +91,34 @@ describe('interactionLog', () => {
     expect(typeof parsed.appBuildTime).toBe('string');
   });
 
+  it('exportAIInteractions embeds the session outcome summary when supplied', () => {
+    recordAIInteraction(base);
+    const parsed = JSON.parse(
+      exportAIInteractions({
+        sessionId: 'session-abcdef12',
+        seed: 12345,
+        model: 'gemma-4-31b-it',
+        outcome: 'won',
+        finalProgress: 100,
+        moveCount: 142,
+      }),
+    );
+    expect(parsed.session).toEqual({
+      sessionId: 'session-abcdef12',
+      seed: 12345,
+      model: 'gemma-4-31b-it',
+      outcome: 'won',
+      finalProgress: 100,
+      moveCount: 142,
+    });
+  });
+
+  it('exportAIInteractions omits the session summary when none is supplied', () => {
+    recordAIInteraction(base);
+    const parsed = JSON.parse(exportAIInteractions());
+    expect(parsed.session).toBeUndefined();
+  });
+
   it('clearAIInteractions empties the buffer', () => {
     recordAIInteraction(base);
     clearAIInteractions();

--- a/packages/app/src/ai/interactionLog.ts
+++ b/packages/app/src/ai/interactionLog.ts
@@ -64,6 +64,29 @@ export interface AIInteraction {
   totalTokens?: number;
 }
 
+/**
+ * Session-level outcome of the game active at export time. Lets a consumer
+ * filter a harvested dataset for quality games (e.g. only wins) without a
+ * separate win-record file.
+ */
+export interface AISessionSummary {
+  /** UUIDv7 of the game session (joins {@link AIInteraction.sessionId}). */
+  sessionId: string;
+  /** Deal seed of the game, when one was used. */
+  seed?: number;
+  /** Model that drove the session. */
+  model: string;
+  /**
+   * How the game ended: `won` (all 52 cards home), `lost` (no legal moves
+   * remain), or `incomplete` (exported mid-game — i.e. abandoned).
+   */
+  outcome: 'won' | 'lost' | 'incomplete';
+  /** Completion progress at export time (0–100). */
+  finalProgress: number;
+  /** Total move-history length at export time. */
+  moveCount: number;
+}
+
 const buffer: AIInteraction[] = [];
 
 /** Record an interaction: append to the ring buffer and log a console summary. */
@@ -107,13 +130,20 @@ export function clearAIInteractions(): void {
   buffer.length = 0;
 }
 
-/** Serialize the full interaction log to a JSON string for export/harvesting. */
-export function exportAIInteractions(): string {
+/**
+ * Serialize the full interaction log to a JSON string for export/harvesting.
+ *
+ * @param session - Outcome summary of the game active at export time, when
+ *   available. Describes the current session only; individual interactions
+ *   carry their own `sessionId` for multi-game buffers.
+ */
+export function exportAIInteractions(session?: AISessionSummary): string {
   return JSON.stringify(
     {
       exportedAt: new Date().toISOString(),
       appCommit: APP_COMMIT,
       appBuildTime: APP_BUILD_TIME,
+      session,
       count: buffer.length,
       interactions: buffer,
     },

--- a/packages/app/src/ai/types.ts
+++ b/packages/app/src/ai/types.ts
@@ -44,7 +44,7 @@ export interface AIConfig {
   includeMoveHistory: boolean;
   /** How many recent moves to include when {@link includeMoveHistory} is on. */
   moveHistoryLimit: number;
-  /** Include completion progress, perceived difficulty, move count, difficulty. */
+  /** Include completion progress, perceived difficulty, and the deal difficulty. */
   includeGameMetrics: boolean;
   /** Include a static block of Klondike strategy heuristics in the prompt. */
   includeStrategyGuidance: boolean;
@@ -119,9 +119,11 @@ export interface AIMoveContext {
 
   /** Game metrics (when `includeGameMetrics`). */
   metrics?: {
+    /** Completion progress (0–100). */
     completionProgress: number;
-    perceivedDifficulty: number | undefined;
-    moveCount: number;
+    /** Perceived difficulty (0–100) of the *current* board — recomputed each turn. */
+    perceivedDifficulty: number;
+    /** Deal difficulty setting. */
     difficulty: number;
   };
   /** Recent moves, most-recent last (when `includeMoveHistory`). */

--- a/packages/app/src/store/gameStore.ts
+++ b/packages/app/src/store/gameStore.ts
@@ -136,14 +136,21 @@ interface GameStore extends GameState {
  * @param difficulty - Game difficulty level (default: 3 = Normal)
  * @param seed - Optional RNG seed for a reproducible deal. Same seed => the
  *   exact same board every time — required for deterministic, high-fidelity
- *   automated/agentic testing. When omitted, the deal is random.
+ *   automated/agentic testing. When omitted, a fresh random seed is generated
+ *   so every game is still reproducible (and the Parallel Window can carry the
+ *   exact board to a new session).
  * @returns Complete initial game state
  */
 const initializeGameState = (
   difficulty: Difficulty = DEFAULT_DIFFICULTY,
   seed?: number,
 ): GameState => {
-  const deck = arrangeDeckByDifficulty(difficulty, seed);
+  // Every game gets a seed. An explicit one comes from the launch URL or a
+  // loaded save; otherwise generate a random 32-bit seed so the deal is still
+  // reproducible — without this, a normally-started game has no seed and the
+  // Parallel Window opens a different board.
+  const resolvedSeed = seed ?? Math.floor(Math.random() * 0x1_0000_0000);
+  const deck = arrangeDeckByDifficulty(difficulty, resolvedSeed);
   const tableau: Card[][] = Array(TABLEAU_COLUMNS).fill(null).map(() => []);
   
   // Deal cards to tableau (1 card to first column, 2 to second, etc.)
@@ -192,7 +199,7 @@ const initializeGameState = (
     autoPlayInProgress: false,
     autoPlayStateHistory: [],
     difficulty,
-    seed,
+    seed: resolvedSeed,
     gameSessionId: uuidv7(),
     gameStartedAt: Date.now(),
     gameWon: false,
@@ -695,8 +702,15 @@ export const useGameStore = create<GameStore>((set, get) => ({
   toggleAutoPlay: () => {
     const state = get();
     const newAutoPlayEnabled = !state.autoPlayEnabled;
-    
+
     if (newAutoPlayEnabled) {
+      // Heuristic auto-play must never run while the AI is driving the game.
+      // An AI session has to stay pure AI — no human or heuristic intervention —
+      // or harvested games are contaminated with non-AI moves.
+      if (state.aiThinking || state.aiAutoPlay) {
+        set({ aiError: 'Stop AI play before starting auto-play.' });
+        return;
+      }
       // Log auto-play start event
       const move: Move = {
         type: 'autoplay_start',
@@ -1465,7 +1479,24 @@ export const useGameStore = create<GameStore>((set, get) => ({
     set({ aiKeyModalOpen: open });
   },
 
-  exportAIInteractions: () => serializeAIInteractions(),
+  exportAIInteractions: () => {
+    // Stamp the export with the current game's outcome so a harvested dataset
+    // can be filtered for quality games (e.g. wins only) on its own.
+    const state = get();
+    const outcome: 'won' | 'lost' | 'incomplete' = state.gameWon
+      ? 'won'
+      : engine.getLegalMoves(uiToCore(state)).length === 0
+        ? 'lost'
+        : 'incomplete';
+    return serializeAIInteractions({
+      sessionId: state.gameSessionId ?? '',
+      seed: state.seed,
+      model: (state.aiConfig ?? DEFAULT_AI_CONFIG).model,
+      outcome,
+      finalProgress: Math.round(state.completionProgress),
+      moveCount: state.moveHistory.length,
+    });
+  },
 
   dismissWinModal: () => {
     set({ winModalDismissed: true });


### PR DESCRIPTION
Addresses data-analytics feedback on the AI harvesting dataset.

## Changes

**Pure-AI guard** — `toggleAutoPlay` now refuses to start heuristic auto-play while `aiThinking || aiAutoPlay`. This was the only path by which a human or heuristic move could leak into an AI session and contaminate a harvested game.

**Confidence rubric** — `OUTPUT_INSTRUCTION` now gives a 5-band calibration rubric for `final_decision.confidence` and instructs the model to report a genuine probability rather than a feeling. Previously the field was requested with no rubric and carried no signal.

**Live metrics** — `metrics.perceivedDifficulty` is recomputed from the current board each turn instead of echoing the static game-start value. `metrics.moveCount` is dropped: it duplicated the interaction log's `turnIndex` exactly.

**Session outcome record** — `exportAIInteractions()` now embeds an `AISessionSummary` (`sessionId`, `seed`, `model`, `outcome`, `finalProgress`, `moveCount`). `outcome` is `won` / `lost` (no legal moves remain) / `incomplete` (exported mid-game). A harvested dataset can now be filtered for quality games without a separate win-record file.

**Seed reproducibility** — every game gets a generated 32-bit seed when none is supplied, so a normally-started game is reproducible and the Parallel Window carries the exact board to a fresh session.

## Testing

- `vitest run` — 250/250 pass (updated `buildContext.test.ts` for the new metrics shape; added two `interactionLog.test.ts` cases for the session summary).
- `tsc -b` clean, `eslint` clean.