### PR TITLE
feat(ai): raise interaction-log cap to 2000 and warn on overflow

### DIFF
--- a/packages/app/src/ai/constants.ts
+++ b/packages/app/src/ai/constants.ts
@@ -17,8 +17,18 @@ export const AI_REQUEST_TIMEOUT_MS = 240_000;
 /** Maximum number of past AI decisions retained in the store's decision log. */
 export const AI_DECISION_LOG_LIMIT = 30;
 
-/** Maximum number of LLM interactions retained in the in-memory harvest log. */
-export const AI_INTERACTION_LOG_LIMIT = 200;
+/**
+ * Maximum number of LLM interactions retained in the in-memory harvest log.
+ *
+ * Sized to cover many auto-played teacher games per tab session — one game can
+ * produce 80–150 entries (including retries, `forced_move` skips, and
+ * `stall_terminated` markers), so the previous 200 silently truncated the
+ * opening of a multi-game harvest run. Worst-case memory at 2 000 entries is
+ * ~20–80 MB, which a browser tab handles comfortably. When the cap is hit,
+ * {@link recordAIInteraction} emits a one-time `console.warn` so silent
+ * truncation is visible.
+ */
+export const AI_INTERACTION_LOG_LIMIT = 2000;
 
 /**
  * Pause between moves while the AI is auto-playing the whole game. The LLM

--- a/packages/app/src/ai/interactionLog.test.ts
+++ b/packages/app/src/ai/interactionLog.test.ts
@@ -79,6 +79,18 @@ describe('interactionLog', () => {
     expect(getLastAIInteraction()?.timestamp).toBe(AI_INTERACTION_LOG_LIMIT + 24);
   });
 
+  it('warns exactly once when the buffer first overflows', () => {
+    const warn = vi.mocked(console.warn);
+    warn.mockClear(); // shed any cross-test history from the shared spy
+    for (let i = 0; i < AI_INTERACTION_LOG_LIMIT + 5; i++) {
+      recordAIInteraction({ ...base, id: `id-${i}`, timestamp: i });
+    }
+    const overflowWarns = warn.mock.calls.filter((c) =>
+      String(c[0]).includes('interaction log reached'),
+    );
+    expect(overflowWarns).toHaveLength(1);
+  });
+
   it('exportAIInteractions returns JSON with metadata and the entries', () => {
     recordAIInteraction(base);
     const parsed = JSON.parse(exportAIInteractions());

--- a/packages/app/src/ai/interactionLog.ts
+++ b/packages/app/src/ai/interactionLog.ts
@@ -135,6 +135,12 @@ export interface AISessionSummary {
 }
 
 const buffer: AIInteraction[] = [];
+/**
+ * Whether the buffer has overflowed at least once in this tab session. A
+ * silent `buffer.shift()` would otherwise discard the opening of a harvest run
+ * unnoticed — we warn exactly once so the operator knows to export sooner.
+ */
+let overflowWarned = false;
 
 /** Record an interaction: append to the ring buffer and log a console summary. */
 export function recordAIInteraction(entry: AIInteraction): void {
@@ -143,7 +149,15 @@ export function recordAIInteraction(entry: AIInteraction): void {
     ? entry
     : { ...entry, appCommit: APP_COMMIT };
   buffer.push(stamped);
-  if (buffer.length > AI_INTERACTION_LOG_LIMIT) buffer.shift();
+  if (buffer.length > AI_INTERACTION_LOG_LIMIT) {
+    buffer.shift();
+    if (!overflowWarned) {
+      overflowWarned = true;
+      console.warn(
+        `[AI] interaction log reached ${AI_INTERACTION_LOG_LIMIT} entries; oldest entries are now being dropped. Export the log to preserve a full harvest.`,
+      );
+    }
+  }
 
   const seconds = (entry.durationMs / 1000).toFixed(1);
   if (entry.outcome === 'success') {
@@ -185,6 +199,7 @@ export function getLastAIInteraction(): AIInteraction | null {
 /** Clear the interaction log (used by tests). */
 export function clearAIInteractions(): void {
   buffer.length = 0;
+  overflowWarned = false;
 }
 
 /**


### PR DESCRIPTION
## Why

The 200-entry in-memory ring buffer in `packages/app/src/ai/interactionLog.ts` was sized when the harvest log was first introduced, before the auto-play and harvest flows existed. A single auto-played teacher game now routinely produces **80–150 entries** (retries + `forced_move` skips + `stall_terminated` markers), so two games back-to-back silently truncated the opening of a multi-game harvest export — quietly violating the docstring promise of *'a complete record of every API call'*.

## What

- Raise `AI_INTERACTION_LOG_LIMIT` from **200 → 2000**. Worst-case memory at ~20–80 MB is well within a browser tab's budget.
- Emit a one-time `console.warn` on first overflow so silent truncation is surfaced; flag is reset in `clearAIInteractions()` for test isolation.
- Updated docstring to reflect the new sizing rationale.
- New test pinning the warn-once behavior; existing cap test continues to pass via the symbolic constant.

## Tests

`pnpm exec vitest run` — **307/307 app tests pass**, **256/256 core tests pass**. No other code paths consume this constant.