### PR TITLE
feat(ai): stamp prompt-template hash + finalised date on every interaction

### DIFF
--- a/packages/app/src/ai/context/systemInstruction.test.ts
+++ b/packages/app/src/ai/context/systemInstruction.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tests for the system-instruction assembly and its identity fingerprint.
+ *
+ * The hash-snapshot tests are intentional tripwires: any change to the
+ * underlying template blocks shifts the SHA-256 and the test fails, forcing
+ * the developer to bump `PROMPT_TEMPLATE_FINALISED_AT` (and update the
+ * snapshot below) in the same commit. This is the discipline that makes the
+ * per-interaction `promptTemplateHash`/`…FinalisedAt` fields trustworthy
+ * downstream — without it, the fields would be cosmetic.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  PROMPT_TEMPLATE_FINALISED_AT,
+  buildSystemInstruction,
+  hashSystemInstruction,
+} from './systemInstruction';
+import type { AIConfig } from '../types';
+
+/** Bare config: only the field that gates template content. */
+function configWith(includeStrategyGuidance: boolean): AIConfig {
+  return {
+    includeStrategyGuidance,
+    // Other AIConfig fields don't influence buildSystemInstruction, so the
+    // type cast is sufficient for this test's scope.
+  } as AIConfig;
+}
+
+describe('buildSystemInstruction', () => {
+  it('includes RULES_PRIMER and OUTPUT_INSTRUCTION but not STRATEGY_GUIDANCE when guidance is off', () => {
+    const text = buildSystemInstruction(configWith(false));
+    expect(text).toContain('KLONDIKE SOLITAIRE RULES');
+    expect(text).toContain('RESPONSE FORMAT');
+    expect(text).not.toContain('STRATEGY GUIDANCE');
+  });
+
+  it('includes STRATEGY_GUIDANCE when guidance is on', () => {
+    const text = buildSystemInstruction(configWith(true));
+    expect(text).toContain('STRATEGY GUIDANCE');
+  });
+});
+
+describe('hashSystemInstruction', () => {
+  it('returns a 64-char lowercase hex SHA-256 digest', async () => {
+    const hash = await hashSystemInstruction('hello');
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    // Known value for "hello" — sanity check the algorithm.
+    expect(hash).toBe('2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824');
+  });
+
+  it('is deterministic for the same input', async () => {
+    const a = await hashSystemInstruction('the quick brown fox');
+    const b = await hashSystemInstruction('the quick brown fox');
+    expect(a).toBe(b);
+  });
+});
+
+/**
+ * Tripwire: pin the template fingerprints. If either snapshot below changes,
+ * you've edited `RULES_PRIMER`, `STRATEGY_GUIDANCE`, or `OUTPUT_INSTRUCTION`
+ * (or the assembly itself). Update the snapshot AND bump
+ * `PROMPT_TEMPLATE_FINALISED_AT` to today's UTC date in the same change —
+ * that pair is what the harvested dataset uses to attribute behaviour to a
+ * specific prompt variant.
+ */
+describe('prompt template identity (tripwire)', () => {
+  it('hash with strategy guidance is pinned', async () => {
+    const hash = await hashSystemInstruction(buildSystemInstruction(configWith(true)));
+    expect(hash).toBe('e2923795519ed672381bcf34311af1e2989d1e5ce3d64d397f045e7e6c2b91b2');
+  });
+
+  it('hash without strategy guidance is pinned', async () => {
+    const hash = await hashSystemInstruction(buildSystemInstruction(configWith(false)));
+    expect(hash).toBe('956f29f5baf8d0ca3d69bd15abea3c1b01b2304331354b24f1dd73a99a0f32af');
+  });
+
+  it('PROMPT_TEMPLATE_FINALISED_AT is a valid ISO 8601 UTC instant', () => {
+    expect(PROMPT_TEMPLATE_FINALISED_AT).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+    expect(Number.isFinite(new Date(PROMPT_TEMPLATE_FINALISED_AT).getTime())).toBe(true);
+  });
+});

