### PR TITLE
feat(ai): refine stall terminator with shuffle-fraction gate + outcome

### DIFF
--- a/packages/app/src/ai/constants.ts
+++ b/packages/app/src/ai/constants.ts
@@ -45,8 +45,37 @@ export const AI_AUTO_LOOP_LIMIT = 5;
  * Distinct from {@link AI_AUTO_LOOP_LIMIT}, which catches an *exactly* repeating
  * board position. A stall is flat progress while the board still churns (e.g.
  * cycling the stock), which loop detection never catches.
+ *
+ * Kept in lockstep with `STALL_TURNS` in the analytics-side
+ * `scripts/ingest_exports.py` — the harness terminates a game exactly when the
+ * ingest filter would have dropped its remaining decisions from training.
  */
 export const AI_AUTO_STALL_LIMIT = 25;
+
+/**
+ * Minimum fraction of *shuffle* moves in the stall window required to trigger
+ * auto-termination. Combined with {@link AI_AUTO_STALL_LIMIT} this is a
+ * two-gate rule: terminate only when (plateau ≥ AI_AUTO_STALL_LIMIT) AND
+ * (shuffle fraction ≥ AI_AUTO_STALL_SHUFFLE_FRACTION).
+ *
+ * The shuffle set is `{tableau_to_tableau, discard_to_tableau}` — moves that
+ * rearrange visible cards without surfacing new information. `draw_card` and
+ * `recycle_stock` are *information-gathering*: a long plateau of draws is an
+ * honest hunt for a still-face-down card (e.g. a missing Ace) and must not
+ * terminate. `tableau_to_foundation` and `discard_to_foundation` always make
+ * progress, so they cannot appear in a plateau window by construction.
+ *
+ * Empirical anchors (analytics 2026-05-20 doc, two real sessions on the
+ * stall threshold):
+ *  - `1279a3` — 24-turn plateau, 0% shuffles (18 draws + 1 recycle): honest
+ *    hunt, must NOT terminate.
+ *  - `73fd85` — 15-turn plateau on its way to a doom-loop, ~70% shuffles
+ *    (tableau-to-tableau oscillation): must terminate.
+ *
+ * 0.6 gives both cases wide headroom; tune from per-termination telemetry on
+ * the `stall_terminated` interaction once a real sample exists.
+ */
+export const AI_AUTO_STALL_SHUFFLE_FRACTION = 0.6;
 
 /**
  * How many times a single move request is attempted before giving up. LLM

--- a/packages/app/src/ai/index.ts
+++ b/packages/app/src/ai/index.ts
@@ -16,9 +16,17 @@ export {
   AI_AUTO_HISTORY_LIMIT,
   AI_AUTO_LOOP_LIMIT,
   AI_AUTO_STALL_LIMIT,
+  AI_AUTO_STALL_SHUFFLE_FRACTION,
   AI_RETRY_MAX_ATTEMPTS,
   AI_AUTO_RETRY_COOLDOWN,
 } from './constants';
+
+// Stall detection (two-gate rule)
+export {
+  STALL_SHUFFLE_MOVE_TYPES,
+  shuffleFraction,
+  shouldTerminateOnStall,
+} from './stallDetection';
 
 // Retry / resilience
 export {

--- a/packages/app/src/ai/interactionLog.test.ts
+++ b/packages/app/src/ai/interactionLog.test.ts
@@ -119,6 +119,37 @@ describe('interactionLog', () => {
     expect(parsed.session).toBeUndefined();
   });
 
+  it('accepts stalled_auto_terminated as a session outcome', () => {
+    recordAIInteraction(base);
+    const parsed = JSON.parse(
+      exportAIInteractions({
+        sessionId: 'session-abcdef12',
+        seed: 99,
+        model: 'gemma-4-31b-it',
+        outcome: 'stalled_auto_terminated',
+        finalProgress: 42,
+        moveCount: 88,
+      }),
+    );
+    expect(parsed.session.outcome).toBe('stalled_auto_terminated');
+  });
+
+  it('carries stall-trigger telemetry on a stall_terminated event entry', () => {
+    recordAIInteraction({
+      ...base,
+      id: 'id-stall',
+      event: 'stall_terminated',
+      plateauLength: 25,
+      shuffleFraction: 0.72,
+      moveTypeWindow: Array.from({ length: 25 }, () => 'tableau_to_tableau'),
+    });
+    const last = getLastAIInteraction();
+    expect(last?.event).toBe('stall_terminated');
+    expect(last?.plateauLength).toBe(25);
+    expect(last?.shuffleFraction).toBe(0.72);
+    expect(last?.moveTypeWindow).toHaveLength(25);
+  });
+
   it('clearAIInteractions empties the buffer', () => {
     recordAIInteraction(base);
     clearAIInteractions();

--- a/packages/app/src/ai/interactionLog.ts
+++ b/packages/app/src/ai/interactionLog.ts
@@ -51,6 +51,25 @@ export interface AIInteraction {
    */
   event?: 'forced_move' | 'stall_terminated';
   /**
+   * Plateau length at the moment a `stall_terminated` event fired — number of
+   * consecutive flat-progress turns. Equals `AI_AUTO_STALL_LIMIT` at the first
+   * possible trigger; may be larger if other gates delayed the fire.
+   */
+  plateauLength?: number;
+  /**
+   * Shuffle fraction over the move-type window at the moment of trigger
+   * (`{tableau_to_tableau, discard_to_tableau}` / window length, in [0, 1]).
+   * Lets the analytics side audit and tune `AI_AUTO_STALL_SHUFFLE_FRACTION`
+   * without re-deriving it from the moves applied.
+   */
+  shuffleFraction?: number;
+  /**
+   * The exact move-type window that produced {@link shuffleFraction}. One entry
+   * per flat turn in the plateau, oldest first. Length matches
+   * {@link plateauLength} at trigger time.
+   */
+  moveTypeWindow?: string[];
+  /**
    * Move-history entry types this interaction's move produced (e.g. a
    * `tableau_to_foundation` followed by a `flip_card`). Lets a consumer
    * reconstruct the full move sequence and see why `turnIndex` advances by
@@ -98,10 +117,17 @@ export interface AISessionSummary {
   /** Model that drove the session. */
   model: string;
   /**
-   * How the game ended: `won` (all 52 cards home), `lost` (no legal moves
-   * remain), or `incomplete` (exported mid-game — i.e. abandoned).
+   * How the game ended:
+   * - `won` — all 52 cards home.
+   * - `lost` — no legal moves remain.
+   * - `stalled_auto_terminated` — auto-play hit the two-gate stall rule
+   *   (long flat-progress plateau dominated by shuffle moves) and the harness
+   *   stopped calling the teacher. Distinct from `incomplete` so the analytics
+   *   side can separate machine-terminated runs from player-abandoned ones.
+   * - `incomplete` — exported mid-game (abandoned, or a stop other than the
+   *   stall terminator).
    */
