### PR TITLE
fix: prevent accidental loss of game progress on navigation

### DIFF
--- a/packages/app/src/components/GameBoard.tsx
+++ b/packages/app/src/components/GameBoard.tsx
@@ -12,10 +12,14 @@ import AIKeyModal from './AIKeyModal';
 import WinModal from './WinModal';
 import ReplayControls from './ReplayControls';
 import { shouldReduceMotion as checkReducedMotion } from '../utils/motion';
+import { useUnloadGuard } from '../hooks/useUnloadGuard';
 
 const GameBoard: React.FC = () => {
   // Check for reduced motion preference
   const shouldReduceMotion = useMemo(() => checkReducedMotion(), []);
+
+  // Warn before an accidental navigation discards an unfinished game.
+  useUnloadGuard();
 
   // Short game identifier: the seed (when the deal was seeded) and the last 6
   // characters of the session UUID. Shown under the title and in the tab.

--- a/packages/app/src/hooks/useUnloadGuard.test.ts
+++ b/packages/app/src/hooks/useUnloadGuard.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Tests for the unsaved-game unload guard.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useUnloadGuard } from './useUnloadGuard';
+import { useGameStore } from '../store/gameStore';
+
+/** Dispatch a cancelable `beforeunload` event; return whether it was prevented. */
+function fireBeforeUnload(): boolean {
+  const event = new Event('beforeunload', { cancelable: true });
+  window.dispatchEvent(event);
+  return event.defaultPrevented;
+}
+
+describe('useUnloadGuard', () => {
+  beforeEach(() => {
+    // Start from a fresh, untouched game.
+    useGameStore.getState().initializeGame(3, 42);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not prompt for an untouched board', () => {
+    renderHook(() => useUnloadGuard());
+    expect(fireBeforeUnload()).toBe(false);
+  });
+
+  it('prompts once the game is in progress', () => {
+    useGameStore.setState({
+      moveHistory: [{ type: 'draw_card', timestamp: 0, card: { suit: 'hearts', rank: 'A', faceUp: true, id: 'h-a' } }],
+      gameWon: false,
+    });
+    renderHook(() => useUnloadGuard());
+    expect(fireBeforeUnload()).toBe(true);
+  });
+
+  it('does not prompt once the game is won', () => {
+    useGameStore.setState({
+      moveHistory: [{ type: 'draw_card', timestamp: 0, card: { suit: 'hearts', rank: 'A', faceUp: true, id: 'h-a' } }],
+      gameWon: true,
+    });
+    renderHook(() => useUnloadGuard());
+    expect(fireBeforeUnload()).toBe(false);
+  });
+
+  it('removes the listener on unmount', () => {
+    useGameStore.setState({
+      moveHistory: [{ type: 'draw_card', timestamp: 0, card: { suit: 'hearts', rank: 'A', faceUp: true, id: 'h-a' } }],
+      gameWon: false,
+    });
+    const { unmount } = renderHook(() => useUnloadGuard());
+    expect(fireBeforeUnload()).toBe(true);
+    unmount();
+    expect(fireBeforeUnload()).toBe(false);
+  });
+});

--- a/packages/app/src/hooks/useUnloadGuard.ts
+++ b/packages/app/src/hooks/useUnloadGuard.ts
@@ -1,0 +1,36 @@
+/**
+ * Warns the player before the page unloads while a game is in progress.
+ *
+ * The game state lives only in memory, so an accidental navigation — a
+ * swipe-back gesture that slips past the `overscroll-behavior` guard, a closed
+ * tab, or a reload — silently discards an unfinished game. This hook attaches a
+ * `beforeunload` handler so the browser shows its native "Leave site?" prompt.
+ *
+ * The handler is attached only while a warning is warranted: a board that has
+ * been touched (`moveHistory` is non-empty) and is not yet won. An untouched or
+ * finished game never prompts. Modern browsers ignore any custom message text
+ * and show their own generic dialog.
+ *
+ * @module hooks/useUnloadGuard
+ */
+
+import { useEffect } from 'react';
+import { useGameStore } from '../store/gameStore';
+
+/** Prompt before unload while an unfinished, in-progress game would be lost. */
+export function useUnloadGuard(): void {
+  const inProgress = useGameStore((s) => s.moveHistory.length > 0 && !s.gameWon);
+
+  useEffect(() => {
+    if (!inProgress) return;
+
+    const handler = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      // Legacy browsers require `returnValue` to be set to trigger the prompt.
+      event.returnValue = '';
+    };
+
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [inProgress]);
+}

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -1,1 +1,13 @@
 @import "tailwindcss";
+
+/*
+ * Disable the browser's swipe-to-navigate gesture (two-finger horizontal
+ * swipe on a macOS trackpad). Without this, an accidental swipe triggers
+ * a back/forward navigation that unloads the page and discards the
+ * in-memory game state. `none` also removes horizontal rubber-banding;
+ * vertical scrolling and the keyboard/back button are unaffected.
+ */
+html,
+body {
+  overscroll-behavior-x: none;
+}


### PR DESCRIPTION
The game state lives only in memory, so an accidental navigation silently discards an unfinished game — e.g. a two-finger swipe-back on a macOS trackpad. Two complementary guards:

## Changes

**Block the swipe-to-navigate gesture** — `overscroll-behavior-x: none` on the document root (`index.css`) disables Chrome/Safari/Edge's two-finger horizontal swipe navigation and horizontal rubber-banding. Vertical scrolling, the keyboard, and the Back button are unaffected.

**Warn before unload** — a `beforeunload` handler (`useUnloadGuard`, wired into `GameBoard`) shows the browser's native "Leave site?" prompt while a game is in progress (the board has been touched and is not yet won). An untouched or finished game never prompts. This is the second line of defense behind the CSS — it also catches a closed tab or a reload.

## Not included

Full multi-session autosave (persist boards to `localStorage`, a Saved Games picker, Parallel-Window-safe per-session storage) is intentionally deferred to its own focused PR — it is a substantial feature with real edge cases and should not be bundled here.

## Testing

- `vitest run` — 254/254 pass (4 new tests for `useUnloadGuard`: untouched / in-progress / won / unmount).
- `tsc -b` clean, `eslint` clean, `vite build` clean.