### PR TITLE
feat(ai): switch per-turn prompt to hybrid ASCII layout

### DIFF
--- a/packages/app/src/ai/context/renderContext.test.ts
+++ b/packages/app/src/ai/context/renderContext.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Tests for the hybrid ASCII renderer.
+ *
+ * The renderer's contract is documented in the layout-ask doc in the
+ * solitaire-analytics sibling repo; these tests pin the wire format so a
+ * silent shape drift is caught here, where it's cheap, rather than at the
+ * dataset-side comparison report.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { PROMPT_LAYOUT_VERSION, renderHybridContext } from './renderContext';
+import type { AIMoveContext } from '../types';
+
+/** Minimal fair-play context — fills in only the always-present fields. */
+function baseContext(overrides: Partial<AIMoveContext> = {}): AIMoveContext {
+  return {
+    notation: 'ignored by hybrid renderer',
+    foundations: { hearts: null, diamonds: null, clubs: null, spades: null },
+    tableau: [
+      { column: 1, faceDownCount: 0, faceUp: [] },
+      { column: 2, faceDownCount: 0, faceUp: [] },
+      { column: 3, faceDownCount: 0, faceUp: [] },
+      { column: 4, faceDownCount: 0, faceUp: [] },
+      { column: 5, faceDownCount: 0, faceUp: [] },
+      { column: 6, faceDownCount: 0, faceUp: [] },
+      { column: 7, faceDownCount: 0, faceUp: [] },
+    ],
+    discardTop: null,
+    drawPileCount: 0,
+    canRecycleStock: false,
+    legalMoves: [{ index: 0, type: 'draw_card', describe: 'Draw the next card' }],
+    ...overrides,
+  };
+}
+
+describe('renderHybridContext', () => {
+  it('always emits the NOTATION, FOUNDATIONS, STOCK, TABLEAU, LEGAL MOVES blocks', () => {
+    const out = renderHybridContext(baseContext());
+    expect(out).toMatch(/^NOTATION: rank\+suit/);
+    expect(out).toContain('FOUNDATIONS:   H: --   D: --   C: --   S: --');
+    expect(out).toContain('STOCK: 0 cards   WASTE top: --   recycle stock: no');
+    expect(out).toContain('TABLEAU:');
+    expect(out).toContain('LEGAL MOVES (respond with the index of your chosen move):');
+  });
+
+  it('renders an empty tableau column as <empty>', () => {
+    const out = renderHybridContext(baseContext());
+    // All seven columns are empty in baseContext.
+    for (let n = 1; n <= 7; n++) {
+      expect(out).toContain(`  col${n}: <empty>`);
+    }
+  });
+
+  it('renders face-down + face-up cards as ?? followed by face-up tokens', () => {
+    const out = renderHybridContext(
+      baseContext({
+        tableau: [
+          { column: 1, faceDownCount: 3, faceUp: ['QC', 'JD', 'TC', '9D'] },
+          ...baseContext().tableau.slice(1),
+        ],
+      }),
+    );
+    expect(out).toContain('  col1: ?? ?? ?? QC JD TC 9D');
+  });
+
+  it('uses real card identities for face-down cards when seeHiddenCards oracle data is present', () => {
+    // `faceDown` is populated only when `seeHiddenCards` is on; the renderer
+    // must trust the oracle data rather than rendering generic `??` tokens.
+    const out = renderHybridContext(
+      baseContext({
+        tableau: [
+          { column: 1, faceDownCount: 2, faceUp: ['5C'], faceDown: ['KH', '7D'] },
+          ...baseContext().tableau.slice(1),
+        ],
+      }),
+    );
+    expect(out).toContain('  col1: KH 7D 5C');
+  });
+
+  it('falls back to ?? when faceDown length does not match faceDownCount', () => {
+    // Defensive: a malformed context with the wrong-length oracle array should
+    // not leak partial data — render generic ?? tokens by count.
+    const out = renderHybridContext(
+      baseContext({
+        tableau: [
+          { column: 1, faceDownCount: 3, faceUp: ['5C'], faceDown: ['KH'] },
+          ...baseContext().tableau.slice(1),
+        ],
+      }),
+    );
+    expect(out).toContain('  col1: ?? ?? ?? 5C');
+  });
+
+  it('omits RECENT MOVES, SEEN IN WASTE, PROGRESS, and PRIOR REASONING when those fields are absent', () => {
+    const out = renderHybridContext(baseContext());
+    expect(out).not.toContain('RECENT MOVES');
+    expect(out).not.toContain('SEEN IN WASTE');
+    expect(out).not.toContain('PROGRESS:');
+    expect(out).not.toContain('PRIOR REASONING');
+  });
+
+  it('right-aligns RECENT MOVES numbers and labels the block with the oscillation hint', () => {
+    const recentMoves = Array.from({ length: 12 }, (_, i) => `draw card-${i + 1}`);
+    const out = renderHybridContext(baseContext({ recentMoves }));
+    expect(out).toContain(
+      'RECENT MOVES (oldest -> newest; review before picking, do not undo your own work):',
+    );
+    // Width is 2 because the list reaches 12 entries — single-digit numbers
+    // are padded so the dots align.
+    expect(out).toContain('   1. draw card-1');
+    expect(out).toContain('   9. draw card-9');
+    expect(out).toContain('  10. draw card-10');
+    expect(out).toContain('  12. draw card-12');
+  });
+
+  it('renders SEEN IN WASTE as a single space-separated line', () => {
+    const out = renderHybridContext(
+      baseContext({ seenDrawPileCards: ['9H', '5S', 'KS', 'JC'] }),
+    );
+    expect(out).toContain('SEEN IN WASTE THIS CYCLE: 9H 5S KS JC');
+  });
+
+  it('renders the HIDDEN INFO oracle block only when hiddenInfo is supplied', () => {
+    const without = renderHybridContext(baseContext());
+    expect(without).not.toContain('HIDDEN INFO');
+
+    const withOracle = renderHybridContext(
+      baseContext({ hiddenInfo: { drawPileOrder: ['AC', '2D', '3H'] } }),
+    );
+    expect(withOracle).toContain('HIDDEN INFO (oracle): draw pile order: AC 2D 3H');
+  });
+
+  it('aligns LEGAL MOVES with [index] prefix and a 24-char type column', () => {
+    const out = renderHybridContext(
+      baseContext({
+        legalMoves: [
+          { index: 0, type: 'tableau_to_tableau', describe: 'Move 7S col 1 -> col 5' },
+          { index: 1, type: 'draw_card', describe: 'Draw the next card' },
+          { index: 2, type: 'discard_to_foundation', describe: 'Play AH to hearts' },
+        ],
+      }),
+    );
+    // `tableau_to_tableau` is 18 chars → 6 trailing spaces; describe follows.
+    expect(out).toContain('  [0] tableau_to_tableau       Move 7S col 1 -> col 5');
+    // `draw_card` is 9 chars → 15 trailing spaces.
+    expect(out).toContain('  [1] draw_card                Draw the next card');
+    // `discard_to_foundation` is 21 chars → 3 trailing spaces + 1 separator.
+    expect(out).toContain('  [2] discard_to_foundation    Play AH to hearts');
+  });
+
+  it('appends the heuristic score on a legal-moves line when present', () => {
+    const out = renderHybridContext(
+      baseContext({
+        legalMoves: [
+          {
+            index: 0,
+            type: 'tableau_to_foundation',
+            describe: 'Play 2S to spades',
+            heuristicScore: 87,
+          },
+        ],
+      }),
+    );
+    expect(out).toContain('Play 2S to spades   (heuristic score: 87)');
+  });
+
+  it('renders the PROGRESS line from metrics when supplied', () => {
+    const out = renderHybridContext(
+      baseContext({
+        metrics: {
+          completionProgress: 12,
+          perceivedDifficulty: 70,
+          difficulty: 2,
+          foundationCards: 6,
+          faceDownTotal: 12,
+          progressScore: 35,
+        },
+      }),
+    );
+    expect(out).toContain('PROGRESS: foundation=6/52, face-down remaining=12, completion=12%');
+  });
+
+  it('carries PRIOR REASONING forward with the soft-de-emphasis header', () => {
+    const out = renderHybridContext(
+      baseContext({
+        reasoningTrail: [
+          { move: 'Draw the next card', reasoning: 'No productive tableau move.' },
+          { move: 'Play AC to clubs', reasoning: 'Aces always go up early.' },
+        ],
+      }),
+    );
+    expect(out).toContain('PRIOR REASONING (may be obsolete; verify against current state):');
+    expect(out).toContain('  1. move: Draw the next card');
+    expect(out).toContain('     why: No productive tableau move.');
+    expect(out).toContain('  2. move: Play AC to clubs');
+  });
+
+  it('places RECENT MOVES immediately before LEGAL MOVES (modulo optional SEEN/HIDDEN blocks)', () => {
+    // The whole point of the layout is the visual adjacency of just-played
+    // moves and on-offer moves. Pin the order so a refactor cannot quietly
+    // split them apart.
+    const out = renderHybridContext(
+      baseContext({
+        recentMoves: ['draw 6C', 'move 9D col 3 -> col 7'],
+        seenDrawPileCards: ['9H', '5S'],
+      }),
+    );
+    const recentIdx = out.indexOf('RECENT MOVES');
+    const seenIdx = out.indexOf('SEEN IN WASTE');
+    const legalIdx = out.indexOf('LEGAL MOVES');
+    expect(recentIdx).toBeGreaterThan(-1);
+    expect(legalIdx).toBeGreaterThan(-1);
+    expect(recentIdx).toBeLessThan(seenIdx);
+    expect(seenIdx).toBeLessThan(legalIdx);
+  });
+
+  it('has no trailing blank line', () => {
+    const out = renderHybridContext(baseContext());
+    expect(out.endsWith('\n')).toBe(false);
+  });
+
+  it('is smaller than the pretty-printed JSON dump it replaces on a realistic snapshot', () => {
+    // Token saving is the main cross-team justification for the change. The
+    // 4–5× ratio quoted in the layout-ask doc is measured against
+    // pretty-printed JSON on real corpus snapshots; a small fixture won't
+    // reproduce it (preamble overhead dominates), but the *direction* should
+    // hold even here. The shape-level tests above are the real regression
+    // guards — this one just catches a verbose label sneaking in.
+    const ctx = baseContext({
+      tableau: [
+        { column: 1, faceDownCount: 0, faceUp: ['8H', '7S', '6D', '5C'] },
+        { column: 2, faceDownCount: 0, faceUp: ['TD'] },
+        { column: 3, faceDownCount: 1, faceUp: ['QS'] },
+        { column: 4, faceDownCount: 0, faceUp: ['7D', '6S', '5H', '4C'] },
+        { column: 5, faceDownCount: 2, faceUp: ['8D'] },
+        { column: 6, faceDownCount: 4, faceUp: ['JS', 'TH'] },
+        { column: 7, faceDownCount: 5, faceUp: ['QC', 'JD', 'TC', '9D'] },
+      ],
+      discardTop: 'KD',
+      drawPileCount: 16,
+      foundations: { hearts: '4H', diamonds: null, clubs: null, spades: '2S' },
+      recentMoves: ['draw 6C', 'draw JC', 'move JD col 3 -> col 7'],
+      seenDrawPileCards: ['9H', '5S', 'KS', 'JC', '6C'],
+      legalMoves: [
+        { index: 0, type: 'tableau_to_tableau', describe: 'Move 7S col 1 -> col 5' },
+        { index: 1, type: 'draw_card', describe: 'Draw the next card from the stock' },
+      ],
+      metrics: {
+        completionProgress: 12,
+        perceivedDifficulty: 70,
+        difficulty: 2,
+        foundationCards: 6,
+        faceDownTotal: 12,
+        progressScore: 35,
+      },
+    });
+    const hybridChars = renderHybridContext(ctx).length;
+    const prettyJsonChars = JSON.stringify(ctx, null, 2).length;
+    expect(hybridChars).toBeLessThan(prettyJsonChars);
+  });
+
+  it('PROMPT_LAYOUT_VERSION is the hybrid-v1 stamp', () => {
+    expect(PROMPT_LAYOUT_VERSION).toBe('hybrid-v1');
+  });
+});

