### PR TITLE
fix(ui): use a dropdown for the AI model selector

### DIFF
--- a/packages/app/src/components/AIKeyModal.tsx
+++ b/packages/app/src/components/AIKeyModal.tsx
@@ -77,25 +77,28 @@ const AIKeyModalContent: React.FC = () => {
           {provider.displayName}
         </div>
 
-        {/* Model */}
+        {/* Model — a dropdown of the provider's known models. If the stored
+            config names one outside that list (e.g. a legacy value), include
+            it so saving the form does not silently swap models. */}
         <label htmlFor="ai-model-input" className="block text-sm font-semibold text-gray-700 mb-1">
           Model
         </label>
-        <input
+        <select
           id="ai-model-input"
           data-testid="ai-model-input"
-          type="text"
-          list="ai-model-options"
           value={model}
           onChange={(e) => setModel(e.target.value)}
-          className="w-full border border-gray-300 rounded px-3 py-2 mb-1 text-sm"
-          placeholder="e.g. gemma-4-31b-it"
-        />
-        <datalist id="ai-model-options">
-          {provider.availableModels.map((m) => (
-            <option key={m} value={m} />
+          className="w-full border border-gray-300 rounded px-3 py-2 mb-1 text-sm bg-white"
+        >
+          {(provider.availableModels.includes(model)
+            ? provider.availableModels
+            : [model, ...provider.availableModels]
+          ).map((m) => (
+            <option key={m} value={m}>
+              {m}
+            </option>
           ))}
-        </datalist>
+        </select>
         <p className="text-xs text-gray-500 mb-4">
           Default <code>gemma-4-31b-it</code> is a thinking model — a suggestion can take
           up to ~3 minutes. Pick a faster model (e.g.{' '}


### PR DESCRIPTION
The model field in the AI Setup modal was a free-text `<input>` with a `<datalist>` of suggestions, so users could type any string and only discover the valid options after a failed call. The set of supported models per provider is small and stable (Gemini ships three), so a proper `<select>` is the right control.

If the stored config names a model outside `provider.availableModels` (e.g. a legacy value), it is prepended as an extra option, so opening and saving the form never silently swaps models.

- `packages/app/src/components/AIKeyModal.tsx` — `<input list=...>` + `<datalist>` → `<select>`. Same testid (`ai-model-input`) and label, so existing e2e/key-modal coverage continues to pass.

Local: 284 unit + 57 e2e pass; lint + typecheck + build clean.