--- a/packages/app/src/ai/context/systemInstruction.ts
+++ b/packages/app/src/ai/context/systemInstruction.ts
@@ -1,12 +1,33 @@
 /**
  * Assembles the system-instruction text for an AI request from the static
- * rule/strategy/output blocks, honoring the active configuration.
+ * rule/strategy/output blocks, honoring the active configuration. Also exposes
+ * a hash of that assembled text and the date the current template was
+ * finalised, so the harvested dataset can attribute behaviour to the specific
+ * prompt that produced it.
+ *
+ * The prompt is the most important independent variable of any harvested run,
+ * and (as the 2026-05-22 prompt-template audit showed) build hashes alone are
+ * a poor proxy for it. Every interaction now carries the prompt's own
+ * fingerprint so a downstream analysis can group/segment on it directly.
  *
  * @module ai/context/systemInstruction
  */
 
 import type { AIConfig } from '../types';
 import { OUTPUT_INSTRUCTION, RULES_PRIMER, STRATEGY_GUIDANCE } from './rulesPrimer';
+
+/**
+ * Date the current system-instruction template was last changed.
+ *
+ * **Bump this whenever {@link RULES_PRIMER}, {@link STRATEGY_GUIDANCE}, or
+ * {@link OUTPUT_INSTRUCTION} is edited.** The tripwire test in
+ * `systemInstruction.test.ts` fails if the hashes shift without a bump.
+ *
+ * Format: ISO 8601 UTC, second precision. A date (not a semantic version)
+ * because the templates evolve independently of any release cadence and the
+ * downstream analytics already key off ISO timestamps.
+ */
+export const PROMPT_TEMPLATE_FINALISED_AT = '2026-05-22T00:00:00Z';
 
 /** Build the full system instruction for a move-suggestion request. */
 export function buildSystemInstruction(config: AIConfig): string {
@@ -16,4 +37,23 @@ export function buildSystemInstruction(config: AIConfig): string {
   }
   parts.push(OUTPUT_INSTRUCTION);
   return parts.join('\n\n');
+}
+
+/**
+ * SHA-256 hex digest of an assembled system instruction. The boundary is the
+ * full output of {@link buildSystemInstruction} — what the model actually sees
+ * as its task framing, excluding the per-turn game-context JSON.
+ *
+ * SHA-256 (rather than the MD5 the offline audit happened to use) because it
+ * is available natively via Web Crypto, needs no dependency, and is the
+ * modern default for content identity. Async because Web Crypto is async;
+ * the cost is sub-millisecond on a ~3 KB input and the call site is already
+ * inside an awaited network round-trip.
+ */
+export async function hashSystemInstruction(systemInstruction: string): Promise<string> {
+  const bytes = new TextEncoder().encode(systemInstruction);
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
 }

--- a/packages/app/src/ai/interactionLog.test.ts
+++ b/packages/app/src/ai/interactionLog.test.ts
@@ -46,6 +46,18 @@ describe('interactionLog', () => {
     expect(stored[0].appCommit).toBeTruthy();
   });
 
