### PR TITLE
fix(ai): stop fabricating a 0.5 confidence default and gate UI on presence

### DIFF
--- a/packages/app/src/ai/decision/schema.test.ts
+++ b/packages/app/src/ai/decision/schema.test.ts
@@ -92,10 +92,22 @@ describe('validateDecision', () => {
     ).toBeCloseTo(0.9);
   });
 
-  it('defaults a missing/NaN confidence to 0.5', () => {
+  it('leaves a missing or non-finite confidence undefined (no fabricated default)', () => {
+    // hybrid-v1.1 removed `final_decision.confidence` from the prompt schema;
+    // fabricating a 0.5 default would render as "50%" in the UI and look like
+    // real signal. Missing/non-numeric values now stay undefined so callers
+    // can gate rendering on presence.
     expect(
       validateDecision({ moveIndex: 0, reasoning: 'x' }, LEGAL_COUNT).confidence,
-    ).toBe(0.5);
+    ).toBeUndefined();
+    expect(
+      validateDecision({ moveIndex: 0, reasoning: 'x', confidence: NaN }, LEGAL_COUNT)
+        .confidence,
+    ).toBeUndefined();
+    expect(
+      validateDecision({ moveIndex: 0, reasoning: 'x', confidence: 'nope' }, LEGAL_COUNT)
+        .confidence,
+    ).toBeUndefined();
   });
 
   it('keeps a valid alternativeMoveIndex', () => {

--- a/packages/app/src/ai/decision/schema.ts
+++ b/packages/app/src/ai/decision/schema.ts
@@ -88,15 +88,22 @@ export function validateDecision(raw: unknown, legalMoveCount: number): AIMoveDe
     );
   }
 
-  // --- confidence (coerced + clamped) ---
-  let confidence = toNumber(pick(decisionBlock.confidence, obj.confidence));
-  if (!Number.isFinite(confidence)) {
-    confidence = 0.5;
+  // --- confidence (coerced + clamped, undefined when absent) ---
+  // The hybrid-v1.1 prompt removed `final_decision.confidence` from the schema
+  // it asks the model to emit; the field has no signal in our corpus (mean
+  // ~0.93 regardless of outcome). When the model omits it, leave `confidence`
+  // undefined rather than fabricating a 0.5 — a fabricated default would
+  // render as "50%" in the UI and look like real signal. A model that still
+  // emits a value (older variants, manual tests) is parsed and clamped as
+  // before.
+  let confidence: number | undefined;
+  const rawConfidence = pick(decisionBlock.confidence, obj.confidence);
+  if (rawConfidence !== undefined && rawConfidence !== null) {
+    const n = toNumber(rawConfidence);
+    if (Number.isFinite(n)) {
+      confidence = clamp(n > 1 ? n / 100 : n, 0, 1);
+    }
   }
-  if (confidence > 1) {
-    confidence = confidence / 100; // tolerate a 0-100 scale
-  }
-  confidence = clamp(confidence, 0, 1);
 
   // --- alternativeMoveIndex (optional, dropped if invalid) ---
   let alternativeMoveIndex: number | undefined;

--- a/packages/app/src/ai/types.ts
+++ b/packages/app/src/ai/types.ts
@@ -166,8 +166,14 @@ export interface AIMoveDecision {
   reasoning: string;
   /** Chosen move index into the legal-moves list (from `final_decision`). */
   moveIndex: number;
-  /** The LLM's self-rated confidence, 0–1 (from `final_decision`). */
-  confidence: number;
+  /**
+   * The LLM's self-rated confidence, 0-1. Optional because hybrid-v1.1
+   * removed `final_decision.confidence` from the prompt schema (saturated
+   * near 0.93 in the corpus, no signal); the parser leaves it undefined
+   * when the model omits it rather than fabricating a misleading 0.5.
+   * Older response shapes that still emit a value are accepted and clamped.
+   */
+  confidence?: number;
   /** Optional runner-up move index (from `final_decision`). */
   alternativeMoveIndex?: number;
 }
@@ -290,8 +296,12 @@ export interface AIDecisionRecord {
   boardAnalysis?: string;
   /** The LLM's strategic plan / reasoning. */
   reasoning: string;
-  /** The LLM's confidence, 0–1. */
-  confidence: number;
+  /**
+   * The LLM's confidence, 0-1. Optional in hybrid-v1.1 onwards (the prompt
+   * no longer asks for it). Older saved sessions / replays may still carry
+   * a number; UI sites must gate rendering on presence.
+   */
+  confidence?: number;
   /** Description of the runner-up move, if the LLM supplied one. */
   alternativeDescribe?: string;
   /** Model that produced the decision. */

--- a/packages/app/src/components/AIAdvisorPanel.tsx
+++ b/packages/app/src/components/AIAdvisorPanel.tsx
@@ -160,20 +160,25 @@ const AIAdvisorPanel: React.FC = () => {
           <div data-testid="ai-last-decision" className="bg-gray-50 border border-gray-200 rounded p-3">
             <p className="text-sm font-semibold text-gray-800">{lastDecision.describe}</p>
 
-            <div className="mt-2">
-              <div className="flex justify-between items-center mb-1">
-                <span className="text-xs font-semibold text-gray-600">Confidence</span>
-                <span className="text-xs font-bold text-gray-700">
-                  {Math.round(lastDecision.confidence * 100)}%
-                </span>
+            {/* Confidence block. Only rendered when the decision actually carries
+                a confidence value (hybrid-v1.1 onwards drops it from the prompt;
+                older saved sessions / replays may still have one). */}
+            {lastDecision.confidence !== undefined && (
+              <div className="mt-2">
+                <div className="flex justify-between items-center mb-1">
+                  <span className="text-xs font-semibold text-gray-600">Confidence</span>
+                  <span className="text-xs font-bold text-gray-700">
+                    {Math.round(lastDecision.confidence * 100)}%
+                  </span>
+                </div>
+                <div className="w-full bg-gray-200 rounded-full h-2">
+                  <div
+                    className={`h-2 rounded-full transition-all ${confidenceColor(lastDecision.confidence)}`}
+                    style={{ width: `${Math.round(lastDecision.confidence * 100)}%` }}
+                  />
+                </div>
               </div>
-              <div className="w-full bg-gray-200 rounded-full h-2">
-                <div
-                  className={`h-2 rounded-full transition-all ${confidenceColor(lastDecision.confidence)}`}
-                  style={{ width: `${Math.round(lastDecision.confidence * 100)}%` }}
-                />
-              </div>
-            </div>
+            )}
 
             <p
               data-testid="ai-reasoning"

--- a/packages/app/src/testBridge.ts
+++ b/packages/app/src/testBridge.ts
@@ -80,8 +80,12 @@ export interface AIBridgeState {
   seeHiddenCards: boolean;
   /** Number of decisions recorded so far. */
   decisionCount: number;
-  /** The most recent decision, or `null`. */
-  lastDecision: { describe: string; reasoning: string; confidence: number } | null;
+  /**
+   * The most recent decision, or `null`. `confidence` is optional because
+   * hybrid-v1.1 removed it from the prompt; older saved sessions / stub
+   * providers may still supply one.
+   */
+  lastDecision: { describe: string; reasoning: string; confidence?: number } | null;
 }
 
 /** The `window.__solitaire` control surface. */


### PR DESCRIPTION
## Summary

hybrid-v1.1 dropped \`final_decision.confidence\` from the prompt schema, but \`validateDecision\` still coerced a missing/non-finite value to \`0.5\`. That fabricated default propagated through to the UI as \`Confidence: 50%\` in the advisor panel and \`[50%]\` on every AI move in the activity log and replay — exactly the \"looks like real signal\" failure mode the removal was meant to avoid.

Fix:
- \`validateDecision\`: a missing or non-finite confidence now stays \`undefined\` rather than defaulting to \`0.5\`. A model that still supplies a value (older variants, manual tests) is parsed and clamped to [0, 1] as before.
- \`AIMoveDecision.confidence\` and \`AIDecisionRecord.confidence\` widen to optional. \`AIAdvisorPanel\` gates the entire Confidence block on presence; \`ActivityLog\` and \`ReplayControls\` already gated on \`aiConfidence !== undefined\` so they Just Work. \`testBridge.AIBridgeState.lastDecision.confidence\` widened to optional.

Backward compat: pre-existing saved sessions and replays still carry numeric \`aiConfidence\` on their move-history entries; those render exactly as before.

## Test plan

- [x] \`pnpm --filter app test:run\` — 347/347 unit tests pass
- [x] \`pnpm --filter app lint\` clean
- [x] \`npx tsc -b --noEmit\` clean
- [x] Live Playwright MCP smoke: stub without confidence shows no \"Confidence\" label, no \`50%\`, no \`[50%]\`; legacy stub with \`confidence: 0.82\` still shows \"Confidence 82%\" and \`[82%]\`