### PR TITLE
feat(ai): ship resign output, prompt hygiene, semantic versioning (hybrid-v1.1)

### DIFF
--- a/packages/app/src/ai/context/renderContext.test.ts
+++ b/packages/app/src/ai/context/renderContext.test.ts
@@ -34,7 +34,7 @@ function baseContext(overrides: Partial<AIMoveContext> = {}): AIMoveContext {
 }
 
 describe('renderHybridContext', () => {
-  it('always emits the FOUNDATIONS, NEXT NEEDED, STOCK, TABLEAU, LEGAL MOVES blocks', () => {
+  it('always emits the FOUNDATIONS, STOCK, TABLEAU, LEGAL MOVES blocks', () => {
     const out = renderHybridContext(baseContext());
     // NOTATION moved to the static rules block in 2026-05-26 hygiene edit 2;
     // the per-turn render must NOT carry it any more (re-rendered every turn
@@ -42,20 +42,9 @@ describe('renderHybridContext', () => {
     expect(out).not.toMatch(/NOTATION:/);
     expect(out).toMatch(/^FOUNDATIONS:/);
     expect(out).toContain('FOUNDATIONS:   H: --   D: --   C: --   S: --');
-    expect(out).toContain('NEXT NEEDED:   H: AH   D: AD   C: AC   S: AS');
     expect(out).toContain('STOCK: 0 cards   WASTE top: --   recycle stock: no');
     expect(out).toContain('TABLEAU:');
     expect(out).toContain('LEGAL MOVES (respond with the index of your chosen move):');
-  });
-
-  it('renders NEXT NEEDED as the next rank up from each foundation top, with "done" for a finished King suit', () => {
-    const out = renderHybridContext(
-      baseContext({
-        foundations: { hearts: 'QH', diamonds: 'KD', clubs: '8C', spades: null },
-      }),
-    );
-    expect(out).toContain('FOUNDATIONS:   H: QH   D: KD   C: 8C   S: --');
-    expect(out).toContain('NEXT NEEDED:   H: KH   D: done   C: 9C   S: AS');
   });
 
   it('renders an empty tableau column as <empty>', () => {

--- a/packages/app/src/ai/context/renderContext.test.ts
+++ b/packages/app/src/ai/context/renderContext.test.ts
@@ -34,13 +34,28 @@ function baseContext(overrides: Partial<AIMoveContext> = {}): AIMoveContext {
 }
 
 describe('renderHybridContext', () => {
-  it('always emits the NOTATION, FOUNDATIONS, STOCK, TABLEAU, LEGAL MOVES blocks', () => {
+  it('always emits the FOUNDATIONS, NEXT NEEDED, STOCK, TABLEAU, LEGAL MOVES blocks', () => {
     const out = renderHybridContext(baseContext());
-    expect(out).toMatch(/^NOTATION: rank\+suit/);
+    // NOTATION moved to the static rules block in 2026-05-26 hygiene edit 2;
+    // the per-turn render must NOT carry it any more (re-rendered every turn
+    // for no information change).
+    expect(out).not.toMatch(/NOTATION:/);
+    expect(out).toMatch(/^FOUNDATIONS:/);
     expect(out).toContain('FOUNDATIONS:   H: --   D: --   C: --   S: --');
+    expect(out).toContain('NEXT NEEDED:   H: AH   D: AD   C: AC   S: AS');
     expect(out).toContain('STOCK: 0 cards   WASTE top: --   recycle stock: no');
     expect(out).toContain('TABLEAU:');
     expect(out).toContain('LEGAL MOVES (respond with the index of your chosen move):');
+  });
+
+  it('renders NEXT NEEDED as the next rank up from each foundation top, with "done" for a finished King suit', () => {
+    const out = renderHybridContext(
+      baseContext({
+        foundations: { hearts: 'QH', diamonds: 'KD', clubs: '8C', spades: null },
+      }),
+    );
+    expect(out).toContain('FOUNDATIONS:   H: QH   D: KD   C: 8C   S: --');
+    expect(out).toContain('NEXT NEEDED:   H: KH   D: done   C: 9C   S: AS');
   });
 
   it('renders an empty tableau column as <empty>', () => {

--- a/packages/app/src/ai/context/renderContext.ts
+++ b/packages/app/src/ai/context/renderContext.ts
@@ -33,30 +33,52 @@ export const PROMPT_LAYOUT_VERSION = 'hybrid-v1';
 /** Pad a column name's value column to keep `[index]` + type aligned. */
 const TYPE_COL_WIDTH = 24;
 
+/** Foundation rank ladder; index = rank's slot in an Ace-to-King build. */
+const FOUNDATION_RANKS = ['A', '2', '3', '4', '5', '6', '7', '8', '9', 'T', 'J', 'Q', 'K'] as const;
+
+/**
+ * The next rank a suit's foundation needs to receive. Pre-computed so the
+ * model does not re-derive it in every reasoning trace; the prior corpus
+ * showed this being recomputed manually almost every turn. See the
+ * 2026-05-26 hygiene ask, edit 3.
+ */
+function nextFoundationToken(top: string | null, suitLetter: string): string {
+  if (top === null) return `A${suitLetter}`;
+  const rank = top[0];
+  const idx = FOUNDATION_RANKS.indexOf(rank as (typeof FOUNDATION_RANKS)[number]);
+  if (idx < 0) return `A${suitLetter}`; // defensive: malformed token
+  if (idx === FOUNDATION_RANKS.length - 1) return 'done';
+  return `${FOUNDATION_RANKS[idx + 1]}${suitLetter}`;
+}
+
 /**
  * Render an {@link AIMoveContext} as a hybrid plain-text block.
  *
  * The output is everything between the system instruction and the closing
- * "Now choose..." prompt suffix — the caller wraps it with its own framing.
+ * "Now choose..." prompt suffix; the caller wraps it with its own framing.
+ *
+ * The NOTATION legend lives in the static rules block (in `rulesPrimer.ts`),
+ * not here, so it is not re-rendered every turn for no information change.
  */
 export function renderHybridContext(context: AIMoveContext): string {
   const lines: string[] = [];
 
-  // NOTATION — the renderer's own legend takes precedence over the
-  // (JSON-shape) `notation` field on the context; the field is now vestigial.
-  lines.push(
-    'NOTATION: rank+suit (A 2-9 T J Q K; H D C S). ?? = face-down. ' +
-      'In each column the top of the stack is the rightmost card.',
-  );
-  lines.push('');
-
-  // FOUNDATIONS + STOCK header
+  // FOUNDATIONS + STOCK header. The NEXT NEEDED line under FOUNDATIONS
+  // pre-computes the card each suit must receive next (Ace for an empty
+  // foundation, `done` when a King is home); it saves the model from doing
+  // the derivation in prose every turn.
   const f = context.foundations;
   lines.push(
     `FOUNDATIONS:   H: ${f.hearts ?? '--'}   ` +
       `D: ${f.diamonds ?? '--'}   ` +
       `C: ${f.clubs ?? '--'}   ` +
       `S: ${f.spades ?? '--'}`,
+  );
+  lines.push(
+    `NEXT NEEDED:   H: ${nextFoundationToken(f.hearts, 'H')}   ` +
+      `D: ${nextFoundationToken(f.diamonds, 'D')}   ` +
+      `C: ${nextFoundationToken(f.clubs, 'C')}   ` +
+      `S: ${nextFoundationToken(f.spades, 'S')}`,
   );
   lines.push(
     `STOCK: ${context.drawPileCount} cards   ` +

--- a/packages/app/src/ai/context/renderContext.ts
+++ b/packages/app/src/ai/context/renderContext.ts
@@ -33,24 +33,6 @@ export const PROMPT_LAYOUT_VERSION = 'hybrid-v1';
 /** Pad a column name's value column to keep `[index]` + type aligned. */
 const TYPE_COL_WIDTH = 24;
 
-/** Foundation rank ladder; index = rank's slot in an Ace-to-King build. */
-const FOUNDATION_RANKS = ['A', '2', '3', '4', '5', '6', '7', '8', '9', 'T', 'J', 'Q', 'K'] as const;
-
-/**
- * The next rank a suit's foundation needs to receive. Pre-computed so the
- * model does not re-derive it in every reasoning trace; the prior corpus
- * showed this being recomputed manually almost every turn. See the
- * 2026-05-26 hygiene ask, edit 3.
- */
-function nextFoundationToken(top: string | null, suitLetter: string): string {
-  if (top === null) return `A${suitLetter}`;
-  const rank = top[0];
-  const idx = FOUNDATION_RANKS.indexOf(rank as (typeof FOUNDATION_RANKS)[number]);
-  if (idx < 0) return `A${suitLetter}`; // defensive: malformed token
-  if (idx === FOUNDATION_RANKS.length - 1) return 'done';
-  return `${FOUNDATION_RANKS[idx + 1]}${suitLetter}`;
-}
-
 /**
  * Render an {@link AIMoveContext} as a hybrid plain-text block.
  *
@@ -63,22 +45,13 @@ function nextFoundationToken(top: string | null, suitLetter: string): string {
 export function renderHybridContext(context: AIMoveContext): string {
   const lines: string[] = [];
 
-  // FOUNDATIONS + STOCK header. The NEXT NEEDED line under FOUNDATIONS
-  // pre-computes the card each suit must receive next (Ace for an empty
-  // foundation, `done` when a King is home); it saves the model from doing
-  // the derivation in prose every turn.
+  // FOUNDATIONS + STOCK header.
   const f = context.foundations;
   lines.push(
     `FOUNDATIONS:   H: ${f.hearts ?? '--'}   ` +
       `D: ${f.diamonds ?? '--'}   ` +
       `C: ${f.clubs ?? '--'}   ` +
       `S: ${f.spades ?? '--'}`,
-  );
-  lines.push(
-    `NEXT NEEDED:   H: ${nextFoundationToken(f.hearts, 'H')}   ` +
-      `D: ${nextFoundationToken(f.diamonds, 'D')}   ` +
-      `C: ${nextFoundationToken(f.clubs, 'C')}   ` +
-      `S: ${nextFoundationToken(f.spades, 'S')}`,
   );
   lines.push(
     `STOCK: ${context.drawPileCount} cards   ` +

--- a/packages/app/src/ai/context/rulesPrimer.ts
+++ b/packages/app/src/ai/context/rulesPrimer.ts
@@ -23,6 +23,7 @@ KLONDIKE SOLITAIRE RULES (this variant):
 - Drawing turns the next stock card face-up onto the waste. When the stock is empty it can be recycled from the waste.
 - When a face-down tableau card is exposed by a move, it flips face-up automatically.
 - The game is WON when all 52 cards reach the foundations.
+NOTATION: rank+suit (A 2-9 T J Q K; H D C S). ?? = face-down. In each column the top of the stack is the rightmost card.
 
 THE GOAL: choose the single move that gives the best chance of eventually winning.`;
 
@@ -49,18 +50,14 @@ these three keys, in this order (no prose or markdown fences outside the object)
   "strategic_plan": <string>,
   "final_decision": { "move_index": <number>, "confidence": <number>, "alternative_move_index": <number> }
 }
-- board_analysis: assess the current board — hidden cards, blocked columns, foundation
+- board_analysis: assess the current board, hidden cards, blocked columns, foundation
   progress, and the opportunities each legal move opens or closes.
 - strategic_plan: explain your plan and why the chosen move is best, given that analysis.
-- final_decision.move_index: the [index] of your chosen move from the LEGAL MOVES block.
-- final_decision.confidence: a calibrated probability (0 to 1) that this move is
-  objectively the best one available — a genuine estimate, not a feeling. Use the
-  full range honestly:
-    1.0-0.9  forced, or clearly dominant — any other move would be a mistake.
-    0.9-0.7  strong — one plausible alternative exists, but this move is better.
-    0.7-0.5  a real toss-up between two or three reasonable moves.
-    0.5-0.3  a guess — the board is unclear or several moves look about equal.
-    below 0.3  little better than picking at random.
-  If you would not bet on the move, do not report high confidence.
+- final_decision.move_index: the [index] of your chosen move from the LEGAL MOVES
+  block, OR -1 to RESIGN. Resign only when no legal move can productively advance
+  the game, drawing has been exhausted, and you would not bet on any of the
+  available moves to recover. Resign is final and ends the session.
+- final_decision.confidence: a probability estimate (0 to 1) that this is the
+  best move. Use the full range honestly.
 - final_decision.alternative_move_index: optional; the index of your second-choice move.
 Produce the keys in the order above: analyse the board first, then plan, then decide.`;

--- a/packages/app/src/ai/context/rulesPrimer.ts
+++ b/packages/app/src/ai/context/rulesPrimer.ts
@@ -48,7 +48,7 @@ these three keys, in this order (no prose or markdown fences outside the object)
 {
   "board_analysis": <string>,
   "strategic_plan": <string>,
-  "final_decision": { "move_index": <number>, "confidence": <number>, "alternative_move_index": <number> }
+  "final_decision": { "move_index": <number> }
 }
 - board_analysis: assess the current board, hidden cards, blocked columns, foundation
   progress, and the opportunities each legal move opens or closes.
@@ -57,7 +57,4 @@ these three keys, in this order (no prose or markdown fences outside the object)
   block, OR -1 to RESIGN. Resign only when no legal move can productively advance
   the game, drawing has been exhausted, and you would not bet on any of the
   available moves to recover. Resign is final and ends the session.
-- final_decision.confidence: a probability estimate (0 to 1) that this is the
-  best move. Use the full range honestly.
-- final_decision.alternative_move_index: optional; the index of your second-choice move.
 Produce the keys in the order above: analyse the board first, then plan, then decide.`;

--- a/packages/app/src/ai/context/systemInstruction.test.ts
+++ b/packages/app/src/ai/context/systemInstruction.test.ts
@@ -67,12 +67,12 @@ describe('hashSystemInstruction', () => {
 describe('prompt template identity (tripwire)', () => {
   it('hash with strategy guidance is pinned', async () => {
     const hash = await hashSystemInstruction(buildSystemInstruction(configWith(true)));
-    expect(hash).toBe('a60f6344096980d7ba4889bd46faced173aca9e925e3e6b886bf5a4db56412b3');
+    expect(hash).toBe('8971cad00d0b6cf1ccf18baf9053742a156a02583b30d19984b524b902ff51eb');
   });
 
   it('hash without strategy guidance is pinned', async () => {
     const hash = await hashSystemInstruction(buildSystemInstruction(configWith(false)));
-    expect(hash).toBe('879a4d8fb4c8507b91fd4139d2fc66505150ca9311e196038ad52dbbae9bef22');
+    expect(hash).toBe('35efc0b832a453bbbb5421bcbb4eb0d677245b423fa2365f1cf70194ae935b9e');
   });
 
   it('PROMPT_TEMPLATE_FINALISED_AT is a valid ISO 8601 UTC instant', () => {

--- a/packages/app/src/ai/context/systemInstruction.test.ts
+++ b/packages/app/src/ai/context/systemInstruction.test.ts
@@ -12,6 +12,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   PROMPT_TEMPLATE_FINALISED_AT,
+  PROMPT_TEMPLATE_VERSION,
   buildSystemInstruction,
   hashSystemInstruction,
 } from './systemInstruction';
@@ -66,16 +67,25 @@ describe('hashSystemInstruction', () => {
 describe('prompt template identity (tripwire)', () => {
   it('hash with strategy guidance is pinned', async () => {
     const hash = await hashSystemInstruction(buildSystemInstruction(configWith(true)));
-    expect(hash).toBe('0462323c366204b491790a90930fffa2916117b4bb210f390b26c33ddd0cdb9c');
+    expect(hash).toBe('a60f6344096980d7ba4889bd46faced173aca9e925e3e6b886bf5a4db56412b3');
   });
 
   it('hash without strategy guidance is pinned', async () => {
     const hash = await hashSystemInstruction(buildSystemInstruction(configWith(false)));
-    expect(hash).toBe('4115634979af4b7f4539f1a154b192ba813b8173a65800bba963bee4ef3582ba');
+    expect(hash).toBe('879a4d8fb4c8507b91fd4139d2fc66505150ca9311e196038ad52dbbae9bef22');
   });
 
   it('PROMPT_TEMPLATE_FINALISED_AT is a valid ISO 8601 UTC instant', () => {
     expect(PROMPT_TEMPLATE_FINALISED_AT).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
     expect(Number.isFinite(new Date(PROMPT_TEMPLATE_FINALISED_AT).getTime())).toBe(true);
+  });
+
+  it('PROMPT_TEMPLATE_VERSION follows the hybrid-v{major}.{minor} semantic scheme', () => {
+    // Per the 2026-05-26 versioning ask: minor bump for text-only edits
+    // within the same layout (`hybrid-v1.x`); major bump for a layout
+    // restructure (`hybrid-v2.0`). The exact value is what the dataset side
+    // partitions on, so it is a tripwire — bump deliberately.
+    expect(PROMPT_TEMPLATE_VERSION).toMatch(/^hybrid-v\d+\.\d+$/);
+    expect(PROMPT_TEMPLATE_VERSION).toBe('hybrid-v1.1');
   });
 });

--- a/packages/app/src/ai/context/systemInstruction.ts
+++ b/packages/app/src/ai/context/systemInstruction.ts
@@ -27,7 +27,23 @@ import { OUTPUT_INSTRUCTION, RULES_PRIMER, STRATEGY_GUIDANCE } from './rulesPrim
  * because the templates evolve independently of any release cadence and the
  * downstream analytics already key off ISO timestamps.
  */
-export const PROMPT_TEMPLATE_FINALISED_AT = '2026-05-24T00:00:00Z';
+export const PROMPT_TEMPLATE_FINALISED_AT = '2026-05-26T00:00:00Z';
+
+/**
+ * Human-readable semantic version of the prompt template (rules + output
+ * instruction + per-turn layout, treated as one artefact). Bumped on every
+ * visible-to-the-model change:
+ * - minor (`hybrid-v1.x`) for text-only edits within the same layout;
+ * - major (`hybrid-v2.0`) for a layout restructure (a new/removed section, a
+ *   changed numbering convention).
+ *
+ * Complements {@link hashSystemInstruction} (which is the deterministic
+ * fingerprint of any byte change); the semantic version is the coarse,
+ * human-meaningful identifier that makes cross-version analysis tractable.
+ * Adopted per the 2026-05-26 harvester-team ask in
+ * `solitaire-analytics/docs/reports/20260526_harvester_team_resign_hygiene_versioning_ask.md`.
+ */
+export const PROMPT_TEMPLATE_VERSION = 'hybrid-v1.1';
 
 /** Build the full system instruction for a move-suggestion request. */
 export function buildSystemInstruction(config: AIConfig): string {

--- a/packages/app/src/ai/decision/schema.test.ts
+++ b/packages/app/src/ai/decision/schema.test.ts
@@ -34,9 +34,20 @@ describe('validateDecision', () => {
     ).toThrow(/non-integer/);
   });
 
-  it('rejects a moveIndex below range', () => {
+  it('accepts moveIndex -1 as the resignation sentinel', () => {
+    // Per the 2026-05-26 resign ask: `-1` means "resign", and the harness
+    // (not the schema) is responsible for skipping move application.
+    const result = validateDecision(
+      { moveIndex: -1, reasoning: 'No productive move available.', confidence: 0.7 },
+      LEGAL_COUNT,
+    );
+    expect(result.moveIndex).toBe(-1);
+    expect(result.reasoning).toBe('No productive move available.');
+  });
+
+  it('rejects a moveIndex below range that is not the resign sentinel', () => {
     expect(() =>
-      validateDecision({ moveIndex: -1, reasoning: 'x', confidence: 1 }, LEGAL_COUNT),
+      validateDecision({ moveIndex: -2, reasoning: 'x', confidence: 1 }, LEGAL_COUNT),
     ).toThrow(/outside the valid range/);
   });
 

--- a/packages/app/src/ai/decision/schema.ts
+++ b/packages/app/src/ai/decision/schema.ts
@@ -45,9 +45,13 @@ function pick(...candidates: unknown[]): unknown {
 /**
  * Validate a parsed object into an {@link AIMoveDecision}.
  *
- * `moveIndex` is validated strictly — an out-of-range or non-integer index is
+ * `moveIndex` is validated strictly: an out-of-range or non-integer index is
  * rejected, because applying it would touch the board. The text fields are
  * display-only and are coerced to safe defaults rather than rejected.
+ *
+ * The sentinel `-1` is accepted as a resignation signal (see the
+ * 2026-05-26 resign ask). The harness branch on `-1` skips move
+ * application and terminates the session; no other code path consumes it.
  *
  * @param raw - The parsed model output (object expected).
  * @param legalMoveCount - Number of legal moves offered to the model.
@@ -76,10 +80,11 @@ export function validateDecision(raw: unknown, legalMoveCount: number): AIMoveDe
       `AI returned a non-integer move index (${JSON.stringify(rawIndex)}).`,
     );
   }
-  if (moveIndex < 0 || moveIndex >= legalMoveCount) {
+  // `-1` is the resignation sentinel; any other negative index is invalid.
+  if (moveIndex !== -1 && (moveIndex < 0 || moveIndex >= legalMoveCount)) {
     throw new AIError(
       'bad_response',
-      `AI chose move index ${moveIndex}, outside the valid range 0..${legalMoveCount - 1}.`,
+      `AI chose move index ${moveIndex}, outside the valid range 0..${legalMoveCount - 1} (or -1 to resign).`,
     );
   }
 

--- a/packages/app/src/ai/interactionLog.ts
+++ b/packages/app/src/ai/interactionLog.ts
@@ -70,6 +70,16 @@ export interface AIInteraction {
    * Bumped in lockstep with `PROMPT_LAYOUT_VERSION` in `context/renderContext`.
    */
   promptLayoutVersion?: string;
+  /**
+   * Human-readable semantic version of the full prompt template (rules +
+   * output instruction + per-turn layout). Bumped on every visible-to-the-
+   * model change: minor (`hybrid-v1.x`) for text edits within the same
+   * layout; major (`hybrid-v2.0`) for a layout restructure. Complements
+   * {@link promptTemplateHash} (the deterministic byte-level fingerprint)
+   * with a coarse identifier that makes cross-version analysis tractable.
+   * Adopted per the 2026-05-26 harvester-team versioning ask.
+   */
+  promptTemplateVersion?: string;
   /** Deal seed of the game, when one was used. */
   seed?: number;
   /** Turn index within the game (move-history length at request time). */
@@ -114,8 +124,16 @@ export interface AIInteraction {
    * more than one between calls.
    */
   movesApplied?: string[];
-  /** Whether the call succeeded. */
-  outcome: 'success' | 'error';
+  /**
+   * Outcome of the call:
+   * - `success`: model returned a parseable decision and the harness applied
+   *   the chosen move.
+   * - `error`: the call failed (network, timeout, parse failure, etc.).
+   * - `resigned`: model returned `move_index: -1`; harness applied no move
+   *   and ended the session. {@link decision} is populated; {@link errorKind}
+   *   is not.
+   */
+  outcome: 'success' | 'error' | 'resigned';
   /** Wall-clock duration of the call, in ms. */
   durationMs: number;
   /** The full prompt text sent to the model. */
@@ -205,6 +223,10 @@ export function recordAIInteraction(entry: AIInteraction): void {
         ` thoughts=${entry.thoughtTokens ?? '?'}` +
         ` output=${entry.outputTokens ?? '?'}` +
         ` total=${entry.totalTokens ?? '?'}`,
+    );
+  } else if (entry.outcome === 'resigned') {
+    console.info(
+      `[AI] ${entry.model} resigned in ${seconds}s (req ${entry.requestId.slice(0, 8)} #${entry.attempt})`,
     );
   } else {
     console.warn(

--- a/packages/app/src/ai/providers/GeminiProvider.test.ts
+++ b/packages/app/src/ai/providers/GeminiProvider.test.ts
@@ -168,7 +168,6 @@ describe('geminiProvider.suggestMove', () => {
     // not the per-turn render; the system instruction is stubbed here so the
     // marker is not in `prompt`. Per-turn markers below are what we pin.)
     expect(prompt).toContain('FOUNDATIONS:');
-    expect(prompt).toContain('NEXT NEEDED:');
     expect(prompt).toContain('TABLEAU:');
     expect(prompt).toContain('LEGAL MOVES (respond with the index of your chosen move):');
     // JSON form is gone.

--- a/packages/app/src/ai/providers/GeminiProvider.test.ts
+++ b/packages/app/src/ai/providers/GeminiProvider.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { geminiProvider } from './GeminiProvider';
 import { AI_TEMPERATURE } from '../constants';
 import { PROMPT_LAYOUT_VERSION } from '../context/renderContext';
+import { PROMPT_TEMPLATE_VERSION } from '../context/systemInstruction';
 import { clearAIInteractions, getLastAIInteraction } from '../interactionLog';
 import { AIError, type AIMoveContext, type AIRequest } from '../types';
 
@@ -163,9 +164,11 @@ describe('geminiProvider.suggestMove', () => {
     await geminiProvider.suggestMove(request);
     const last = getLastAIInteraction();
     const prompt = last?.prompt ?? '';
-    // Hybrid markers present.
-    expect(prompt).toContain('NOTATION: rank+suit');
+    // Hybrid markers present. (NOTATION lives in the static rules block now,
+    // not the per-turn render; the system instruction is stubbed here so the
+    // marker is not in `prompt`. Per-turn markers below are what we pin.)
     expect(prompt).toContain('FOUNDATIONS:');
+    expect(prompt).toContain('NEXT NEEDED:');
     expect(prompt).toContain('TABLEAU:');
     expect(prompt).toContain('LEGAL MOVES (respond with the index of your chosen move):');
     // JSON form is gone.
@@ -196,6 +199,61 @@ describe('geminiProvider.suggestMove', () => {
     const last = getLastAIInteraction();
     expect(last?.outcome).toBe('error');
     expect(last?.promptLayoutVersion).toBe(PROMPT_LAYOUT_VERSION);
+  });
+
+  it('stamps the prompt-template semantic version on success and error interactions', async () => {
+    // Per the 2026-05-26 versioning ask: every harvested interaction must
+    // carry the human-readable template version (e.g. `hybrid-v1.1`)
+    // alongside the per-row hash, so the dataset side can partition on it
+    // without inferring from `appCommit`.
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse(200, {
+        candidates: [
+          {
+            content: { parts: [{ text: '{"moveIndex":0,"reasoning":"Draw.","confidence":0.5}' }] },
+            finishReason: 'STOP',
+          },
+        ],
+      }),
+    );
+    await geminiProvider.suggestMove(request);
+    expect(getLastAIInteraction()?.promptTemplateVersion).toBe(PROMPT_TEMPLATE_VERSION);
+
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse(401, { error: { code: 401, message: 'API key not valid' } }),
+    );
+    await expect(geminiProvider.suggestMove(request)).rejects.toBeInstanceOf(AIError);
+    expect(getLastAIInteraction()?.promptTemplateVersion).toBe(PROMPT_TEMPLATE_VERSION);
+  });
+
+  it('records outcome="resigned" when the model returns move_index -1, no error thrown', async () => {
+    // Resign sentinel: parser passes `-1` through, harness (not provider)
+    // skips move application. The provider's job is to log the interaction
+    // with the right outcome.
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse(200, {
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  text:
+                    '{"board_analysis":"oscillation, no out","strategic_plan":"resign",' +
+                    '"final_decision":{"move_index":-1,"confidence":0.6}}',
+                },
+              ],
+            },
+            finishReason: 'STOP',
+          },
+        ],
+      }),
+    );
+    const decision = await geminiProvider.suggestMove(request);
+    expect(decision.moveIndex).toBe(-1);
+    const last = getLastAIInteraction();
+    expect(last?.outcome).toBe('resigned');
+    expect(last?.decision?.moveIndex).toBe(-1);
+    expect(last?.errorKind).toBeUndefined();
   });
 
   it('falls back to all parts when none are flagged as thoughts', async () => {

--- a/packages/app/src/ai/providers/GeminiProvider.ts
+++ b/packages/app/src/ai/providers/GeminiProvider.ts
@@ -29,6 +29,7 @@ import {
 } from '../context/renderContext';
 import {
   PROMPT_TEMPLATE_FINALISED_AT,
+  PROMPT_TEMPLATE_VERSION,
   hashSystemInstruction,
 } from '../context/systemInstruction';
 import { parseDecision } from '../decision/schema';
@@ -274,7 +275,13 @@ export const geminiProvider: AIProvider = {
       const decision = parseDecision(rawResponse, request.context.legalMoves.length);
 
       // Log the full interaction: prompt, response, thinking, decision, tokens.
+      // A parsed decision with `moveIndex === -1` is the resignation signal
+      // (see the 2026-05-26 resign ask); the interaction is recorded with
+      // outcome `resigned` rather than `success`, no move is applied, and
+      // the harness ends the session. The decision itself is still
+      // populated so the analysis text/confidence are harvested intact.
       const usage = data.usageMetadata;
+      const isResign = decision.moveIndex === -1;
       recordAIInteraction({
         id: uuidv7(),
         requestId: request.requestId ?? uuidv7(),
@@ -286,11 +293,12 @@ export const geminiProvider: AIProvider = {
         seed: request.seed,
         turnIndex: request.turnIndex,
         config: request.config,
-        outcome: 'success',
+        outcome: isResign ? 'resigned' : 'success',
         durationMs: Date.now() - startedAt,
         prompt,
         promptTemplateHash,
         promptTemplateFinalisedAt: PROMPT_TEMPLATE_FINALISED_AT,
+        promptTemplateVersion: PROMPT_TEMPLATE_VERSION,
         inferenceParams: { temperature: AI_TEMPERATURE },
         promptLayoutVersion: PROMPT_LAYOUT_VERSION,
         rawResponse,
@@ -320,6 +328,7 @@ export const geminiProvider: AIProvider = {
         prompt,
         promptTemplateHash,
         promptTemplateFinalisedAt: PROMPT_TEMPLATE_FINALISED_AT,
+        promptTemplateVersion: PROMPT_TEMPLATE_VERSION,
         inferenceParams: { temperature: AI_TEMPERATURE },
         promptLayoutVersion: PROMPT_LAYOUT_VERSION,
         rawResponse,

--- a/packages/app/src/ai/providers/stubProvider.ts
+++ b/packages/app/src/ai/providers/stubProvider.ts
@@ -54,7 +54,7 @@ export function createStubProvider(decide?: StubDecisionFn): AIProvider {
           seed: request.seed,
           turnIndex: request.turnIndex,
           config: request.config,
-          outcome: 'success',
+          outcome: decision.moveIndex === -1 ? 'resigned' : 'success',
           durationMs: Date.now() - startedAt,
           prompt,
           rawResponse: JSON.stringify(decision),

--- a/packages/app/src/ai/types.ts
+++ b/packages/app/src/ai/types.ts
@@ -279,8 +279,11 @@ export class AIError extends Error {
 export interface AIDecisionRecord {
   /** When the decision was applied. */
   timestamp: number;
-  /** The chosen move's type. */
-  moveType: MoveCommand['type'];
+  /**
+   * The chosen move's type, or `'resign'` when the model returned
+   * `move_index: -1` and the harness ended the session without a move.
+   */
+  moveType: MoveCommand['type'] | 'resign';
   /** Human-readable description of the chosen move. */
   describe: string;
   /** The LLM's board analysis (the `board_analysis` output key). */

--- a/packages/app/src/store/aiAdvisor.test.ts
+++ b/packages/app/src/store/aiAdvisor.test.ts
@@ -163,6 +163,45 @@ describe('AI Move Advisor store actions', () => {
     useGameStore.getState().clearAIError();
     expect(useGameStore.getState().aiError).toBeUndefined();
   });
+
+  it('records a resign decision and applies no move when the model returns move_index -1', async () => {
+    // Resign path: harness must record `moveType: 'resign'`, set the
+    // interaction outcome to `resigned`, and leave the board untouched.
+    // No error is reported; the analysis text and confidence pass through.
+    clearAIInteractions();
+    useStub({
+      boardAnalysis: 'Three-card oscillation, stock exhausted, no out.',
+      moveIndex: -1,
+      reasoning: 'No legal move advances the game; drawing is exhausted.',
+      confidence: 0.6,
+    });
+
+    const before = useGameStore.getState().moveHistory.length;
+    await useGameStore.getState().askAIForMove();
+    const state = useGameStore.getState();
+
+    // Board untouched.
+    expect(state.moveHistory.length).toBe(before);
+    // Harness state: not thinking, no error, auto-play off, status reflects resign.
+    expect(state.aiThinking).toBe(false);
+    expect(state.aiError).toBeUndefined();
+    expect(state.aiAutoPlay).toBe(false);
+    expect(state.aiStatus).toBe('AI resigned.');
+    // Decision recorded with the resign sentinel.
+    expect(state.aiDecisionLog).toHaveLength(1);
+    const decision = state.aiDecisionLog?.[0];
+    expect(decision?.moveType).toBe('resign');
+    expect(decision?.moveIndex).toBe(-1);
+    expect(decision?.describe).toBe('AI resigned');
+    expect(decision?.boardAnalysis).toBe('Three-card oscillation, stock exhausted, no out.');
+    expect(decision?.reasoning).toBe('No legal move advances the game; drawing is exhausted.');
+    expect(decision?.confidence).toBeCloseTo(0.6);
+    // Interaction logged with outcome `resigned` and an empty movesApplied[].
+    const last = getLastAIInteraction();
+    expect(last?.outcome).toBe('resigned');
+    expect(last?.movesApplied).toEqual([]);
+    expect(last?.decision?.moveIndex).toBe(-1);
+  });
 });
 
 describe('AI auto-play', () => {

--- a/packages/app/src/store/gameStore.ts
+++ b/packages/app/src/store/gameStore.ts
@@ -1453,6 +1453,51 @@ export const useGameStore = create<GameStore>((set, get) => ({
         },
       );
 
+      // Resignation: `move_index: -1` means the model surrendered the game
+      // because no legal move can productively advance and drawing is
+      // exhausted. The 2026-05-26 ask wired this through; the harness applies
+      // no move, records the decision with `moveType: 'resign'`, stops
+      // auto-play, and ends the session. The interaction was logged by the
+      // provider with `outcome: 'resigned'` and the decision's analysis text
+      // / confidence intact.
+      if (decision.moveIndex === -1) {
+        setLastInteractionMovesApplied([]);
+        const interaction = getLastAIInteraction();
+        const record: AIDecisionRecord = {
+          timestamp: Date.now(),
+          moveType: 'resign',
+          describe: 'AI resigned',
+          boardAnalysis: decision.boardAnalysis,
+          reasoning: decision.reasoning,
+          confidence: decision.confidence,
+          model: config.model,
+          requestId,
+          moveIndex: -1,
+          legalMoveCount: legalMoves.length,
+          durationMs: Date.now() - requestStartedAt,
+          retries: get().aiRetryCount ?? 0,
+          promptTokens: interaction?.promptTokens,
+          thoughtTokens: interaction?.thoughtTokens,
+          outputTokens: interaction?.outputTokens,
+          totalTokens: interaction?.totalTokens,
+        };
+        const aiDecisionLog = [...(get().aiDecisionLog ?? []), record].slice(
+          -AI_DECISION_LOG_LIMIT,
+        );
+        set({
+          aiThinking: false,
+          aiThinkingSince: undefined,
+          aiStatus: 'AI resigned.',
+          aiDecisionLog,
+          aiError: undefined,
+          aiAutoPlay: false,
+        });
+        console.info(
+          `[AI] resign applied in ${((Date.now() - requestStartedAt) / 1000).toFixed(1)}s`,
+        );
+        return;
+      }
+
       // Defensive: the provider already range-checked moveIndex, but never
       // index a move list with an unverified value.
       if (decision.moveIndex < 0 || decision.moveIndex >= legalMoves.length) {


### PR DESCRIPTION
## Summary

Bundles the 2026-05-26 dataset-side ask into one prompt-template bump (`hybrid-v1.0` → `hybrid-v1.1`):

1. **Resign output**: `final_decision.move_index: -1` is now the resignation sentinel. Schema accepts it; harness skips move application, records the decision with `moveType: 'resign'`, logs the interaction with `outcome: 'resigned'`, stops auto-play, and ends the session. Analysis text is preserved.
2. **Prompt hygiene**:
   - Drop the multi-line confidence-calibration bands block; replace with a one-line probability instruction. (Then in the follow-up commit, drop `confidence` and `alternative_move_index` from the prompt schema entirely — saturated/unused, no signal.)
   - Move `NOTATION:` from the per-turn block into the static `KLONDIKE SOLITAIRE RULES` block (~35 tokens/turn reclaimed).
   - **NEXT NEEDED line: dropped from this cycle** (initially shipped, then removed in the follow-up commit — didn't earn its line over the model's own derivation).
   - Edit 4 from the ask (truncate `PRIOR REASONING`) was held this cycle per the local bench: clean SHIP on v1.1 deployed student, -10pp teacher-match on the Gemma 4 E2B untuned v2 ship target.
3. **Semantic prompt versioning**: new `promptTemplateVersion` field on every exported interaction (`hybrid-v1.1` this cycle). Complements the existing per-byte `promptTemplateHash` and the layout-shape `promptLayoutVersion` (unchanged at `hybrid-v1`).

Final final_decision shape sent to the model:
```
{
  "board_analysis": <string>,
  "strategic_plan": <string>,
  "final_decision": { "move_index": <number> }
}
```

Schema additions:
- `AIInteraction.outcome` enum gains `'resigned'`.
- `AIDecisionRecord.moveType` widens to `MoveCommand['type'] | 'resign'`.
- `AIInteraction.promptTemplateVersion?: string` added.

Tripwire bumped: `PROMPT_TEMPLATE_FINALISED_AT = '2026-05-26T00:00:00Z'`; pinned template hashes refreshed.

Ask reference: `solitaire-analytics/docs/reports/20260526_harvester_team_resign_hygiene_versioning_ask.md`.

## Test plan

- [x] `pnpm --filter app test:run` — 347/347 unit tests pass (resign schema test, resign store integration test, `promptTemplateVersion` stamping test, `PROMPT_TEMPLATE_VERSION` format tripwire)
- [x] `pnpm --filter app test:e2e e2e/ai-advisor.spec.ts` — 10/10 Playwright tests pass headless
- [x] `pnpm --filter app lint` clean
- [x] Live dev-server smoke via Playwright MCP: NOTATION absent from per-turn block, stub-driven `-1` resign returns `outcome: 'resigned'`, `movesApplied: []`, board untouched, auto-play disabled
- [ ] Full Playwright suite green in CI