### PR TITLE
chore(ai): bump promptLayoutVersion to hybrid-v1.1 in lockstep

### DIFF
--- a/packages/app/src/ai/context/renderContext.test.ts
+++ b/packages/app/src/ai/context/renderContext.test.ts
@@ -263,7 +263,11 @@ describe('renderHybridContext', () => {
     expect(hybridChars).toBeLessThan(prettyJsonChars);
   });
 
-  it('PROMPT_LAYOUT_VERSION is the hybrid-v1 stamp', () => {
-    expect(PROMPT_LAYOUT_VERSION).toBe('hybrid-v1');
+  it('PROMPT_LAYOUT_VERSION follows the lockstep semver and matches the template version', () => {
+    // Tripwire: layout and template versions are now bumped together so the
+    // two fields on a harvested interaction never disagree. See the
+    // promptlayoutversion-lockstep follow-up note.
+    expect(PROMPT_LAYOUT_VERSION).toMatch(/^hybrid-v\d+\.\d+$/);
+    expect(PROMPT_LAYOUT_VERSION).toBe('hybrid-v1.1');
   });
 });

--- a/packages/app/src/ai/context/renderContext.ts
+++ b/packages/app/src/ai/context/renderContext.ts
@@ -22,13 +22,19 @@
 import type { AIMoveContext } from '../types';
 
 /**
- * Stamp identifying the layout that produced a given interaction. The
- * dataset side keys its comparison reports on (`promptTemplateHash`,
- * `inferenceParams`, `promptLayoutVersion`) — bumping this constant lets
- * harvests be partitioned cleanly across format changes without inferring
- * from the build hash. Bump when the renderer's output shape changes.
+ * Stamp identifying the prompt variant that produced a given interaction.
+ *
+ * Bumped in lockstep with `PROMPT_TEMPLATE_VERSION` (in
+ * `context/systemInstruction`) so the two version fields never disagree on
+ * which variant produced a row. The semver follows the same scheme:
+ * - major (`hybrid-v2.0`) on a layout-shape change;
+ * - minor (`hybrid-v1.x`) on any visible text edit within the same layout.
+ *
+ * Anyone reading a harvested ai-log can read this one field instead of
+ * computing `promptTemplateHash` to identify the variant. The hash stays
+ * authoritative for byte-level identity.
  */
-export const PROMPT_LAYOUT_VERSION = 'hybrid-v1';
+export const PROMPT_LAYOUT_VERSION = 'hybrid-v1.1';
 
 /** Pad a column name's value column to keep `[index]` + type aligned. */
 const TYPE_COL_WIDTH = 24;


### PR DESCRIPTION
## Summary

After hybrid-v1.1 shipped, a harvested interaction carried two version stamps that disagreed:
- \`promptTemplateVersion: 'hybrid-v1.1'\` (semver, bumps on every text edit)
- \`promptLayoutVersion: 'hybrid-v1'\` (only bumps on layout-shape changes)

A reader keying on the layout version sees \`'hybrid-v1'\` for v1.0, v1.1, v1.2, ... and has to recompute the hash to identify the variant — partly undermining the semantic-versioning discipline the 2026-05-26 ask just installed.

Fix: bump \`PROMPT_LAYOUT_VERSION\` to \`'hybrid-v1.1'\` and adopt the lockstep rule documented in its docstring — major (\`hybrid-v2.0\`) on layout-shape changes; minor (\`hybrid-v1.x\`) on text edits within the same layout. \`promptTemplateHash\` keeps byte-level authority; readers can use either version field to identify the variant.

No production behaviour change.

## Test plan

- [x] 347/347 vitest pass (test pin refreshed to match the lockstep semver pattern)
- [x] typecheck clean
- [x] lint clean