### PR TITLE
feat: multi-session autosave with a saved-games manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ dist-ssr
 
 # Claude Code local (personal) settings
 .claude/settings.local.json
+
+# Playwright MCP screenshot output
+.playwright-mcp/

--- a/packages/app/e2e/session-persistence.spec.ts
+++ b/packages/app/e2e/session-persistence.spec.ts
@@ -1,0 +1,171 @@
+import { test, expect, type Page } from '@playwright/test';
+import { waitForGame, summary } from './helpers';
+
+/**
+ * Session persistence — games autosave to localStorage and survive a reload,
+ * with each board (including Parallel Windows) kept independently.
+ */
+
+/** Wait until the active game's autosave entry exists in localStorage. */
+async function waitForSave(page: Page): Promise<void> {
+  const id = (await summary(page)).gameSessionId;
+  await expect
+    .poll(() =>
+      page.evaluate(
+        (sessionId) => localStorage.getItem(`solitaire:save:${sessionId}`) !== null,
+        id,
+      ),
+    )
+    .toBe(true);
+}
+
+test.describe('Session persistence', () => {
+  test('autosaves a played game and restores it after a reload', async ({ page }) => {
+    await page.goto('/?seed=12345');
+    await waitForGame(page);
+    const before = await summary(page);
+
+    await page.evaluate(() => {
+      window.__solitaire!.draw();
+      window.__solitaire!.draw();
+    });
+    expect((await summary(page)).moveCount).toBe(before.moveCount + 2);
+
+    // The tab is anchored to its session in the URL.
+    expect(page.url()).toContain('session=');
+    await waitForSave(page);
+
+    await page.reload();
+    await waitForGame(page);
+
+    const after = await summary(page);
+    expect(after.gameSessionId).toBe(before.gameSessionId);
+    expect(after.moveCount).toBe(before.moveCount + 2);
+  });
+
+  test('parallel windows persist and restore independent boards', async ({
+    page,
+    context,
+  }) => {
+    await page.goto('/?seed=111');
+    await waitForGame(page);
+
+    // Window A: two moves.
+    await page.evaluate(() => {
+      window.__solitaire!.draw();
+      window.__solitaire!.draw();
+    });
+    await waitForSave(page);
+    const a = await summary(page);
+    expect(a.moveCount).toBe(2);
+
+    // Open a Parallel Window — a fresh, independent session on the same board.
+    const popupPromise = context.waitForEvent('page');
+    await page.getByTestId('parallel-session-btn').click();
+    const popup = await popupPromise;
+    await waitForGame(popup);
+
+    // Window B: four moves.
+    await popup.evaluate(() => {
+      window.__solitaire!.draw();
+      window.__solitaire!.draw();
+      window.__solitaire!.draw();
+      window.__solitaire!.draw();
+    });
+    await waitForSave(popup);
+    const b = await summary(popup);
+    expect(b.moveCount).toBe(4);
+    expect(b.gameSessionId).not.toBe(a.gameSessionId);
+
+    // Reloading each window restores its OWN board — no clobbering.
+    await page.reload();
+    await waitForGame(page);
+    const aAfter = await summary(page);
+    expect(aAfter.gameSessionId).toBe(a.gameSessionId);
+    expect(aAfter.moveCount).toBe(2);
+
+    await popup.reload();
+    await waitForGame(popup);
+    const bAfter = await summary(popup);
+    expect(bAfter.gameSessionId).toBe(b.gameSessionId);
+    expect(bAfter.moveCount).toBe(4);
+
+    await popup.close();
+  });
+
+  test('the saved-games manager lists games and resumes another one', async ({
+    page,
+  }) => {
+    // First game.
+    await page.goto('/?seed=222');
+    await waitForGame(page);
+    await page.evaluate(() => window.__solitaire!.draw());
+    await waitForSave(page);
+    const first = await summary(page);
+    expect(first.moveCount).toBe(1);
+
+    // Start a second game — a new session.
+    await page.getByTestId('new-game-btn').click();
+    await waitForGame(page);
+    await page.evaluate(() => {
+      window.__solitaire!.draw();
+      window.__solitaire!.draw();
+    });
+    await waitForSave(page);
+    const second = await summary(page);
+    expect(second.gameSessionId).not.toBe(first.gameSessionId);
+
+    // The manager lists both games.
+    await page.getByTestId('session-manager-btn').click();
+    await expect(page.getByTestId('session-manager-modal')).toBeVisible();
+    await expect(page.getByTestId(`session-row-${first.gameSessionId}`)).toBeVisible();
+    await expect(page.getByTestId(`session-row-${second.gameSessionId}`)).toBeVisible();
+
+    // Resuming the first game switches the board back to it.
+    await page
+      .getByTestId(`session-row-${first.gameSessionId}`)
+      .getByTestId('resume-session-btn')
+      .click();
+    await expect(page.getByTestId('session-manager-modal')).not.toBeVisible();
+
+    const resumed = await summary(page);
+    expect(resumed.gameSessionId).toBe(first.gameSessionId);
+    expect(resumed.moveCount).toBe(1);
+  });
+
+  test('the saved-games manager deletes a game after confirmation', async ({ page }) => {
+    await page.goto('/?seed=444');
+    await waitForGame(page);
+    await page.evaluate(() => window.__solitaire!.draw());
+    await waitForSave(page);
+    const id = (await summary(page)).gameSessionId;
+
+    await page.getByTestId('session-manager-btn').click();
+    const row = page.getByTestId(`session-row-${id}`);
+    await expect(row).toBeVisible();
+
+    // The first click arms the confirmation; the second deletes.
+    const del = row.getByTestId('delete-session-btn');
+    await del.click();
+    await expect(del).toHaveText('Confirm?');
+    await del.click();
+
+    await expect(page.getByTestId(`session-row-${id}`)).not.toBeVisible();
+  });
+
+  test('a clean visit with saved games opens the picker', async ({ page, context }) => {
+    // Create a saved game in this browser.
+    await page.goto('/?seed=555');
+    await waitForGame(page);
+    await page.evaluate(() => window.__solitaire!.draw());
+    await waitForSave(page);
+
+    // A brand-new tab (its own empty sessionStorage) visiting "/" is a clean
+    // visit — with saved games present, it opens the picker.
+    const fresh = await context.newPage();
+    await fresh.goto('/');
+    await waitForGame(fresh);
+    await expect(fresh.getByTestId('session-manager-modal')).toBeVisible();
+    await fresh.close();
+  });
+});