+  it('preserves promptTemplateHash and promptTemplateFinalisedAt when supplied', () => {
+    recordAIInteraction({
+      ...base,
+      id: 'id-tpl',
+      promptTemplateHash: 'a'.repeat(64),
+      promptTemplateFinalisedAt: '2026-05-22T00:00:00Z',
+    });
+    const last = getLastAIInteraction();
+    expect(last?.promptTemplateHash).toBe('a'.repeat(64));
+    expect(last?.promptTemplateFinalisedAt).toBe('2026-05-22T00:00:00Z');
+  });
+
   it('getLastAIInteraction returns the most recent entry', () => {
     expect(getLastAIInteraction()).toBeNull();
     recordAIInteraction(base);

--- a/packages/app/src/ai/interactionLog.ts
+++ b/packages/app/src/ai/interactionLog.ts
@@ -32,6 +32,22 @@ export interface AIInteraction {
   model: string;
   /** Git commit hash of the build that produced this interaction. */
   appCommit?: string;
+  /**
+   * SHA-256 hex digest of the assembled system-instruction text sent to the
+   * model — the deterministic identity of the prompt template variant. Lets a
+   * harvested dataset segment on the prompt directly instead of inferring it
+   * from `appCommit` (which, per the 2026-05-22 audit, can drift independently
+   * of any visible template change).
+   */
+  promptTemplateHash?: string;
+  /**
+   * ISO 8601 UTC timestamp marking when the current prompt template was
+   * finalised — the human-readable companion to {@link promptTemplateHash}.
+   * Defined as `PROMPT_TEMPLATE_FINALISED_AT` in `ai/context/systemInstruction`
+   * and bumped whenever any of the template blocks changes (the tripwire test
+   * enforces it).
+   */
+  promptTemplateFinalisedAt?: string;
   /** Deal seed of the game, when one was used. */
   seed?: number;
   /** Turn index within the game (move-history length at request time). */

--- a/packages/app/src/ai/providers/GeminiProvider.test.ts
+++ b/packages/app/src/ai/providers/GeminiProvider.test.ts
@@ -40,6 +40,7 @@ function mockResponse(status: number, body: unknown): Response {
 describe('geminiProvider.suggestMove', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', vi.fn());
+    clearAIInteractions();
   });
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -78,6 +79,40 @@ describe('geminiProvider.suggestMove', () => {
     expect(decision.reasoning).toBe('Bank the card.');
     expect(decision.boardAnalysis).toBe('An ace is playable.');
     expect(decision.confidence).toBeCloseTo(0.9);
+  });
+
+  it('stamps the prompt template hash and finalised date on the logged interaction', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse(200, {
+        candidates: [
+          {
+            content: { parts: [{ text: '{"moveIndex":0,"reasoning":"Draw.","confidence":0.5}' }] },
+            finishReason: 'STOP',
+          },
+        ],
+      }),
+    );
+    await geminiProvider.suggestMove(request);
+    const last = getLastAIInteraction();
+    // SHA-256 hex of `request.systemInstruction` ('Be a solitaire advisor.').
+    expect(last?.promptTemplateHash).toMatch(/^[0-9a-f]{64}$/);
+    // Finalised date is the constant from systemInstruction.ts, in ISO 8601.
+    expect(last?.promptTemplateFinalisedAt).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/,
+    );
+  });
+
+  it('stamps the prompt template hash on an error-outcome interaction too', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse(401, { error: { code: 401, message: 'API key not valid' } }),
+    );
+    await expect(geminiProvider.suggestMove(request)).rejects.toBeInstanceOf(AIError);
+    const last = getLastAIInteraction();
+    expect(last?.outcome).toBe('error');
+    expect(last?.promptTemplateHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(last?.promptTemplateFinalisedAt).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/,
+    );
   });
 
   it('falls back to all parts when none are flagged as thoughts', async () => {

--- a/packages/app/src/ai/providers/GeminiProvider.ts
+++ b/packages/app/src/ai/providers/GeminiProvider.ts
@@ -23,6 +23,10 @@ import {
   AI_TEMPERATURE,
   GEMINI_API_BASE,
 } from '../constants';
+import {
+  PROMPT_TEMPLATE_FINALISED_AT,
+  hashSystemInstruction,
+} from '../context/systemInstruction';
 import { parseDecision } from '../decision/schema';
 import { recordAIInteraction } from '../interactionLog';
 import { uuidv7 } from '../uuid';
@@ -177,6 +181,10 @@ export const geminiProvider: AIProvider = {
       `${request.systemInstruction}\n\n` +
       `CURRENT GAME (JSON):\n${JSON.stringify(request.context)}\n\n` +
       'Now choose the best move and reply with only the JSON object.';
+    // Fingerprint the prompt template for the harvested log. Hashed once per
+    // call, before any network IO, so both the success and error branches can
+    // stamp it without recomputing. SHA-256 on ~3 KB is sub-ms.
+    const promptTemplateHash = await hashSystemInstruction(request.systemInstruction);
     let rawResponse: string | undefined;
     let thinkingText: string | undefined;
     let httpStatus: number | undefined;
@@ -274,6 +282,8 @@ export const geminiProvider: AIProvider = {
         outcome: 'success',
         durationMs: Date.now() - startedAt,
         prompt,
+        promptTemplateHash,
+        promptTemplateFinalisedAt: PROMPT_TEMPLATE_FINALISED_AT,
         rawResponse,
         thinkingText,
         decision,
@@ -299,6 +309,8 @@ export const geminiProvider: AIProvider = {
         outcome: 'error',
         durationMs: Date.now() - startedAt,
         prompt,
+        promptTemplateHash,
+        promptTemplateFinalisedAt: PROMPT_TEMPLATE_FINALISED_AT,
         rawResponse,
         thinkingText,
         httpStatus,


### PR DESCRIPTION
## Why

The 2026-05-22 prompt-template audit ([analytics handover doc](../../solitaire-analytics/docs/reports/20260522_harvester_team_handover.md)) found that all five recent builds (`71130ac`, `ce6afe1`, `afa8c24`, `6dfc8a9`, `7894202`) were serving a byte-identical system instruction. Every behavioural difference the dataset side had been attributing to "the new build" was therefore *not* a prompt change — it was sampling, retry, infra, or post-processing. From the harvested-log side, `appCommit` had become a poor proxy for what the model actually saw.

This PR makes the prompt itself a first-class indexable field on every interaction.

## What

Two new fields on `AIInteraction`:

| Field | Type | Source |
|---|---|---|
| `promptTemplateHash` | `string` (SHA-256 hex) | Live digest of `buildSystemInstruction(config)` output, computed once per call |
| `promptTemplateFinalisedAt` | `string` (ISO 8601 UTC) | `PROMPT_TEMPLATE_FINALISED_AT` constant, currently `2026-05-22T00:00:00Z` |

Stamped on **both** success and error branches in `GeminiProvider` — a session that fails its API call still carries the template identity.

## Discipline: tripwire test

`packages/app/src/ai/context/systemInstruction.test.ts` snapshots the SHA-256 for both the with-guidance and no-guidance variants:

```
e2923795519ed672381bcf34311af1e2989d1e5ce3d64d397f045e7e6c2b91b2  // includeStrategyGuidance: true
956f29f5baf8d0ca3d69bd15abea3c1b01b2304331354b24f1dd73a99a0f32af  // includeStrategyGuidance: false
```

Any edit to `RULES_PRIMER`, `STRATEGY_GUIDANCE`, or `OUTPUT_INSTRUCTION` shifts a hash, fails the test, and forces a `PROMPT_TEMPLATE_FINALISED_AT` bump in the same change. This is what keeps the new fields more than cosmetic.

## Design notes

**Hash algorithm:** SHA-256 via Web Crypto. Native, no new dep, sub-ms on a ~3 KB input. The dataset-side audit used MD5 (`a39354fa…`); going forward, every interaction carries SHA-256, and the dataset side will need to recompute one backfill value against the current `buildSystemInstruction` output. The handover doc's MD5 reconstruction also appears to have used a slightly different boundary (≈2-char delta from any reasonable replication of the current assembly), so the SHA-256 boundary is documented explicitly: it is the full output of `buildSystemInstruction(config)`, excluding the per-turn game-context JSON appended downstream.

**Hash timing:** computed in `GeminiProvider.suggestMove` immediately after the prompt is assembled, before any network IO, so both branches use the same value and there's no recomputation.

## Out of scope

- The resignation protocol (Ask 2 in the handover) — held pending evidence that the model actually expresses self-diagnosed stuckness in its reasoning traces. Will revisit after a few sessions are harvested with the new identity fields and the model's prose can be scanned.
- The same-seed cross-build experiment (Ask 3) — not a code change.

## Verification

- `pnpm typecheck` — clean
- `pnpm --filter app test:run` — 317/317 passing (29 files)
- `pnpm --filter app lint` — clean
