### PR TITLE
chore(deps): add a 30-day Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "UTC"
+    # Let a release sit for 30 days before Dependabot proposes it. Filters out
+    # day-zero releases that get yanked and lets the ecosystem react first.
+    cooldown:
+      default-days: 30
     groups:
       # Group all production dependencies together
       production-dependencies:
@@ -47,6 +51,9 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "UTC"
+    # Same 30-day cooldown as the npm updates.
+    cooldown:
+      default-days: 30
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
Day-zero releases get yanked, contain broken transitives, or break the ecosystem in ways the maintainer fixes within the first month. Waiting 30 days for any new version before Dependabot proposes it filters those out without sacrificing the long-term update cadence.

Uses Dependabot's native [`cooldown.default-days`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-) option, which honors security advisories regardless — security updates ignore cooldown.

Applies to both update streams in `.github/dependabot.yml`:
- `npm` (monorepo dependencies)
- `github-actions`

## Companion cleanup
Stale Dependabot PRs #165 (13 production-dep bumps) and #166 (`@types/node`) closed in tandem — their CI predates today's #170/#171 merges. Dependabot will re-issue updates on the next weekly run, now subject to the 30-day cooldown.