### PR TITLE
chore(ai): bump AI_REQUEST_TIMEOUT_MS from 210s to 240s

### DIFF
--- a/packages/app/src/ai/constants.ts
+++ b/packages/app/src/ai/constants.ts
@@ -9,10 +9,10 @@
  *
  * `gemma-4-31b-it` is a *thinking* model: it reasons internally before
  * answering, and on a complex board that can take a couple of minutes. We
- * allow a generous 3.5-minute ceiling so a slow-but-valid response is not
+ * allow a generous 4-minute ceiling so a slow-but-valid response is not
  * killed prematurely.
  */
-export const AI_REQUEST_TIMEOUT_MS = 210_000;
+export const AI_REQUEST_TIMEOUT_MS = 240_000;
 
 /** Maximum number of past AI decisions retained in the store's decision log. */
 export const AI_DECISION_LOG_LIMIT = 30;


### PR DESCRIPTION
Give thinking-model responses a slightly larger per-request ceiling (3.5 min → 4 min) so a slow-but-valid answer on a complex board isn't killed prematurely.

Single-constant change in `packages/app/src/ai/constants.ts`; docstring updated to match. No behavior change to retry/backoff, stall detection, or auto-play pacing.