-  outcome: 'won' | 'lost' | 'incomplete';
+  outcome: 'won' | 'lost' | 'stalled_auto_terminated' | 'incomplete';
   /** Completion progress at export time (0–100). */
   finalProgress: number;
   /** Total move-history length at export time. */

--- a/packages/app/src/ai/stallDetection.test.ts
+++ b/packages/app/src/ai/stallDetection.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for the two-gate stall-detection rule.
+ *
+ * Anchors come from real harvested sessions (analytics 2026-05-20 doc):
+ *   - `1279a3` — long draw-dominated plateau (honest Ace-hunt). Must NOT fire.
+ *   - `73fd85` — tableau-shuffle dominated plateau. Must fire.
+ *   - `645d03` — late-game oscillation (5C/4D). Must fire.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  AI_AUTO_STALL_LIMIT,
+  AI_AUTO_STALL_SHUFFLE_FRACTION,
+} from './constants';
+import {
+  STALL_SHUFFLE_MOVE_TYPES,
+  shouldTerminateOnStall,
+  shuffleFraction,
+} from './stallDetection';
+
+describe('STALL_SHUFFLE_MOVE_TYPES', () => {
+  it('contains only the two visible-rearrangement move types', () => {
+    expect(STALL_SHUFFLE_MOVE_TYPES.has('tableau_to_tableau')).toBe(true);
+    expect(STALL_SHUFFLE_MOVE_TYPES.has('discard_to_tableau')).toBe(true);
+    expect(STALL_SHUFFLE_MOVE_TYPES.size).toBe(2);
+  });
+
+  it('excludes information-gathering moves (draw, recycle)', () => {
+    expect(STALL_SHUFFLE_MOVE_TYPES.has('draw_card')).toBe(false);
+    expect(STALL_SHUFFLE_MOVE_TYPES.has('recycle_stock')).toBe(false);
+  });
+
+  it('excludes foundation moves (always make progress, never on a plateau)', () => {
+    expect(STALL_SHUFFLE_MOVE_TYPES.has('tableau_to_foundation')).toBe(false);
+    expect(STALL_SHUFFLE_MOVE_TYPES.has('discard_to_foundation')).toBe(false);
+  });
+});
+
+describe('shuffleFraction', () => {
+  it('returns 0 for an empty window (no plateau, no fraction)', () => {
+    expect(shuffleFraction([])).toBe(0);
+  });
+
+  it('returns 1 for an all-shuffle window', () => {
+    const window = Array.from({ length: 10 }, () => 'tableau_to_tableau');
+    expect(shuffleFraction(window)).toBe(1);
+  });
+
+  it('returns 0 for an all-draw window (information-gathering)', () => {
+    const window = Array.from({ length: 10 }, () => 'draw_card');
+    expect(shuffleFraction(window)).toBe(0);
+  });
+
+  it('treats recycle_stock as information-gathering, not shuffle', () => {
+    expect(shuffleFraction(['recycle_stock'])).toBe(0);
+  });
+
+  it('blends shuffle and draw entries by count', () => {
+    // 3 shuffles, 1 draw → 0.75
+    const window = [
+      'tableau_to_tableau',
+      'discard_to_tableau',
+      'tableau_to_tableau',
+      'draw_card',
+    ];
+    expect(shuffleFraction(window)).toBe(0.75);
+  });
+
+  it('counts both shuffle subtypes', () => {
+    expect(shuffleFraction(['tableau_to_tableau', 'discard_to_tableau'])).toBe(1);
+  });
+});
+
+describe('shouldTerminateOnStall', () => {
+  it('does not fire when the plateau is shorter than the stall limit', () => {
+    const window = Array.from({ length: AI_AUTO_STALL_LIMIT - 1 }, () => 'tableau_to_tableau');
+    expect(shouldTerminateOnStall(AI_AUTO_STALL_LIMIT - 1, window)).toBe(false);
+  });
+
+  it('fires on a 25-turn plateau of pure tableau-to-tableau shuffles (73fd85)', () => {
+    const window = Array.from({ length: AI_AUTO_STALL_LIMIT }, () => 'tableau_to_tableau');
+    expect(shouldTerminateOnStall(AI_AUTO_STALL_LIMIT, window)).toBe(true);
+  });
+
+  it('does NOT fire on a long draw-dominated plateau (honest Ace-hunt, 1279a3)', () => {
+    // 24 draws + 1 recycle: plateau length AI_AUTO_STALL_LIMIT, shuffle fraction 0.
+    const window = [
+      ...Array.from({ length: AI_AUTO_STALL_LIMIT - 1 }, () => 'draw_card'),
+      'recycle_stock',
+    ];
+    expect(shouldTerminateOnStall(AI_AUTO_STALL_LIMIT, window)).toBe(false);
+  });
+
+  it('fires on the late-game 5C/4D oscillation (645d03)', () => {
+    // ~75-turn plateau dominated by tableau-to-tableau swaps.
+    const window = Array.from({ length: 30 }, (_, i) =>
+      i % 5 === 0 ? 'discard_to_tableau' : 'tableau_to_tableau',
+    );
+    expect(shouldTerminateOnStall(75, window)).toBe(true);
+  });
+
+  it('fires right at the shuffle-fraction threshold', () => {
+    // Exactly AI_AUTO_STALL_SHUFFLE_FRACTION shuffles → boundary fires.
+    const shuffleCount = Math.ceil(
+      AI_AUTO_STALL_LIMIT * AI_AUTO_STALL_SHUFFLE_FRACTION,
+    );
+    const drawCount = AI_AUTO_STALL_LIMIT - shuffleCount;
+    const window = [
+      ...Array.from({ length: shuffleCount }, () => 'tableau_to_tableau'),
+      ...Array.from({ length: drawCount }, () => 'draw_card'),
+    ];
+    expect(shuffleFraction(window)).toBeGreaterThanOrEqual(
+      AI_AUTO_STALL_SHUFFLE_FRACTION,
+    );
+    expect(shouldTerminateOnStall(AI_AUTO_STALL_LIMIT, window)).toBe(true);
+  });
+
+  it('does not fire just below the shuffle-fraction threshold', () => {
+    // One fewer shuffle than the boundary.
+    const shuffleCount = Math.ceil(
+      AI_AUTO_STALL_LIMIT * AI_AUTO_STALL_SHUFFLE_FRACTION,
+    ) - 1;
+    const drawCount = AI_AUTO_STALL_LIMIT - shuffleCount;
+    const window = [
+      ...Array.from({ length: shuffleCount }, () => 'tableau_to_tableau'),
+      ...Array.from({ length: drawCount }, () => 'draw_card'),
+    ];
+    expect(shuffleFraction(window)).toBeLessThan(
+      AI_AUTO_STALL_SHUFFLE_FRACTION,
+    );
+    expect(shouldTerminateOnStall(AI_AUTO_STALL_LIMIT, window)).toBe(false);
+  });
+
+  it('respects override thresholds for ablations', () => {
+    const window = Array.from({ length: 10 }, () => 'tableau_to_tableau');
+    // Lower the gate: 10 plateau turns with full shuffles → fires.
+    expect(shouldTerminateOnStall(10, window, 10, 0.5)).toBe(true);
+    // Raise the plateau gate above 10 → does not fire.
+    expect(shouldTerminateOnStall(10, window, 25, 0.5)).toBe(false);
+    // Raise the fraction gate above 1 → impossible, never fires.
+    expect(shouldTerminateOnStall(10, window, 10, 1.1)).toBe(false);
+  });
+});