--- a/packages/app/src/ai/context/renderContext.ts
+++ b/packages/app/src/ai/context/renderContext.ts
@@ -1,0 +1,152 @@
+/**
+ * Hybrid ASCII renderer for {@link AIMoveContext}.
+ *
+ * Replaces the per-turn `CURRENT GAME (JSON)` dump with a plain-text layout
+ * that puts `RECENT MOVES` visually adjacent to `LEGAL MOVES`, costs roughly
+ * 4–5× fewer tokens per turn for the same information, and preserves every
+ * field the JSON form carried.
+ *
+ * Contract: `solitaire-analytics/docs/reports/20260524_harvester_team_layout_ask.md`.
+ * The Python reference (`scripts/compare_prompt_formats.py:render_hybrid`) is
+ * the source of truth for the layout — this is its TS port, kept faithful so a
+ * sample produced offline matches the wire format byte-for-byte (modulo
+ * trailing-whitespace conventions).
+ *
+ * `reasoningTrail` is carried forward under a soft-de-emphasis header, as the
+ * layout-ask doc recommends — the change is about the board / moves layout,
+ * not the trail. The decision to keep, relocate, or drop it is a separate ask.
+ *
+ * @module ai/context/renderContext
+ */
+
+import type { AIMoveContext } from '../types';
+
+/**
+ * Stamp identifying the layout that produced a given interaction. The
+ * dataset side keys its comparison reports on (`promptTemplateHash`,
+ * `inferenceParams`, `promptLayoutVersion`) — bumping this constant lets
+ * harvests be partitioned cleanly across format changes without inferring
+ * from the build hash. Bump when the renderer's output shape changes.
+ */
+export const PROMPT_LAYOUT_VERSION = 'hybrid-v1';
+
+/** Pad a column name's value column to keep `[index]` + type aligned. */
+const TYPE_COL_WIDTH = 24;
+
+/**
+ * Render an {@link AIMoveContext} as a hybrid plain-text block.
+ *
+ * The output is everything between the system instruction and the closing
+ * "Now choose..." prompt suffix — the caller wraps it with its own framing.
+ */
+export function renderHybridContext(context: AIMoveContext): string {
+  const lines: string[] = [];
+
+  // NOTATION — the renderer's own legend takes precedence over the
+  // (JSON-shape) `notation` field on the context; the field is now vestigial.
+  lines.push(
+    'NOTATION: rank+suit (A 2-9 T J Q K; H D C S). ?? = face-down. ' +
+      'In each column the top of the stack is the rightmost card.',
+  );
+  lines.push('');
+
+  // FOUNDATIONS + STOCK header
+  const f = context.foundations;
+  lines.push(
+    `FOUNDATIONS:   H: ${f.hearts ?? '--'}   ` +
+      `D: ${f.diamonds ?? '--'}   ` +
+      `C: ${f.clubs ?? '--'}   ` +
+      `S: ${f.spades ?? '--'}`,
+  );
+  lines.push(
+    `STOCK: ${context.drawPileCount} cards   ` +
+      `WASTE top: ${context.discardTop ?? '--'}   ` +
+      `recycle stock: ${context.canRecycleStock ? 'yes' : 'no'}`,
+  );
+  lines.push('');
+
+  // TABLEAU — one line per column, face-down (`??`) first then face-up.
+  // Top of stack = rightmost token. Empty columns render as `<empty>`.
+  lines.push('TABLEAU:');
+  for (const col of context.tableau) {
+    const fd =
+      col.faceDown && col.faceDown.length === col.faceDownCount
+        ? col.faceDown // oracle mode: real card identities
+        : Array<string>(col.faceDownCount).fill('??');
+    const tokens = [...fd, ...col.faceUp];
+    const content = tokens.length > 0 ? tokens.join(' ') : '<empty>';
+    lines.push(`  col${col.column}: ${content}`);
+  }
+  lines.push('');
+
+  // RECENT MOVES — numbered, oldest first, right-aligned. Deliberately
+  // adjacent to LEGAL MOVES so an oscillation trap (recent move whose
+  // reversal is on offer) shows up as a one-glance comparison.
+  const recent = context.recentMoves ?? [];
+  if (recent.length > 0) {
+    lines.push(
+      'RECENT MOVES (oldest -> newest; review before picking, ' +
+        'do not undo your own work):',
+    );
+    const width = String(recent.length).length;
+    recent.forEach((m, i) => {
+      lines.push(`  ${String(i + 1).padStart(width, ' ')}. ${m}`);
+    });
+    lines.push('');
+  }
+
+  // SEEN IN WASTE — kept on one line; needed for stock-cycle decisions.
+  const seen = context.seenDrawPileCards ?? [];
+  if (seen.length > 0) {
+    lines.push(`SEEN IN WASTE THIS CYCLE: ${seen.join(' ')}`);
+    lines.push('');
+  }
+
+  // HIDDEN INFO — only present under the `seeHiddenCards` (oracle) toggle.
+  // Surfacing it inline keeps the renderer information-preserving in that
+  // mode without affecting fair (default) play.
+  if (context.hiddenInfo) {
+    lines.push(
+      `HIDDEN INFO (oracle): draw pile order: ${context.hiddenInfo.drawPileOrder.join(' ')}`,
+    );
+    lines.push('');
+  }
+
+  // LEGAL MOVES — `[index]` is the canonical identifier; the response shape
+  // is unchanged (`{"final_decision":{"move_index": N, ...}}`).
+  lines.push('LEGAL MOVES (respond with the index of your chosen move):');
+  for (const m of context.legalMoves) {
+    const typeCol = m.type.padEnd(TYPE_COL_WIDTH, ' ');
+    const score =
+      m.heuristicScore !== undefined ? `   (heuristic score: ${m.heuristicScore})` : '';
+    lines.push(`  [${m.index}] ${typeCol} ${m.describe}${score}`);
+  }
+  lines.push('');
+
+  // PROGRESS — game metrics in a single line.
+  const metrics = context.metrics;
+  if (metrics) {
+    lines.push(
+      `PROGRESS: foundation=${metrics.foundationCards}/52, ` +
+        `face-down remaining=${metrics.faceDownTotal}, ` +
+        `completion=${metrics.completionProgress}%`,
+    );
+    lines.push('');
+  }
+
+  // PRIOR REASONING — carried forward with the layout-ask doc's
+  // soft-de-emphasis label. Not dropped: that decision is a separate ask.
+  const trail = context.reasoningTrail ?? [];
+  if (trail.length > 0) {
+    lines.push('PRIOR REASONING (may be obsolete; verify against current state):');
+    trail.forEach((t, i) => {
+      lines.push(`  ${i + 1}. move: ${t.move}`);
+      lines.push(`     why: ${t.reasoning}`);
+    });
+    lines.push('');
+  }
+
+  // Trim trailing blank line for cleanliness.
+  while (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
+  return lines.join('\n');
+}

--- a/packages/app/src/ai/context/rulesPrimer.ts
+++ b/packages/app/src/ai/context/rulesPrimer.ts
@@ -38,7 +38,10 @@ export const STRATEGY_GUIDANCE = `STRATEGY GUIDANCE (heuristics, not absolute ru
 
 /** Instructions describing the required JSON output. Always included. */
 export const OUTPUT_INSTRUCTION = `RESPONSE FORMAT:
-You will receive the current game as JSON, including a numbered array "legalMoves".
+You will receive the current game as plain-text blocks (NOTATION, FOUNDATIONS, STOCK,
+TABLEAU, RECENT MOVES, SEEN IN WASTE, LEGAL MOVES, PROGRESS — some are optional). The
+LEGAL MOVES block is a numbered list; each line begins with [index], the canonical
+move identifier you must return.
 Reason step by step, then respond with ONLY a single JSON object containing exactly
 these three keys, in this order (no prose or markdown fences outside the object):
 {
@@ -49,7 +52,7 @@ these three keys, in this order (no prose or markdown fences outside the object)
 - board_analysis: assess the current board — hidden cards, blocked columns, foundation
   progress, and the opportunities each legal move opens or closes.
 - strategic_plan: explain your plan and why the chosen move is best, given that analysis.
-- final_decision.move_index: the "index" of your chosen move from the legalMoves array.
+- final_decision.move_index: the [index] of your chosen move from the LEGAL MOVES block.
 - final_decision.confidence: a calibrated probability (0 to 1) that this move is
   objectively the best one available — a genuine estimate, not a feeling. Use the
   full range honestly:

--- a/packages/app/src/ai/context/systemInstruction.test.ts
+++ b/packages/app/src/ai/context/systemInstruction.test.ts
@@ -66,12 +66,12 @@ describe('hashSystemInstruction', () => {
 describe('prompt template identity (tripwire)', () => {
   it('hash with strategy guidance is pinned', async () => {
     const hash = await hashSystemInstruction(buildSystemInstruction(configWith(true)));
-    expect(hash).toBe('e2923795519ed672381bcf34311af1e2989d1e5ce3d64d397f045e7e6c2b91b2');
+    expect(hash).toBe('0462323c366204b491790a90930fffa2916117b4bb210f390b26c33ddd0cdb9c');
   });
 
   it('hash without strategy guidance is pinned', async () => {
     const hash = await hashSystemInstruction(buildSystemInstruction(configWith(false)));
-    expect(hash).toBe('956f29f5baf8d0ca3d69bd15abea3c1b01b2304331354b24f1dd73a99a0f32af');
+    expect(hash).toBe('4115634979af4b7f4539f1a154b192ba813b8173a65800bba963bee4ef3582ba');
   });
 
   it('PROMPT_TEMPLATE_FINALISED_AT is a valid ISO 8601 UTC instant', () => {

--- a/packages/app/src/ai/context/systemInstruction.ts
+++ b/packages/app/src/ai/context/systemInstruction.ts
@@ -27,7 +27,7 @@ import { OUTPUT_INSTRUCTION, RULES_PRIMER, STRATEGY_GUIDANCE } from './rulesPrim
  * because the templates evolve independently of any release cadence and the
  * downstream analytics already key off ISO timestamps.
  */
-export const PROMPT_TEMPLATE_FINALISED_AT = '2026-05-22T00:00:00Z';
+export const PROMPT_TEMPLATE_FINALISED_AT = '2026-05-24T00:00:00Z';
 
 /** Build the full system instruction for a move-suggestion request. */
 export function buildSystemInstruction(config: AIConfig): string {

--- a/packages/app/src/ai/interactionLog.test.ts
+++ b/packages/app/src/ai/interactionLog.test.ts
@@ -77,6 +77,15 @@ describe('interactionLog', () => {
     expect(getLastAIInteraction()?.inferenceParams).toEqual({ temperature: 0 });
   });
 
+  it('preserves promptLayoutVersion when supplied', () => {
+    recordAIInteraction({
+      ...base,
+      id: 'id-layout',
+      promptLayoutVersion: 'hybrid-v1',
+    });
+    expect(getLastAIInteraction()?.promptLayoutVersion).toBe('hybrid-v1');
+  });
+
   it('getLastAIInteraction returns the most recent entry', () => {
     expect(getLastAIInteraction()).toBeNull();
     recordAIInteraction(base);

--- a/packages/app/src/ai/interactionLog.ts
+++ b/packages/app/src/ai/interactionLog.ts
@@ -60,6 +60,16 @@ export interface AIInteraction {
     /** Sampling temperature passed to the provider (0 = greedy). */
     temperature?: number;
   };
+  /**
+   * Identifier for the per-turn-prompt layout that produced this row. Mirrors
+   * `promptTemplateHash` (which fingerprints the system instruction): even
+   * though the system instruction and the layout always change together in
+   * practice, the dataset side keys its comparison reports on
+   * (`promptTemplateHash`, `inferenceParams`, `promptLayoutVersion`) so a
+   * layout switch can be attributed without inferring from build hash.
+   * Bumped in lockstep with `PROMPT_LAYOUT_VERSION` in `context/renderContext`.
+   */
+  promptLayoutVersion?: string;
   /** Deal seed of the game, when one was used. */
   seed?: number;
   /** Turn index within the game (move-history length at request time). */

--- a/packages/app/src/ai/providers/GeminiProvider.test.ts
+++ b/packages/app/src/ai/providers/GeminiProvider.test.ts
@@ -6,6 +6,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { geminiProvider } from './GeminiProvider';
 import { AI_TEMPERATURE } from '../constants';
+import { PROMPT_LAYOUT_VERSION } from '../context/renderContext';
 import { clearAIInteractions, getLastAIInteraction } from '../interactionLog';
 import { AIError, type AIMoveContext, type AIRequest } from '../types';
 
@@ -143,6 +144,58 @@ describe('geminiProvider.suggestMove', () => {
     const last = getLastAIInteraction();
     expect(last?.outcome).toBe('error');
     expect(last?.inferenceParams).toEqual({ temperature: AI_TEMPERATURE });
+  });
+
+  it('renders the per-turn game context as the hybrid ASCII layout, not JSON', async () => {
+    // The cross-team change PR ships: the wire format for the per-turn block
+    // is the hybrid layout. Pin the markers here so a future refactor that
+    // silently regresses to JSON is caught.
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse(200, {
+        candidates: [
+          {
+            content: { parts: [{ text: '{"moveIndex":0,"reasoning":"Draw.","confidence":0.5}' }] },
+            finishReason: 'STOP',
+          },
+        ],
+      }),
+    );
+    await geminiProvider.suggestMove(request);
+    const last = getLastAIInteraction();
+    const prompt = last?.prompt ?? '';
+    // Hybrid markers present.
+    expect(prompt).toContain('NOTATION: rank+suit');
+    expect(prompt).toContain('FOUNDATIONS:');
+    expect(prompt).toContain('TABLEAU:');
+    expect(prompt).toContain('LEGAL MOVES (respond with the index of your chosen move):');
+    // JSON form is gone.
+    expect(prompt).not.toContain('CURRENT GAME (JSON):');
+    expect(prompt).not.toContain('"legalMoves":');
+  });
+
+  it('stamps the prompt-layout version on a success interaction', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse(200, {
+        candidates: [
+          {
+            content: { parts: [{ text: '{"moveIndex":0,"reasoning":"Draw.","confidence":0.5}' }] },
+            finishReason: 'STOP',
+          },
+        ],
+      }),
+    );
+    await geminiProvider.suggestMove(request);
+    expect(getLastAIInteraction()?.promptLayoutVersion).toBe(PROMPT_LAYOUT_VERSION);
+  });
+
+  it('stamps the prompt-layout version on an error-outcome interaction too', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse(401, { error: { code: 401, message: 'API key not valid' } }),
+    );
+    await expect(geminiProvider.suggestMove(request)).rejects.toBeInstanceOf(AIError);
+    const last = getLastAIInteraction();
+    expect(last?.outcome).toBe('error');
+    expect(last?.promptLayoutVersion).toBe(PROMPT_LAYOUT_VERSION);
   });
 
   it('falls back to all parts when none are flagged as thoughts', async () => {

--- a/packages/app/src/ai/providers/GeminiProvider.ts
+++ b/packages/app/src/ai/providers/GeminiProvider.ts
@@ -24,6 +24,10 @@ import {
   GEMINI_API_BASE,
 } from '../constants';
 import {
+  PROMPT_LAYOUT_VERSION,
+  renderHybridContext,
+} from '../context/renderContext';
+import {
   PROMPT_TEMPLATE_FINALISED_AT,
   hashSystemInstruction,
 } from '../context/systemInstruction';
@@ -176,10 +180,13 @@ export const geminiProvider: AIProvider = {
 
     const startedAt = Date.now();
     // Single user message: system instruction + game context (the output
-    // rules are already inside the system instruction).
+    // rules are already inside the system instruction). The per-turn block is
+    // rendered as the hybrid ASCII layout — roughly 4–5× fewer tokens than the
+    // prior JSON dump for the same information, and visually adjacent
+    // RECENT/LEGAL moves blocks; layout contract lives in `context/renderContext`.
     const prompt =
       `${request.systemInstruction}\n\n` +
-      `CURRENT GAME (JSON):\n${JSON.stringify(request.context)}\n\n` +
+      `CURRENT GAME:\n${renderHybridContext(request.context)}\n\n` +
       'Now choose the best move and reply with only the JSON object.';
     // Fingerprint the prompt template for the harvested log. Hashed once per
     // call, before any network IO, so both the success and error branches can
@@ -285,6 +292,7 @@ export const geminiProvider: AIProvider = {
         promptTemplateHash,
         promptTemplateFinalisedAt: PROMPT_TEMPLATE_FINALISED_AT,
         inferenceParams: { temperature: AI_TEMPERATURE },
+        promptLayoutVersion: PROMPT_LAYOUT_VERSION,
         rawResponse,
         thinkingText,
         decision,
@@ -313,6 +321,7 @@ export const geminiProvider: AIProvider = {
         promptTemplateHash,
         promptTemplateFinalisedAt: PROMPT_TEMPLATE_FINALISED_AT,
         inferenceParams: { temperature: AI_TEMPERATURE },
+        promptLayoutVersion: PROMPT_LAYOUT_VERSION,
         rawResponse,
         thinkingText,
         httpStatus,


### PR DESCRIPTION
## What

Replaces the per-turn `CURRENT GAME (JSON):` block in the AI advisor's prompt with a plain-text **hybrid layout**: `NOTATION` / `FOUNDATIONS` / `STOCK` / `TABLEAU` / `RECENT MOVES` / `SEEN IN WASTE` / `LEGAL MOVES` / `PROGRESS` / `PRIOR REASONING`. Same fields, different encoding.

```
FOUNDATIONS:   H: 4H   D: --   C: --   S: 2S
STOCK: 16 cards   WASTE top: KD   recycle stock: no

TABLEAU:
  col1: 8H 7S 6D 5C
  col2: TD
  col3: ?? QS
  ...

RECENT MOVES (oldest -> newest; review before picking, do not undo your own work):
   1. draw 6C
   ...
  10. draw KD

LEGAL MOVES (respond with the index of your chosen move):
  [0] tableau_to_tableau       Move 7S plus 2 more from column 1 to column 5
  [1] draw_card                Draw the next card from the stock onto the waste
  [2] tableau_to_tableau       Move JD plus 2 more from column 7 to column 3
```

## Why

- **~4–5× fewer characters per turn** than the pretty-printed JSON form on real corpus snapshots, with no information loss. Token cost back even before any decision-quality change.
- **`RECENT MOVES` is now visually adjacent to `LEGAL MOVES`** — an oscillation trap (recent move whose reversal is on offer) shows up as a one-glance comparison instead of being split across nested JSON, which was a meaningful contributor to documented doom-loop patterns in the harvested corpus.
- Matches the layout the dataset side is keying its next comparison report on.

## Discipline carried over from #178–#180

- New `AIInteraction.promptLayoutVersion` field (`'hybrid-v1'`), stamped on **both** success and error branches in `GeminiProvider`. Same always-stamped pattern as `inferenceParams` and `promptTemplateHash`. Lets harvests be partitioned cleanly on `(promptTemplateHash, inferenceParams, promptLayoutVersion)` without inferring from build hash.
- `OUTPUT_INSTRUCTION` updated to describe the new wire format (it was still claiming "as JSON" — would have been a lie under the new layout). Pinned tripwire hashes in `systemInstruction.test.ts` updated and `PROMPT_TEMPLATE_FINALISED_AT` bumped to `2026-05-24T00:00:00Z` in the same commit, per the existing test-enforced discipline.

## What's new

- `packages/app/src/ai/context/renderContext.ts` — `renderHybridContext(ctx)` plus `PROMPT_LAYOUT_VERSION` constant. TS port of the Python reference at `solitaire-analytics/scripts/compare_prompt_formats.py:render_hybrid`; visual byte-for-byte match against the layout-ask doc's "after" example verified locally.
- `reasoningTrail` is **carried forward** under the soft-de-emphasis header `PRIOR REASONING (may be obsolete; verify against current state):`. The decision to drop / relocate / re-label it is a deliberately separate ask — the parallel investigation found the trail is high-variance (helpful when prior reasoning was right, harmful when wrong) rather than uniformly bad.

## Tests

- `renderContext.test.ts` — 17 layout-shape tests covering empty columns, face-down rendering, oracle (`seeHiddenCards`) override, recent-moves padding, legal-moves `[index]` + 24-char type-column alignment, block-order adjacency (`RECENT` → `SEEN` → `LEGAL`), optional-field gating.
- `GeminiProvider.test.ts` — assert the assembled prompt carries hybrid markers and **not** `CURRENT GAME (JSON):`; `promptLayoutVersion` stamped on both outcomes.
- `interactionLog.test.ts` — `promptLayoutVersion` round-trips through `recordAIInteraction`.

**631 tests green across the three workspaces; lint and build clean.**

## Migration notes

- Existing harvested rows pre-PR have no `promptLayoutVersion` (the field is optional). The dataset-side comparison report should treat rows without the field as the pre-hybrid layout — there's no ambiguity since the build hash, template hash, and finalised-at date all shift in lockstep.
- The `AIMoveContext.notation` field is now vestigial (the renderer prints its own `NOTATION` line). Left in place for type stability; can be retired in a follow-up.

## Standing asks not in this PR (queued)

- Resignation output (`move_index = -1` → `outcome: resigned`)
- Same-seed cross-build experiment on seed `3263196305`

Both are queued behind one full harvest cycle on the hybrid layout, then return as single-ask docs.