--- a/packages/app/src/components/ControlPanel.tsx
+++ b/packages/app/src/components/ControlPanel.tsx
@@ -15,6 +15,7 @@ import AISettingsSection from './AISettingsSection';
  */
 const ControlPanel: React.FC = () => {
   const { exportGameState, importGameState, initializeGame, toggleValidMoves, toggleGodMode, toggleAutoPlay, setDifficulty, startReplay, askAIForMove, toggleAIAutoPlay } = useGameStore();
+  const setSessionManagerOpen = useGameStore((state) => state.setSessionManagerOpen);
   const showValidMoves = useGameStore((state) => state.showValidMoves);
   const godMode = useGameStore((state) => state.godMode);
   const autoPlayEnabled = useGameStore((state) => state.autoPlayEnabled);
@@ -83,6 +84,10 @@ const ControlPanel: React.FC = () => {
     const params = new URLSearchParams();
     if (seed !== undefined) params.set('seed', String(seed));
     params.set('difficulty', String(difficulty));
+    // `fork=1` tells the new tab it is a fresh Parallel Window: it must start
+    // its own saved session and ignore the sessionStorage copied from this
+    // tab, so the two boards autosave independently without clobbering.
+    params.set('fork', '1');
     window.open(`${window.location.pathname}?${params.toString()}`, '_blank');
     setMessage({
       type: 'success',
@@ -186,6 +191,15 @@ const ControlPanel: React.FC = () => {
           className="w-full bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded transition-colors text-sm"
         >
           New Game
+        </button>
+
+        <button
+          data-testid="session-manager-btn"
+          onClick={() => setSessionManagerOpen(true)}
+          className="w-full bg-amber-600 hover:bg-amber-700 text-white font-semibold py-2 px-4 rounded transition-colors text-sm"
+          title="Browse, resume, or delete games saved automatically in this browser"
+        >
+          📂 Saved Games
         </button>
 
         <button

--- a/packages/app/src/components/GameBoard.tsx
+++ b/packages/app/src/components/GameBoard.tsx
@@ -10,6 +10,7 @@ import ActivityLog from './ActivityLog';
 import AIAdvisorPanel from './AIAdvisorPanel';
 import AIKeyModal from './AIKeyModal';
 import WinModal from './WinModal';
+import SessionManagerModal from './SessionManagerModal';
 import ReplayControls from './ReplayControls';
 import { shouldReduceMotion as checkReducedMotion } from '../utils/motion';
 import { useUnloadGuard } from '../hooks/useUnloadGuard';
@@ -65,6 +66,7 @@ const GameBoard: React.FC = () => {
     <div data-testid="game-board" className="min-h-screen bg-gradient-to-br from-green-700 via-green-600 to-green-800">
       <WinModal />
       <AIKeyModal />
+      <SessionManagerModal />
 
       {/* Desktop: side panels, Mobile: stacked layout */}
       <div className="flex flex-col lg:flex-row lg:items-start gap-4 p-2 sm:p-4 lg:p-6">

--- a/packages/app/src/components/SessionManagerModal.tsx
+++ b/packages/app/src/components/SessionManagerModal.tsx
@@ -1,0 +1,177 @@
+/**
+ * Saved-games manager.
+ *
+ * Lists every game persisted in this browser (see {@link module:store/sessionPersistence})
+ * and lets the player resume or delete one, or start a new game. It is opened
+ * from the control panel, and automatically on a plain first visit when saved
+ * games exist.
+ *
+ * @module components/SessionManagerModal
+ */
+
+import { useCallback, useState } from 'react';
+import { useGameStore } from '../store/gameStore';
+import type { SessionMeta } from '../store/sessionPersistence';
+
+const DIFFICULTY_NAMES = ['', 'Very Easy', 'Easy', 'Normal', 'Hard', 'Very Hard'];
+
+/** Format a save's `updatedAt` timestamp as a short relative time. */
+function relativeTime(timestamp: number): string {
+  const seconds = Math.round((Date.now() - timestamp) / 1000);
+  if (seconds < 60) return 'just now';
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  return `${days}d ago`;
+}
+
+/** Modal body — mounted only while the modal is open, so state starts fresh. */
+const SessionManagerContent: React.FC = () => {
+  const setSessionManagerOpen = useGameStore((s) => s.setSessionManagerOpen);
+  const listSavedSessions = useGameStore((s) => s.listSavedSessions);
+  const loadSavedSession = useGameStore((s) => s.loadSavedSession);
+  const deleteSavedSession = useGameStore((s) => s.deleteSavedSession);
+  const initializeGame = useGameStore((s) => s.initializeGame);
+  const currentSessionId = useGameStore((s) => s.gameSessionId);
+
+  const [sessions, setSessions] = useState<SessionMeta[]>(() => listSavedSessions());
+  const [confirmingId, setConfirmingId] = useState<string | null>(null);
+
+  const refresh = useCallback(() => {
+    setSessions(listSavedSessions());
+  }, [listSavedSessions]);
+
+  const close = () => setSessionManagerOpen(false);
+
+  const handleResume = (sessionId: string) => {
+    if (sessionId === currentSessionId) {
+      close();
+      return;
+    }
+    if (loadSavedSession(sessionId)) close();
+  };
+
+  const handleDelete = (sessionId: string) => {
+    if (confirmingId !== sessionId) {
+      setConfirmingId(sessionId);
+      return;
+    }
+    deleteSavedSession(sessionId);
+    setConfirmingId(null);
+    refresh();
+  };
+
+  const handleNewGame = () => {
+    initializeGame();
+    close();
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Saved games"
+      data-testid="session-manager-modal"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      onClick={close}
+    >
+      <div
+        className="bg-white rounded-lg shadow-2xl w-full max-w-lg p-6"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between mb-4">
+          <div>
+            <h2 className="text-lg font-bold text-gray-900">Saved Games</h2>
+            <p className="text-xs text-gray-500">
+              Games are saved automatically in this browser.
+            </p>
+          </div>
+          <button
+            type="button"
+            data-testid="session-manager-close"
+            onClick={close}
+            aria-label="Close"
+            className="text-gray-400 hover:text-gray-700 text-xl leading-none"
+          >
+            ×
+          </button>
+        </div>
+
+        {sessions.length === 0 ? (
+          <p className="text-sm text-gray-600 bg-gray-100 rounded px-3 py-6 text-center">
+            No saved games yet. Play a move and your game is kept here.
+          </p>
+        ) : (
+          <ul className="max-h-80 overflow-y-auto divide-y divide-gray-100">
+            {sessions.map((s) => {
+              const isCurrent = s.sessionId === currentSessionId;
+              return (
+                <li
+                  key={s.sessionId}
+                  data-testid={`session-row-${s.sessionId}`}
+                  className="flex items-center gap-3 py-2"
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2 text-sm font-semibold text-gray-800">
+                      <span>
+                        #{s.sessionId.slice(-6)}
+                        {s.seed !== undefined ? ` · seed ${s.seed}` : ''}
+                      </span>
+                      {s.gameWon && (
+                        <span className="text-xs font-bold text-green-700">🏆 Won</span>
+                      )}
+                      {isCurrent && (
+                        <span className="text-xs font-medium text-blue-600">· current</span>
+                      )}
+                    </div>
+                    <div className="text-xs text-gray-500">
+                      {DIFFICULTY_NAMES[s.difficulty] ?? 'Normal'} · {s.completionProgress}%
+                      complete · {s.moveCount} moves · {relativeTime(s.updatedAt)}
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    data-testid="resume-session-btn"
+                    onClick={() => handleResume(s.sessionId)}
+                    className="shrink-0 bg-blue-600 hover:bg-blue-700 text-white text-xs font-semibold py-1.5 px-3 rounded transition-colors"
+                  >
+                    {isCurrent ? 'Close' : 'Resume'}
+                  </button>
+                  <button
+                    type="button"
+                    data-testid="delete-session-btn"
+                    onClick={() => handleDelete(s.sessionId)}
+                    className="shrink-0 bg-gray-200 hover:bg-red-100 text-red-700 text-xs font-semibold py-1.5 px-3 rounded transition-colors"
+                  >
+                    {confirmingId === s.sessionId ? 'Confirm?' : 'Delete'}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+
+        <div className="mt-4 flex justify-end">
+          <button
+            type="button"
+            data-testid="session-manager-new-game"
+            onClick={handleNewGame}
+            className="bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded transition-colors text-sm"
+          >
+            New Game
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+/** Saved-games modal — renders only while open. */
+const SessionManagerModal: React.FC = () => {
+  const open = useGameStore((s) => s.sessionManagerOpen);
+  return open ? <SessionManagerContent /> : null;
+};
+
+export default SessionManagerModal;

--- a/packages/app/src/store/activeSession.test.ts
+++ b/packages/app/src/store/activeSession.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for the per-tab active-session anchor.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  resolveActiveSessionId,
+  setActiveSessionId,
+  wasCleanVisit,
+} from './activeSession';
+
+const STORAGE_KEY = 'solitaire:activeSessionId';
+
+/** Set the page URL (path + query) without a navigation. */
+function setUrl(pathAndQuery: string): void {
+  window.history.replaceState({}, '', pathAndQuery);
+}
+
+describe('activeSession', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    setUrl('/');
+  });
+
+  it('resolves the id from the URL and mirrors it into sessionStorage', () => {
+    setUrl('/?session=abc-123');
+    expect(resolveActiveSessionId()).toBe('abc-123');
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBe('abc-123');
+    expect(wasCleanVisit()).toBe(false);
+  });
+
+  it('falls back to sessionStorage when the URL has no anchor', () => {
+    window.sessionStorage.setItem(STORAGE_KEY, 'from-storage');
+    expect(resolveActiveSessionId()).toBe('from-storage');
+  });
+
+  it('prefers the URL over sessionStorage', () => {
+    window.sessionStorage.setItem(STORAGE_KEY, 'stale');
+    setUrl('/?session=fresh');
+    expect(resolveActiveSessionId()).toBe('fresh');
+  });
+
+  it('a ?fork=1 launch starts fresh and discards the inherited anchor', () => {
+    // sessionStorage copied from the opener tab.
+    window.sessionStorage.setItem(STORAGE_KEY, 'opener-session');
+    setUrl('/?seed=42&difficulty=3&fork=1');
+    expect(resolveActiveSessionId()).toBeNull();
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+    // A fork is not a plain visit — it must not show the picker.
+    expect(wasCleanVisit()).toBe(false);
+  });
+
+  it('a plain first visit is a clean visit', () => {
+    setUrl('/');
+    expect(resolveActiveSessionId()).toBeNull();
+    expect(wasCleanVisit()).toBe(true);
+  });
+
+  it('an explicit ?seed= deal is not a clean visit', () => {
+    setUrl('/?seed=99');
+    expect(resolveActiveSessionId()).toBeNull();
+    expect(wasCleanVisit()).toBe(false);
+  });
+
+  it('setActiveSessionId writes the URL and sessionStorage, dropping fork', () => {
+    setUrl('/?seed=7&fork=1');
+    setActiveSessionId('new-session');
+    const params = new URLSearchParams(window.location.search);
+    expect(params.get('session')).toBe('new-session');
+    expect(params.has('fork')).toBe(false);
+    expect(params.get('seed')).toBe('7');
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBe('new-session');
+  });
+});

--- a/packages/app/src/store/activeSession.ts
+++ b/packages/app/src/store/activeSession.ts
@@ -1,0 +1,101 @@
+/**
+ * Per-tab active-session anchor.
+ *
+ * A tab needs to remember which saved game it is playing so a reload — or an
+ * accidental swipe-back/forward — restores the *same* board, while other tabs
+ * (Parallel Windows) keep their own boards.
+ *
+ * The id is anchored in two places ("Both"):
+ *  - the URL (`?session=<id>`) — intrinsically per-tab and reload-stable, and
+ *    the authoritative source on load;
+ *  - `sessionStorage` — a fallback if the URL is ever stripped.
+ *
+ * The Parallel Window trap: `window.open()` to a same-origin page *copies* the
+ * opener's `sessionStorage` into the child. A child must therefore not inherit
+ * the opener's session. The opener opens it with `?fork=1`; the child sees that
+ * flag, discards the inherited anchor, and starts a brand-new session.
+ *
+ * @module store/activeSession
+ */
+
+/** URL query parameter holding the active session id. */
+const URL_PARAM = 'session';
+
+/** URL query parameter marking a freshly-forked Parallel Window. */
+const FORK_PARAM = 'fork';
+
+/** `sessionStorage` key mirroring the active session id. */
+const STORAGE_KEY = 'solitaire:activeSessionId';
+
+/** True when startup found no anchor and the launch was not an explicit deal. */
+let cleanVisit = false;
+
+/** Safe `sessionStorage` accessor (it can throw in private modes / SSR). */
+function sessionStore(): Storage | null {
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the session id this tab should restore on startup.
+ *
+ * Returns `null` when the tab should start a fresh game: a `?fork=1` launch, an
+ * explicit `?seed=`/`?difficulty=` deal, or a plain first visit. {@link wasCleanVisit}
+ * distinguishes the plain first visit (the only case that may show the picker).
+ */
+export function resolveActiveSessionId(): string | null {
+  cleanVisit = false;
+  if (typeof window === 'undefined') return null;
+
+  const params = new URLSearchParams(window.location.search);
+
+  // A Parallel Window fork must ignore the sessionStorage copied from its
+  // opener and start its own session.
+  if (params.has(FORK_PARAM)) {
+    sessionStore()?.removeItem(STORAGE_KEY);
+    return null;
+  }
+
+  // The URL is authoritative; mirror it into sessionStorage.
+  const fromUrl = params.get(URL_PARAM);
+  if (fromUrl) {
+    sessionStore()?.setItem(STORAGE_KEY, fromUrl);
+    return fromUrl;
+  }
+
+  // No URL anchor — fall back to sessionStorage (e.g. URL stripped by a tool).
+  const fromStorage = sessionStore()?.getItem(STORAGE_KEY) ?? null;
+  if (fromStorage) return fromStorage;
+
+  // Nothing to restore. A plain visit may show the saved-games picker; an
+  // explicit deal (?seed=/?difficulty=) should just deal that board.
+  cleanVisit = !params.has('seed') && !params.has('difficulty');
+  return null;
+}
+
+/**
+ * Whether startup was a plain first visit with no session to restore — the
+ * only case in which the saved-games picker should be offered.
+ */
+export function wasCleanVisit(): boolean {
+  return cleanVisit;
+}
+
+/**
+ * Anchor this tab to `sessionId`: reflect it into the URL (via `replaceState`,
+ * so no history entry is added) and into `sessionStorage`. The one-shot
+ * `?fork=1` flag is removed once consumed.
+ */
+export function setActiveSessionId(sessionId: string): void {
+  if (typeof window === 'undefined') return;
+
+  sessionStore()?.setItem(STORAGE_KEY, sessionId);
+
+  const url = new URL(window.location.href);
+  url.searchParams.set(URL_PARAM, sessionId);
+  url.searchParams.delete(FORK_PARAM);
+  window.history.replaceState(window.history.state, '', url);
+}

--- a/packages/app/src/store/gameStore.session.test.ts
+++ b/packages/app/src/store/gameStore.session.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests for the game store's saved-session actions.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useGameStore } from './gameStore';
+import { saveSession, loadSession } from './sessionPersistence';
+import type { Move } from '../types';
+
+const aMove: Move = {
+  type: 'draw_card',
+  timestamp: 0,
+  card: { suit: 'hearts', rank: 'A', faceUp: true, id: 'h-a' },
+};
+
+describe('gameStore — saved sessions', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useGameStore.getState().initializeGame(3, 1);
+  });
+
+  it('setSessionManagerOpen toggles the modal flag', () => {
+    useGameStore.getState().setSessionManagerOpen(true);
+    expect(useGameStore.getState().sessionManagerOpen).toBe(true);
+    useGameStore.getState().setSessionManagerOpen(false);
+    expect(useGameStore.getState().sessionManagerOpen).toBe(false);
+  });
+
+  it('loadSavedSession restores a saved game into the store', () => {
+    // Seed a saved game directly in storage.
+    saveSession({
+      ...useGameStore.getState(),
+      gameSessionId: 'saved-x',
+      seed: 555,
+      moveHistory: [aMove],
+      sessionManagerOpen: true,
+    });
+
+    const ok = useGameStore.getState().loadSavedSession('saved-x');
+    expect(ok).toBe(true);
+
+    const state = useGameStore.getState();
+    expect(state.gameSessionId).toBe('saved-x');
+    expect(state.seed).toBe(555);
+    expect(state.moveHistory).toHaveLength(1);
+    // Restoring closes the manager and resets transient state.
+    expect(state.sessionManagerOpen).toBe(false);
+    expect(state.aiThinking).toBe(false);
+    expect(state.replayMode).toBe(false);
+  });
+
+  it('loadSavedSession returns false for an unknown id', () => {
+    expect(useGameStore.getState().loadSavedSession('does-not-exist')).toBe(false);
+  });
+
+  it('deleteSavedSession removes a save from storage', () => {
+    saveSession({
+      ...useGameStore.getState(),
+      gameSessionId: 'saved-del',
+      moveHistory: [aMove],
+    });
+    expect(loadSession('saved-del')).not.toBeNull();
+
+    useGameStore.getState().deleteSavedSession('saved-del');
+    expect(loadSession('saved-del')).toBeNull();
+  });
+
+  it('listSavedSessions reports saved games', () => {
+    saveSession({
+      ...useGameStore.getState(),
+      gameSessionId: 'saved-list',
+      moveHistory: [aMove],
+    });
+    const ids = useGameStore.getState().listSavedSessions().map((m) => m.sessionId);
+    expect(ids).toContain('saved-list');
+  });
+});

--- a/packages/app/src/store/gameStore.ts
+++ b/packages/app/src/store/gameStore.ts
@@ -46,6 +46,22 @@ import {
 } from '../ai';
 import type { AIConfig, AIDecisionRecord } from '../ai';
 import { APP_BUILD_TIME, APP_COMMIT } from '../buildInfo';
+import {
+  resolveActiveSessionId,
+  setActiveSessionId,
+  wasCleanVisit,
+} from './activeSession';
+import {
+  loadSession,
+  saveSession,
+  deleteSession,
+  listSessions,
+  type PersistedGameState,
+  type SessionMeta,
+} from './sessionPersistence';
+
+/** Debounce window (ms) for autosaving the active game after a change. */
+const SESSION_AUTOSAVE_DELAY = 500;
 
 /** Shared core engine instance — used for legal-move generation by the AI advisor. */
 const engine = new GameEngine();
@@ -128,6 +144,14 @@ interface GameStore extends GameState {
   exportAIInteractions: () => string;
   /** Dismiss the win modal without starting a new game. */
   dismissWinModal: () => void;
+  /** Restore a previously saved game by its session id. Returns success. */
+  loadSavedSession: (sessionId: string) => boolean;
+  /** Delete a saved game from storage. */
+  deleteSavedSession: (sessionId: string) => void;
+  /** Every saved game's metadata, most recently played first. */
+  listSavedSessions: () => SessionMeta[];
+  /** Open or close the saved-games manager modal. */
+  setSessionManagerOpen: (open: boolean) => void;
 }
 
 /**
@@ -220,6 +244,7 @@ const initializeGameState = (
     aiError: undefined,
     aiDecisionLog: [],
     aiKeyModalOpen: false,
+    sessionManagerOpen: false,
   };
 
   // Calculate perceived difficulty after initialState is created
@@ -228,10 +253,98 @@ const initializeGameState = (
   return initialState;
 };
 
+/**
+ * Whether a persisted snapshot has the structural shape of a real game and is
+ * safe to restore (seven tableau columns, the four foundations, card arrays).
+ */
+function isRestorable(p: PersistedGameState | null): p is PersistedGameState {
+  return (
+    p != null &&
+    Array.isArray(p.tableau) &&
+    p.tableau.length === 7 &&
+    Array.isArray(p.drawPile) &&
+    Array.isArray(p.discardPile) &&
+    Array.isArray(p.moveHistory) &&
+    p.foundations != null &&
+    Array.isArray(p.foundations.hearts) &&
+    Array.isArray(p.foundations.diamonds) &&
+    Array.isArray(p.foundations.clubs) &&
+    Array.isArray(p.foundations.spades)
+  );
+}
+
+/**
+ * Reconstitute a full {@link GameState} from a persisted snapshot. All
+ * transient state — selection, in-flight AI, replay and auto-play progress —
+ * is reset; only the game itself is restored.
+ */
+function hydratePersisted(p: PersistedGameState): GameState {
+  return {
+    drawPile: p.drawPile,
+    discardPile: p.discardPile,
+    foundations: p.foundations,
+    tableau: p.tableau,
+    selectedCard: undefined,
+    moveHistory: p.moveHistory,
+    showValidMoves: p.showValidMoves,
+    godMode: p.godMode,
+    autoPlayEnabled: false,
+    autoPlayInProgress: false,
+    autoPlayStateHistory: [],
+    difficulty: p.difficulty,
+    seed: p.seed,
+    gameSessionId: p.gameSessionId,
+    gameStartedAt: p.gameStartedAt,
+    gameWon: p.gameWon,
+    winModalDismissed: p.winModalDismissed,
+    initialBoardSetup: p.initialBoardSetup,
+    perceivedDifficulty: p.perceivedDifficulty,
+    completionProgress: p.completionProgress,
+    replayMode: false,
+    replayIndex: 0,
+    replayPaused: false,
+    replaySpeed: p.replaySpeed ?? 1000,
+    aiConfig: p.aiConfig ?? DEFAULT_AI_CONFIG,
+    aiThinking: false,
+    aiAutoPlay: false,
+    aiThinkingSince: undefined,
+    aiStatus: undefined,
+    aiRetryCount: 0,
+    aiError: undefined,
+    aiDecisionLog: p.aiDecisionLog ?? [],
+    aiKeyModalOpen: false,
+    sessionManagerOpen: false,
+  };
+}
+
+/**
+ * Resolve the state the store starts with: a restored saved game when this tab
+ * is anchored to one, otherwise a fresh deal. On a plain first visit with
+ * saved games available, the saved-games picker is opened over the fresh deal.
+ */
+function buildInitialState(): GameState {
+  const activeId = resolveActiveSessionId();
+  if (activeId) {
+    const persisted = loadSession(activeId);
+    if (isRestorable(persisted)) {
+      return hydratePersisted(persisted);
+    }
+  }
+
+  const fresh = initializeGameState(
+    initialGameConfig.difficulty,
+    initialGameConfig.seed,
+  );
+  if (wasCleanVisit() && listSessions().length > 0) {
+    fresh.sessionManagerOpen = true;
+  }
+  return fresh;
+}
+
 
 
 export const useGameStore = create<GameStore>((set, get) => ({
-  ...initializeGameState(initialGameConfig.difficulty, initialGameConfig.seed),
+  ...buildInitialState(),
   initializeGame: (difficulty?: Difficulty, seed?: number) => {
     const currentDifficulty = difficulty ?? get().difficulty ?? 3;
     // A new game invalidates any in-flight AI request.
@@ -1501,4 +1614,65 @@ export const useGameStore = create<GameStore>((set, get) => ({
   dismissWinModal: () => {
     set({ winModalDismissed: true });
   },
+
+  loadSavedSession: (sessionId: string) => {
+    const persisted = loadSession(sessionId);
+    if (!isRestorable(persisted)) return false;
+    // Restoring a game invalidates any in-flight AI request.
+    aiAbortController?.abort();
+    aiAbortController = null;
+    set({ ...hydratePersisted(persisted), sessionManagerOpen: false });
+    return true;
+  },
+
+  deleteSavedSession: (sessionId: string) => {
+    deleteSession(sessionId);
+  },
+
+  listSavedSessions: () => listSessions(),
+
+  setSessionManagerOpen: (open: boolean) => {
+    set({ sessionManagerOpen: open });
+  },
 }));
+
+// ---------------------------------------------------------------------------
+// Session persistence: anchor the tab to its game, and autosave on change.
+// ---------------------------------------------------------------------------
+
+if (typeof window !== 'undefined') {
+  const firstId = useGameStore.getState().gameSessionId;
+  if (firstId) setActiveSessionId(firstId);
+  // Persist the starting game so even an immediate reload restores it. (An
+  // untouched, move-free deal is skipped by saveSession — nothing to lose.)
+  saveSession(useGameStore.getState());
+
+  let anchoredId = firstId;
+  let lastSignature = '';
+  let saveTimer: ReturnType<typeof setTimeout> | null = null;
+
+  useGameStore.subscribe((state) => {
+    // Re-anchor the tab whenever the game identity changes — a New Game, or
+    // resuming a save — so a reload restores the game now on screen.
+    if (state.gameSessionId && state.gameSessionId !== anchoredId) {
+      anchoredId = state.gameSessionId;
+      setActiveSessionId(state.gameSessionId);
+    }
+
+    // Debounced autosave, skipped when nothing persisted actually changed
+    // (e.g. an AI "thinking" flag toggling does not touch the saved game).
+    const signature =
+      `${state.gameSessionId}|${state.moveHistory.length}|${state.gameWon}` +
+      `|${Math.round(state.completionProgress)}|${state.godMode}` +
+      `|${state.showValidMoves}|${state.replaySpeed}` +
+      `|${state.winModalDismissed}|${state.aiDecisionLog?.length ?? 0}`;
+    if (signature === lastSignature) return;
+    lastSignature = signature;
+
+    if (saveTimer) clearTimeout(saveTimer);
+    saveTimer = setTimeout(() => {
+      saveTimer = null;
+      saveSession(useGameStore.getState());
+    }, SESSION_AUTOSAVE_DELAY);
+  });
+}

--- a/packages/app/src/store/sessionPersistence.test.ts
+++ b/packages/app/src/store/sessionPersistence.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for per-session game persistence.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  saveSession,
+  loadSession,
+  listSessions,
+  deleteSession,
+  MAX_SESSIONS,
+} from './sessionPersistence';
+import type { GameState, Move } from '../types';
+
+const aMove: Move = {
+  type: 'draw_card',
+  timestamp: 0,
+  card: { suit: 'hearts', rank: 'A', faceUp: true, id: 'h-a' },
+};
+
+/** Build a minimal but structurally valid game state. */
+function makeState(overrides: Partial<GameState> = {}): GameState {
+  return {
+    drawPile: [],
+    discardPile: [],
+    foundations: { hearts: [], diamonds: [], clubs: [], spades: [] },
+    tableau: [[], [], [], [], [], [], []],
+    moveHistory: [aMove],
+    showValidMoves: true,
+    godMode: false,
+    autoPlayEnabled: false,
+    autoPlayInProgress: false,
+    difficulty: 3,
+    seed: 42,
+    gameSessionId: 'session-1',
+    gameStartedAt: 1000,
+    gameWon: false,
+    completionProgress: 25,
+    replayMode: false,
+    replayIndex: 0,
+    replayPaused: false,
+    replaySpeed: 1000,
+    ...overrides,
+  };
+}
+
+describe('sessionPersistence', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('saves and reloads a game by its session id', () => {
+    saveSession(makeState({ gameSessionId: 's-A', seed: 7, completionProgress: 40 }));
+    const loaded = loadSession('s-A');
+    expect(loaded).not.toBeNull();
+    expect(loaded?.gameSessionId).toBe('s-A');
+    expect(loaded?.seed).toBe(7);
+    expect(loaded?.completionProgress).toBe(40);
+    expect(loaded?.moveHistory).toHaveLength(1);
+  });
+
+  it('returns null for a missing or corrupt session', () => {
+    expect(loadSession('nope')).toBeNull();
+    localStorage.setItem('solitaire:save:bad', '{not json');
+    expect(loadSession('bad')).toBeNull();
+  });
+
+  it('skips an untouched, move-free deal', () => {
+    saveSession(makeState({ gameSessionId: 's-empty', moveHistory: [], gameWon: false }));
+    expect(loadSession('s-empty')).toBeNull();
+  });
+
+  it('persists a won game even with no recorded moves', () => {
+    saveSession(makeState({ gameSessionId: 's-won', moveHistory: [], gameWon: true }));
+    expect(loadSession('s-won')?.gameWon).toBe(true);
+  });
+
+  it('lists saved games most-recently-updated first', () => {
+    let now = 1000;
+    vi.spyOn(Date, 'now').mockImplementation(() => (now += 1000));
+    saveSession(makeState({ gameSessionId: 's-old' }));
+    saveSession(makeState({ gameSessionId: 's-mid' }));
+    saveSession(makeState({ gameSessionId: 's-new' }));
+    expect(listSessions().map((m) => m.sessionId)).toEqual(['s-new', 's-mid', 's-old']);
+  });
+
+  it('deletes a saved game', () => {
+    saveSession(makeState({ gameSessionId: 's-del' }));
+    expect(loadSession('s-del')).not.toBeNull();
+    deleteSession('s-del');
+    expect(loadSession('s-del')).toBeNull();
+  });
+
+  it('evicts the oldest game once the cap is exceeded', () => {
+    let now = 1000;
+    vi.spyOn(Date, 'now').mockImplementation(() => (now += 1000));
+    for (let i = 0; i < MAX_SESSIONS + 1; i++) {
+      saveSession(makeState({ gameSessionId: `s-${i}` }));
+    }
+    const ids = listSessions().map((m) => m.sessionId);
+    expect(ids).toHaveLength(MAX_SESSIONS);
+    // The first-saved (oldest) game was evicted; the newest survived.
+    expect(ids).not.toContain('s-0');
+    expect(ids).toContain(`s-${MAX_SESSIONS}`);
+  });
+
+  it('overwriting an existing game never evicts it', () => {
+    let now = 1000;
+    vi.spyOn(Date, 'now').mockImplementation(() => (now += 1000));
+    // Fill to the cap.
+    for (let i = 0; i < MAX_SESSIONS; i++) {
+      saveSession(makeState({ gameSessionId: `s-${i}` }));
+    }
+    // Re-save the oldest — it must still be present afterwards.
+    saveSession(makeState({ gameSessionId: 's-0', completionProgress: 99 }));
+    expect(loadSession('s-0')?.completionProgress).toBe(99);
+    expect(listSessions()).toHaveLength(MAX_SESSIONS);
+  });
+});

--- a/packages/app/src/store/sessionPersistence.ts
+++ b/packages/app/src/store/sessionPersistence.ts
@@ -1,0 +1,223 @@
+/**
+ * Per-session game persistence.
+ *
+ * Each saved game is stored as a single `localStorage` entry keyed by its
+ * session id (`solitaire:save:<sessionId>`). Keeping one entry per game means
+ * multiple boards open at once — e.g. Parallel Windows — persist independently
+ * and never clobber one another.
+ *
+ * The saved-games list is derived by *scanning* keys with the shared prefix;
+ * there is deliberately no single index entry, so concurrent windows cannot
+ * race on a shared registry.
+ *
+ * @module store/sessionPersistence
+ */
+
+import type { GameState } from '../types';
+
+/** Key prefix for every persisted game entry. */
+const KEY_PREFIX = 'solitaire:save:';
+
+/** Storage schema version. A saved entry with a different version is ignored. */
+const SCHEMA_VERSION = 1;
+
+/** Most-recently-played games to retain; older ones are evicted on write. */
+export const MAX_SESSIONS = 12;
+
+/**
+ * The {@link GameState} fields that make up a restorable game. Transient state
+ * (selection, in-flight AI flags, replay/auto-play progress) is deliberately
+ * excluded — it is reset on restore.
+ */
+export interface PersistedGameState {
+  drawPile: GameState['drawPile'];
+  discardPile: GameState['discardPile'];
+  foundations: GameState['foundations'];
+  tableau: GameState['tableau'];
+  moveHistory: GameState['moveHistory'];
+  showValidMoves: GameState['showValidMoves'];
+  godMode: GameState['godMode'];
+  difficulty: GameState['difficulty'];
+  seed: GameState['seed'];
+  gameSessionId: GameState['gameSessionId'];
+  gameStartedAt: GameState['gameStartedAt'];
+  gameWon: GameState['gameWon'];
+  winModalDismissed: GameState['winModalDismissed'];
+  initialBoardSetup: GameState['initialBoardSetup'];
+  perceivedDifficulty: GameState['perceivedDifficulty'];
+  completionProgress: GameState['completionProgress'];
+  replaySpeed: GameState['replaySpeed'];
+  aiConfig: GameState['aiConfig'];
+  aiDecisionLog: GameState['aiDecisionLog'];
+}
+
+/** Lightweight, list-friendly summary of a saved game. */
+export interface SessionMeta {
+  sessionId: string;
+  seed?: number;
+  difficulty: number;
+  /** Completion progress, 0–100 (rounded). */
+  completionProgress: number;
+  /** Move-history length. */
+  moveCount: number;
+  gameWon: boolean;
+  /** When the game was first saved. */
+  createdAt: number;
+  /** When the game was last saved. */
+  updatedAt: number;
+}
+
+/** The full stored shape: schema version, list metadata, and the game state. */
+interface StoredSession {
+  version: number;
+  meta: SessionMeta;
+  state: PersistedGameState;
+}
+
+/** Whether `localStorage` is usable (it can throw in private modes / SSR). */
+function storageAvailable(): boolean {
+  try {
+    return typeof localStorage !== 'undefined';
+  } catch {
+    return false;
+  }
+}
+
+/** Extract the restorable subset of a live game state. */
+function pickPersisted(state: GameState): PersistedGameState {
+  return {
+    drawPile: state.drawPile,
+    discardPile: state.discardPile,
+    foundations: state.foundations,
+    tableau: state.tableau,
+    moveHistory: state.moveHistory,
+    showValidMoves: state.showValidMoves,
+    godMode: state.godMode,
+    difficulty: state.difficulty,
+    seed: state.seed,
+    gameSessionId: state.gameSessionId,
+    gameStartedAt: state.gameStartedAt,
+    gameWon: state.gameWon,
+    winModalDismissed: state.winModalDismissed,
+    initialBoardSetup: state.initialBoardSetup,
+    perceivedDifficulty: state.perceivedDifficulty,
+    completionProgress: state.completionProgress,
+    replaySpeed: state.replaySpeed,
+    aiConfig: state.aiConfig,
+    aiDecisionLog: state.aiDecisionLog,
+  };
+}
+
+/** Parse a stored entry, returning `null` when missing, corrupt, or stale. */
+function readEntry(key: string): StoredSession | null {
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as StoredSession;
+    if (parsed.version !== SCHEMA_VERSION || !parsed.meta || !parsed.state) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/** Every persisted-session key currently in `localStorage`. */
+function sessionKeys(): string[] {
+  const keys: string[] = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key && key.startsWith(KEY_PREFIX)) keys.push(key);
+  }
+  return keys;
+}
+
+/**
+ * Evict the oldest saved games until at most `MAX_SESSIONS - 1` remain, so the
+ * caller can write one more. The key being (re)written is exempt — overwriting
+ * an existing game must never evict it. Returns whether anything was removed.
+ */
+function evictForWrite(keyBeingWritten: string): boolean {
+  const others = sessionKeys().filter((k) => k !== keyBeingWritten);
+  if (others.length < MAX_SESSIONS) return false;
+
+  const byAge = others
+    .map((k) => ({ k, updatedAt: readEntry(k)?.meta.updatedAt ?? 0 }))
+    .sort((a, b) => a.updatedAt - b.updatedAt);
+
+  let removed = false;
+  // Leave room for the new entry: keep at most MAX_SESSIONS - 1 others.
+  const excess = others.length - (MAX_SESSIONS - 1);
+  for (let i = 0; i < excess && i < byAge.length; i++) {
+    localStorage.removeItem(byAge[i].k);
+    removed = true;
+  }
+  return removed;
+}
+
+/**
+ * Persist a game under its session id. No-op when the state has no session id,
+ * storage is unavailable, or the game is an untouched fresh deal (no moves and
+ * not won — there is nothing worth restoring). Enforces the {@link MAX_SESSIONS}
+ * cap and retries once, after evicting the oldest game, on a quota error.
+ */
+export function saveSession(state: GameState): void {
+  if (!storageAvailable() || !state.gameSessionId) return;
+  if (state.moveHistory.length === 0 && !state.gameWon) return;
+
+  const key = KEY_PREFIX + state.gameSessionId;
+  const now = Date.now();
+  const existing = readEntry(key);
+
+  const stored: StoredSession = {
+    version: SCHEMA_VERSION,
+    meta: {
+      sessionId: state.gameSessionId,
+      seed: state.seed,
+      difficulty: state.difficulty,
+      completionProgress: Math.round(state.completionProgress),
+      moveCount: state.moveHistory.length,
+      gameWon: state.gameWon,
+      createdAt: existing?.meta.createdAt ?? state.gameStartedAt ?? now,
+      updatedAt: now,
+    },
+    state: pickPersisted(state),
+  };
+
+  evictForWrite(key);
+  const payload = JSON.stringify(stored);
+  try {
+    localStorage.setItem(key, payload);
+  } catch {
+    // Quota exceeded — drop the oldest game and try once more.
+    if (evictForWrite(key)) {
+      try {
+        localStorage.setItem(key, payload);
+      } catch {
+        // Give up silently; an unsaved game is better than a thrown error.
+      }
+    }
+  }
+}
+
+/** Load a saved game's persisted state, or `null` when absent/corrupt/stale. */
+export function loadSession(sessionId: string): PersistedGameState | null {
+  if (!storageAvailable()) return null;
+  return readEntry(KEY_PREFIX + sessionId)?.state ?? null;
+}
+
+/** Delete a saved game. */
+export function deleteSession(sessionId: string): void {
+  if (!storageAvailable()) return;
+  localStorage.removeItem(KEY_PREFIX + sessionId);
+}
+
+/** Every saved game's metadata, most recently played first. */
+export function listSessions(): SessionMeta[] {
+  if (!storageAvailable()) return [];
+  return sessionKeys()
+    .map((k) => readEntry(k)?.meta)
+    .filter((m): m is SessionMeta => m != null)
+    .sort((a, b) => b.updatedAt - a.updatedAt);
+}

--- a/packages/app/src/types/index.ts
+++ b/packages/app/src/types/index.ts
@@ -105,4 +105,5 @@ export interface GameState {
   aiError?: string; // Last AI advisor error message, shown until the next request
   aiDecisionLog?: AIDecisionRecord[]; // History of AI decisions (most recent last)
   aiKeyModalOpen?: boolean; // True when the API key modal is open
+  sessionManagerOpen?: boolean; // True when the saved-games manager modal is open
 }


### PR DESCRIPTION
Games are kept only in memory, so a reload or an accidental navigation discards an unfinished game. This adds automatic per-session persistence to `localStorage`, designed so multiple boards — including Parallel Windows — persist independently and never clobber one another.

## Design

**`sessionPersistence`** — one `localStorage` entry per game (`solitaire:save:<sessionId>`). The saved-games list is derived by *scanning* keys with the shared prefix; there is no single index entry, so concurrent windows cannot race on a shared registry. Retained games are capped (12) and the oldest is evicted on write; quota errors are handled with an evict-and-retry. Untouched, move-free deals are not saved.

**`activeSession`** — anchors each tab to its game in **both** the URL (`?session=<id>`) and `sessionStorage`. The URL is authoritative and reload-stable; `sessionStorage` is a fallback. A Parallel Window opens the child with `?fork=1` so it discards the `sessionStorage` copied from its opener (a `window.open` quirk) and starts its own session.

**`gameStore`** — restores the anchored game on load; debounced autosave on change (skipped when nothing persisted changed); new actions `loadSavedSession` / `deleteSavedSession` / `listSavedSessions` / `setSessionManagerOpen`. Transient state (selection, in-flight AI, replay/auto-play progress) is reset on restore.

**`SessionManagerModal`** — browse, resume, or delete saved games. Opens from the control panel ("📂 Saved Games") and automatically on a plain first visit when saved games exist.

## Testing

- **Unit/integration** — 274 pass, incl. new suites for `sessionPersistence` (save/load/list/delete/eviction/quota), `activeSession` (URL vs storage vs fork resolution), and the store's saved-session actions.
- **E2E (headless Playwright)** — 57 pass, incl. a new `session-persistence.spec.ts`: autosave + restore on reload, **parallel windows persisting and restoring independent boards**, the manager listing/resuming/deleting games, and the picker auto-opening on a clean visit.
- `tsc -b`, `eslint`, and `vite build` all clean.