--- a/packages/app/src/ai/stallDetection.ts
+++ b/packages/app/src/ai/stallDetection.ts
@@ -1,0 +1,60 @@
+/**
+ * Stall-detection helpers for the AI auto-play loop.
+ *
+ * The auto-play loop already counts consecutive flat-progress turns
+ * (`AI_AUTO_STALL_LIMIT`); this module adds the second gate of the two-gate
+ * rule — a *shuffle fraction* over the move-type window — and exposes both
+ * pieces as pure functions so the rule is unit-testable without driving the
+ * full store.
+ *
+ * Rationale and constants live in `constants.ts`. Empirical anchors:
+ *   - `1279a3` — long plateau, draw-dominated → honest hunt, must NOT fire.
+ *   - `73fd85` / `645d03` — long plateau, tableau-shuffle dominated → fires.
+ *
+ * @module ai/stallDetection
+ */
+
+import { AI_AUTO_STALL_LIMIT, AI_AUTO_STALL_SHUFFLE_FRACTION } from './constants';
+
+/**
+ * Move types that count as *shuffles* — rearranging visible cards without
+ * surfacing new information. The complement (`draw_card`, `recycle_stock`)
+ * is information-gathering and tolerated during a plateau.
+ *
+ * Foundation moves (`tableau_to_foundation`, `discard_to_foundation`) always
+ * make progress and therefore cannot appear in a plateau window; they are
+ * intentionally excluded from this set rather than listed as non-shuffles.
+ */
+export const STALL_SHUFFLE_MOVE_TYPES: ReadonlySet<string> = new Set([
+  'tableau_to_tableau',
+  'discard_to_tableau',
+]);
+
+/**
+ * Fraction of moves in {@link window} that count as shuffles. Returns 0 for an
+ * empty window so a not-yet-flat run never satisfies the threshold by vacuity.
+ */
+export function shuffleFraction(window: readonly string[]): number {
+  if (window.length === 0) return 0;
+  let shuffles = 0;
+  for (const moveType of window) {
+    if (STALL_SHUFFLE_MOVE_TYPES.has(moveType)) shuffles += 1;
+  }
+  return shuffles / window.length;
+}
+
+/**
+ * Whether the AI auto-play run should terminate on stall grounds. Both gates
+ * must fire: plateau long enough AND shuffle fraction high enough.
+ *
+ * Defaults use the production thresholds; pass overrides only from tests.
+ */
+export function shouldTerminateOnStall(
+  plateauLength: number,
+  recentMoveTypes: readonly string[],
+  stallLimit: number = AI_AUTO_STALL_LIMIT,
+  shuffleFractionThreshold: number = AI_AUTO_STALL_SHUFFLE_FRACTION,
+): boolean {
+  if (plateauLength < stallLimit) return false;
+  return shuffleFraction(recentMoveTypes) >= shuffleFractionThreshold;
+}

--- a/packages/app/src/store/aiAdvisor.test.ts
+++ b/packages/app/src/store/aiAdvisor.test.ts
@@ -10,7 +10,10 @@ import {
   clearAIInteractions,
   createStubProvider,
   getAIInteractions,
+  getLastAIInteraction,
+  recordAIInteraction,
   setProviderOverride,
+  uuidv7,
 } from '../ai';
 import type { AIMoveDecision } from '../ai';
 import type { Card, GameState, Rank, Suit } from '../types';
@@ -329,6 +332,7 @@ describe('harvest instrumentation', () => {
 describe('AI auto-play stall terminator', () => {
   beforeEach(() => {
     useGameStore.getState().initializeGame(3, 42);
+    clearAIInteractions();
   });
 
   afterEach(() => {
@@ -338,25 +342,125 @@ describe('AI auto-play stall terminator', () => {
     }
   });
 
-  it('stops auto-play when progress is flat for too long', () => {
-    useStub({ moveIndex: 0, reasoning: 'go', confidence: 0.5 });
-    useGameStore.setState({ aiAutoPlay: true, aiError: undefined });
-
-    // Drive continueAIAutoPlay with a board that changes every turn (rotating
-    // the stock => a distinct position hash, so loop detection never fires) but
-    // makes no real progress (foundations and face-down counts stay flat). The
-    // stall guard must eventually halt the run.
-    for (let i = 0; i < 60 && useGameStore.getState().aiAutoPlay; i++) {
+  /**
+   * Drive `continueAIAutoPlay` for `iterations` cycles. Each iteration:
+   *   - records a synthetic interaction tagged with `moveType` so the stall
+   *     tracker reads the move type from the last interaction,
+   *   - rotates the stock one card so the position hash is fresh (otherwise
+   *     loop detection trips before the stall threshold is reached).
+   *
+   * Stops early if the store turned auto-play off (the terminator fired).
+   */
+  function driveFlatTurns(moveType: string, iterations: number): void {
+    const sessionId = useGameStore.getState().gameSessionId ?? '';
+    for (let i = 0; i < iterations && useGameStore.getState().aiAutoPlay; i++) {
       const dp = useGameStore.getState().drawPile;
       if (dp.length > 1) {
         useGameStore.setState({ drawPile: [...dp.slice(1), dp[0]] });
       }
+      recordAIInteraction({
+        id: uuidv7(),
+        requestId: uuidv7(),
+        sessionId,
+        attempt: 1,
+        timestamp: Date.now() + i,
+        provider: 'stub',
+        model: 'stub',
+        outcome: 'success',
+        durationMs: 0,
+        prompt: '',
+        movesApplied: [moveType],
+      });
       useGameStore.getState().continueAIAutoPlay();
     }
+  }
+
+  it('stops auto-play on a long shuffle-dominated plateau (doom-loop)', () => {
+    useStub({ moveIndex: 0, reasoning: 'go', confidence: 0.5 });
+    useGameStore.setState({ aiAutoPlay: true, aiError: undefined });
+
+    driveFlatTurns('tableau_to_tableau', 60);
 
     const state = useGameStore.getState();
     expect(state.aiAutoPlay).toBe(false);
-    expect(state.aiError).toMatch(/progress/i);
+    expect(state.aiError).toMatch(/no progress/i);
+    expect(state.aiError).toMatch(/shuffle/i);
+  });
+
+  it('records a stall_terminated event with shuffle-fraction telemetry', () => {
+    useStub({ moveIndex: 0, reasoning: 'go', confidence: 0.5 });
+    useGameStore.setState({ aiAutoPlay: true, aiError: undefined });
+
+    driveFlatTurns('tableau_to_tableau', 60);
+
+    // Find the most recent stall_terminated interaction; production code stamps
+    // shuffle fraction, plateau length, and the move-type window onto it.
+    const stall = [...getAIInteractions()]
+      .reverse()
+      .find((entry) => entry.event === 'stall_terminated');
+    expect(stall).toBeTruthy();
+    expect(stall?.shuffleFraction).toBe(1);
+    expect(stall?.plateauLength).toBeGreaterThanOrEqual(25);
+    expect(stall?.moveTypeWindow?.every((mt) => mt === 'tableau_to_tableau')).toBe(true);
+  });
+
+  it('does NOT terminate a draw-dominated plateau (honest Ace-hunt)', () => {
+    useStub({ moveIndex: 0, reasoning: 'go', confidence: 0.5 });
+    useGameStore.setState({ aiAutoPlay: true, aiError: undefined });
+
+    // 40 flat turns of pure information-gathering draws — well beyond the
+    // plateau gate but with shuffle fraction 0. Must not fire.
+    driveFlatTurns('draw_card', 40);
+
+    expect(useGameStore.getState().aiAutoPlay).toBe(true);
+    const stall = getAIInteractions().find((e) => e.event === 'stall_terminated');
+    expect(stall).toBeUndefined();
+  });
+
+  it('marks the session outcome as stalled_auto_terminated after a doom-loop', () => {
+    useStub({ moveIndex: 0, reasoning: 'go', confidence: 0.5 });
+    useGameStore.setState({ aiAutoPlay: true, aiError: undefined });
+
+    driveFlatTurns('tableau_to_tableau', 60);
+    expect(useGameStore.getState().aiAutoPlay).toBe(false);
+
+    const parsed = JSON.parse(useGameStore.getState().exportAIInteractions());
+    expect(parsed.session.outcome).toBe('stalled_auto_terminated');
+  });
+
+  // Sanity: the previous interaction's movesApplied field is the source of
+  // truth for the rolling window. If it is absent, the stall tracker must
+  // still progress its counter (the plateau gate) and simply skip the push.
+  it('tolerates an unstamped previous interaction without crashing', () => {
+    useStub({ moveIndex: 0, reasoning: 'go', confidence: 0.5 });
+    useGameStore.setState({ aiAutoPlay: true, aiError: undefined });
+
+    const sessionId = useGameStore.getState().gameSessionId ?? '';
+    for (let i = 0; i < 30 && useGameStore.getState().aiAutoPlay; i++) {
+      const dp = useGameStore.getState().drawPile;
+      if (dp.length > 1) {
+        useGameStore.setState({ drawPile: [...dp.slice(1), dp[0]] });
+      }
+      // No movesApplied — simulates a leftover interaction with missing tags.
+      recordAIInteraction({
+        id: uuidv7(),
+        requestId: uuidv7(),
+        sessionId,
+        attempt: 1,
+        timestamp: Date.now() + i,
+        provider: 'stub',
+        model: 'stub',
+        outcome: 'success',
+        durationMs: 0,
+        prompt: '',
+      });
+      useGameStore.getState().continueAIAutoPlay();
+    }
+
+    // The plateau gate is satisfied, but no shuffle entries got into the
+    // window, so the second gate fails and termination does not fire.
+    expect(useGameStore.getState().aiAutoPlay).toBe(true);
+    expect(getLastAIInteraction()?.event).not.toBe('stall_terminated');
   });
 });
 

--- a/packages/app/src/store/gameStore.ts
+++ b/packages/app/src/store/gameStore.ts
@@ -29,7 +29,7 @@ import {
   AI_AUTO_MOVE_DELAY,
   AI_AUTO_HISTORY_LIMIT,
   AI_AUTO_LOOP_LIMIT,
-  AI_AUTO_STALL_LIMIT,
+  AI_AUTO_STALL_SHUFFLE_FRACTION,
   AI_AUTO_RETRY_COOLDOWN,
   AI_RETRY_MAX_ATTEMPTS,
   DEFAULT_AI_CONFIG,
@@ -45,6 +45,8 @@ import {
   isTransientAIError,
   recordAIInteraction,
   setLastInteractionMovesApplied,
+  shouldTerminateOnStall,
+  shuffleFraction,
   suggestMoveWithRetry,
   uuidv7,
 } from '../ai';
@@ -89,6 +91,22 @@ let aiAutoStateHistory: string[] = [];
  */
 let aiAutoLastProgress: { f: number; d: number } | null = null;
 let aiAutoStallCount = 0;
+
+/**
+ * Move types applied on each consecutive flat-progress turn — the rolling
+ * window the shuffle-fraction gate reads to decide whether a long plateau is
+ * a real doom-loop (shuffle-dominated) or an honest hunt (draw-dominated).
+ * Cleared whenever progress is made or auto-play is re-engaged.
+ */
+let aiAutoRecentMoveTypes: string[] = [];
+
+/**
+ * Whether the current game's auto-play was halted by the stall terminator. The
+ * store reads this at export time so a harvested record carries
+ * `outcome: 'stalled_auto_terminated'` rather than the catch-all `incomplete`.
+ * Reset on a new game or re-engaged auto-play.
+ */
+let aiAutoStalled = false;
 
 /** Keys in {@link AIConfig} that a context preset controls. */
 const AI_TOGGLE_KEYS: readonly (keyof AIConfig)[] = [
@@ -362,6 +380,13 @@ export const useGameStore = create<GameStore>((set, get) => ({
     // A new game invalidates any in-flight AI request.
     aiAbortController?.abort();
     aiAbortController = null;
+    // Auto-play tracking belongs to the previous game; clear it so the new
+    // game starts with a fresh plateau / window / outcome / position history.
+    aiAutoStateHistory = [];
+    aiAutoLastProgress = null;
+    aiAutoStallCount = 0;
+    aiAutoRecentMoveTypes = [];
+    aiAutoStalled = false;
     // The AI config is a session-level preference — preserve it across games.
     const preservedConfig = get().aiConfig ?? DEFAULT_AI_CONFIG;
     set({ ...initializeGameState(currentDifficulty, seed), aiConfig: preservedConfig });
@@ -1590,6 +1615,8 @@ export const useGameStore = create<GameStore>((set, get) => ({
     aiAutoStateHistory = [];
     aiAutoLastProgress = null;
     aiAutoStallCount = 0;
+    aiAutoRecentMoveTypes = [];
+    aiAutoStalled = false;
     set({ aiAutoPlay: true, aiError: undefined });
     void get().askAIForMove();
   },
@@ -1620,25 +1647,35 @@ export const useGameStore = create<GameStore>((set, get) => ({
     }
     aiAutoStateHistory = [...aiAutoStateHistory, hash].slice(-AI_AUTO_HISTORY_LIMIT);
 
-    // Stall detection: a turn is "flat" when neither a card reached a foundation
-    // nor a face-down card was revealed. A few flat turns are normal (cycling
-    // the stock to reach a card); AI_AUTO_STALL_LIMIT in a row means the run is
-    // genuinely stuck. Loop detection above misses this — the board keeps
-    // changing — so it is a separate guard. Log it so a harvested game reads as
-    // auto-terminated, not abandoned.
+    // Stall detection — two-gate rule. A turn is "flat" when neither a card
+    // reached a foundation nor a face-down card was revealed. A few flat turns
+    // are normal (cycling the stock to reach a card); AI_AUTO_STALL_LIMIT in a
+    // row is the first gate. The second gate is the *shuffle fraction* over
+    // the plateau: a long flat run dominated by `tableau_to_tableau` /
+    // `discard_to_tableau` is a doom-loop and terminates; the same length
+    // dominated by `draw_card` / `recycle_stock` is an honest hunt for a still
+    // face-down card and is allowed to continue. Loop detection above misses
+    // both cases — the board keeps changing — so this is a separate guard.
+    // Log it so a harvested game reads as auto-terminated, not abandoned.
     const { foundationCards, faceDownTotal } = computeProgressComponents(state);
+    const lastInteractionMoveType = getLastAIInteraction()?.movesApplied?.[0];
     if (
       aiAutoLastProgress &&
       aiAutoLastProgress.f === foundationCards &&
       aiAutoLastProgress.d === faceDownTotal
     ) {
       aiAutoStallCount += 1;
+      if (lastInteractionMoveType) aiAutoRecentMoveTypes.push(lastInteractionMoveType);
     } else {
       aiAutoStallCount = 0;
+      aiAutoRecentMoveTypes = [];
     }
     aiAutoLastProgress = { f: foundationCards, d: faceDownTotal };
-    if (aiAutoStallCount >= AI_AUTO_STALL_LIMIT) {
+    if (shouldTerminateOnStall(aiAutoStallCount, aiAutoRecentMoveTypes)) {
       const stallConfig = state.aiConfig ?? DEFAULT_AI_CONFIG;
+      const fraction = shuffleFraction(aiAutoRecentMoveTypes);
+      const window = [...aiAutoRecentMoveTypes];
+      aiAutoStalled = true;
       recordAIInteraction({
         id: uuidv7(),
         requestId: uuidv7(),
@@ -1651,6 +1688,9 @@ export const useGameStore = create<GameStore>((set, get) => ({
         turnIndex: state.moveHistory.length,
         config: stallConfig,
         event: 'stall_terminated',
+        plateauLength: aiAutoStallCount,
+        shuffleFraction: fraction,
+        moveTypeWindow: window,
         outcome: 'success',
         durationMs: 0,
         prompt: '',
@@ -1658,8 +1698,9 @@ export const useGameStore = create<GameStore>((set, get) => ({
       set({
         aiAutoPlay: false,
         aiError:
-          `AI auto-play stopped: no progress for ${AI_AUTO_STALL_LIMIT} turns ` +
-          `(foundations and revealed cards both unchanged).`,
+          `AI auto-play stopped: no progress for ${aiAutoStallCount} turns ` +
+          `with ${Math.round(fraction * 100)}% shuffle moves ` +
+          `(threshold ${Math.round(AI_AUTO_STALL_SHUFFLE_FRACTION * 100)}%).`,
       });
       return;
     }
@@ -1704,12 +1745,18 @@ export const useGameStore = create<GameStore>((set, get) => ({
   exportAIInteractions: () => {
     // Stamp the export with the current game's outcome so a harvested dataset
     // can be filtered for quality games (e.g. wins only) on its own.
+    // `stalled_auto_terminated` is preferred over `incomplete` so the
+    // analytics side can tell a machine-terminated doom-loop apart from a
+    // genuinely abandoned game.
     const state = get();
-    const outcome: 'won' | 'lost' | 'incomplete' = state.gameWon
-      ? 'won'
-      : engine.getLegalMoves(uiToCore(state)).length === 0
-        ? 'lost'
-        : 'incomplete';
+    const outcome: 'won' | 'lost' | 'stalled_auto_terminated' | 'incomplete' =
+      state.gameWon
+        ? 'won'
+        : engine.getLegalMoves(uiToCore(state)).length === 0
+          ? 'lost'
+          : aiAutoStalled
+            ? 'stalled_auto_terminated'
+            : 'incomplete';
     return serializeAIInteractions({
       sessionId: state.gameSessionId ?? '',
       seed: state.seed,


### PR DESCRIPTION
Implements the next-correction recommendation in `solitaire-analytics/HARVEST_TEAM_NEXT_CORRECTION_2026-05-20.md`. AI auto-play termination is now a two-gate rule:

> terminate iff `(plateau ≥ AI_AUTO_STALL_LIMIT) AND (shuffle fraction ≥ AI_AUTO_STALL_SHUFFLE_FRACTION)`

The shuffle set is `{tableau_to_tableau, discard_to_tableau}` — visible-rearrangement moves. `draw_card` and `recycle_stock` are information-gathering and tolerated during a plateau (an honest Ace-hunt is a long draw-dominated plateau and must not terminate).

## Why

The previous plateau-only rule (`AI_AUTO_STALL_LIMIT = 25`) is correct for late-game oscillations like `645d03` (5C/4D doom-loop, ~100% shuffles) but false-positives on `1279a3`-shaped sessions: a 24-turn plateau composed of 18 draws + 1 recycle, where the AI is rationally hunting for an unseen Ace. Terminating those loses legitimate training data.

Empirical anchors from real harvested sessions:

| Session | Plateau | Shuffle fraction | Verdict |
|---|---|---|---|
| `1279a3` | 24 turns | 0% (18 draws + 1 recycle) | keep playing |
| `73fd85` | 15 turns | ~70% (tableau oscillation) | terminate |
| `645d03` | 75 turns | ~100% (5C/4D oscillation) | terminate |

The 0.6 fraction threshold gives both sides wide headroom; per-termination telemetry (added below) lets the analytics side tune it from real data.

## Changes

- **`AI_AUTO_STALL_SHUFFLE_FRACTION = 0.6`** in `packages/app/src/ai/constants.ts`, next to the existing `AI_AUTO_STALL_LIMIT`.
- **`ai/stallDetection.ts`** — pure helpers (`shuffleFraction`, `shouldTerminateOnStall`, `STALL_SHUFFLE_MOVE_TYPES`) so the rule is unit-testable without driving the full store.
- **`gameStore.continueAIAutoPlay`** now maintains a rolling move-type window over the plateau (cleared on progress) and consults `shouldTerminateOnStall` instead of plateau alone.
- **New `AISessionSummary.outcome` value: `'stalled_auto_terminated'`** — alongside `won` / `lost` / `incomplete` — so harvested records distinguish a machine-terminated doom-loop from a player-abandoned game. `scripts/ingest_exports.py` keys on `outcome === 'success'`, so this is transparent to ingest.
- The existing `stall_terminated` `AIInteraction` event now carries **`plateauLength`**, **`shuffleFraction`**, and the **`moveTypeWindow`** at trigger time, for tuning.
- `initializeGame` now also resets `aiAutoStateHistory` and the new stall window/outcome flag — fixes cross-test state leakage and matches the documented semantics (a new game starts clean).

## Tests

- `stallDetection.test.ts` — 13 tests covering the shuffle set, `shuffleFraction`, and `shouldTerminateOnStall` against all three real-session anchors plus boundary cases at the 0.6 threshold.
- `interactionLog.test.ts` — new cases for the `stalled_auto_terminated` outcome and the stall-event telemetry payload.
- `aiAdvisor.test.ts` — the existing stall test, rewritten for the two-gate rule, plus an honest-hunt counterpart (40 flat `draw_card` turns must NOT fire) and an outcome-marking integration check.

Local: 306/306 app tests pass, lint + tsc + build all clean. Lib tests: 256 + 33 pass.

## Out of scope

- Re-running the 12-session corpus on the same seeds for the doc's quantitative acceptance criteria (wasted-call ratio 50% → 10–15%, training-set size unchanged) — needs a fresh data-collection pass on the harness, not a code change.
- Prompt-engineering Phase 1 patches (doc #2). The doc requires this PR to ship first so the A/B baseline is clean.
- MCP-server migration — no MCP server lives in this repo today.

## Open question for the analytics side

`scripts/ingest_exports.py` was confirmed to key on `outcome === 'success'`, so a new failure-side value is transparent. If a future filter wants to keep stall-terminated sessions (their early turns are still high-quality decisions), it can opt into `outcome === 'stalled_auto_terminated'` explicitly.