### PR TITLE
feat(ai): ship DRAW TIMELINE, CYCLE counter, and ONLY-IF heuristic (hybrid-v1.2)

### DIFF
--- a/packages/app/src/ai/context/buildContext.ts
+++ b/packages/app/src/ai/context/buildContext.ts
@@ -86,6 +86,44 @@ function computeSeenDrawPileCards(state: GameState): string[] {
 }
 
 /**
+ * Build the DRAW TIMELINE token sequence for the AI prompt (hybrid-v1.2).
+ *
+ * The output is a single linear sequence rendered left-to-right with the
+ * leftmost token = the furthest-future draw, then the upcoming stock cards
+ * in draw order, then the current waste top wrapped in `{}` (the `{NOW}`
+ * marker), then the cards drawn earlier in this cycle that still sit beneath
+ * the top of the waste, in most-recent-first order.
+ *
+ * Stock identity rule:
+ * - cycle 1 (no recycles yet): every stock position renders as `???` because
+ *   the model has not observed those cards;
+ * - cycle 2+: every stock card was observed in a previous cycle, so identities
+ *   surface (the "perfect-recall human" assumption from the 2026-05-27 ask).
+ *
+ * Returns `undefined` when no draws have happened yet (`discardPile` empty);
+ * the renderer then skips the block entirely.
+ */
+function computeDrawTimeline(state: GameState, cycle: number): string[] | undefined {
+  if (state.discardPile.length === 0) return undefined;
+
+  // Stock side: UI orientation has `drawPile[0]` as the next draw and
+  // `drawPile[last]` as the furthest-future card. The timeline reads
+  // furthest-future first, so we reverse.
+  const stockTokens =
+    cycle === 1
+      ? Array<string>(state.drawPile.length).fill('???')
+      : [...state.drawPile].reverse().map(cardShort);
+
+  // Waste side: `discardPile[last]` is the current top = `{NOW}`. Below the
+  // top, oldest-this-cycle is `discardPile[0]`. Right of `{NOW}` reads
+  // most-recent-first, so we drop the top and reverse what remains.
+  const nowToken = `{${cardShort(state.discardPile[state.discardPile.length - 1])}}`;
+  const wasteBelow = state.discardPile.slice(0, -1).reverse().map(cardShort);
+
+  return [...stockTokens, nowToken, ...wasteBelow];
+}
+
+/**
  * Build the AI context payload for the current game state.
  *
  * @param state - The current UI game state.
@@ -149,6 +187,13 @@ export function buildContext(
       ? cardShort(state.discardPile[state.discardPile.length - 1])
       : null;
 
+  // Cycle is always defined: 1 + number of times the waste has been recycled.
+  // Older saved sessions imported before recycleCount was tracked default to
+  // 0, so a mid-cycle-2 import will read as cycle 1 until the next recycle
+  // fires; acceptable since the AI is not queried during pure replay.
+  const cycle = (state.recycleCount ?? 0) + 1;
+  const drawTimeline = computeDrawTimeline(state, cycle);
+
   const context: AIMoveContext = {
     notation:
       'Cards: rank then suit (A 2-9 T J Q K; H D C S). Tableau columns are ' +
@@ -159,8 +204,12 @@ export function buildContext(
     discardTop,
     drawPileCount: state.drawPile.length,
     canRecycleStock: state.drawPile.length === 0 && state.discardPile.length > 0,
+    cycle,
     legalMoves: aiLegalMoves,
   };
+  if (drawTimeline !== undefined) {
+    context.drawTimeline = drawTimeline;
+  }
 
   // --- Optional: game metrics ---
   if (config.includeGameMetrics) {

--- a/packages/app/src/ai/context/renderContext.test.ts
+++ b/packages/app/src/ai/context/renderContext.test.ts
@@ -28,6 +28,7 @@ function baseContext(overrides: Partial<AIMoveContext> = {}): AIMoveContext {
     discardTop: null,
     drawPileCount: 0,
     canRecycleStock: false,
+    cycle: 1,
     legalMoves: [{ index: 0, type: 'draw_card', describe: 'Draw the next card' }],
     ...overrides,
   };
@@ -42,7 +43,7 @@ describe('renderHybridContext', () => {
     expect(out).not.toMatch(/NOTATION:/);
     expect(out).toMatch(/^FOUNDATIONS:/);
     expect(out).toContain('FOUNDATIONS:   H: --   D: --   C: --   S: --');
-    expect(out).toContain('STOCK: 0 cards   WASTE top: --   recycle stock: no');
+    expect(out).toContain('STOCK: 0 cards   CYCLE: 1   WASTE top: --   recycle stock: no');
     expect(out).toContain('TABLEAU:');
     expect(out).toContain('LEGAL MOVES (respond with the index of your chosen move):');
   });
@@ -117,11 +118,30 @@ describe('renderHybridContext', () => {
     expect(out).toContain('  12. draw card-12');
   });
 
-  it('renders SEEN IN WASTE as a single space-separated line', () => {
+  it('renders DRAW TIMELINE as a single space-separated line when supplied', () => {
+    // hybrid-v1.2 replaces the old SEEN IN WASTE THIS CYCLE block with a
+    // single linear DRAW TIMELINE: stock cards left of {NOW}, current waste
+    // top wrapped in {}, and earlier-this-cycle waste cards to the right.
     const out = renderHybridContext(
-      baseContext({ seenDrawPileCards: ['9H', '5S', 'KS', 'JC'] }),
+      baseContext({
+        drawTimeline: ['???', '???', '8D', 'QH', '3C', '{7H}', '4S', 'KH', '2D'],
+      }),
     );
-    expect(out).toContain('SEEN IN WASTE THIS CYCLE: 9H 5S KS JC');
+    expect(out).toContain('DRAW TIMELINE:\n  ??? ??? 8D QH 3C {7H} 4S KH 2D');
+  });
+
+  it('skips DRAW TIMELINE when no draws have happened (drawTimeline undefined)', () => {
+    const out = renderHybridContext(baseContext());
+    expect(out).not.toContain('DRAW TIMELINE');
+  });
+
+  it('renders CYCLE inline on the STOCK line', () => {
+    expect(renderHybridContext(baseContext())).toContain(
+      'STOCK: 0 cards   CYCLE: 1   WASTE top: --   recycle stock: no',
+    );
+    expect(
+      renderHybridContext(baseContext({ cycle: 3, drawPileCount: 14, discardTop: '2H' })),
+    ).toContain('STOCK: 14 cards   CYCLE: 3   WASTE top: 2H   recycle stock: no');
   });
 
   it('renders the HIDDEN INFO oracle block only when hiddenInfo is supplied', () => {
@@ -199,23 +219,24 @@ describe('renderHybridContext', () => {
     expect(out).toContain('  2. move: Play AC to clubs');
   });
 
-  it('places RECENT MOVES immediately before LEGAL MOVES (modulo optional SEEN/HIDDEN blocks)', () => {
+  it('places RECENT MOVES before DRAW TIMELINE before LEGAL MOVES', () => {
     // The whole point of the layout is the visual adjacency of just-played
-    // moves and on-offer moves. Pin the order so a refactor cannot quietly
-    // split them apart.
+    // moves and on-offer moves. The DRAW TIMELINE (hybrid-v1.2) replaces the
+    // old SEEN IN WASTE block at the same slot.
     const out = renderHybridContext(
       baseContext({
         recentMoves: ['draw 6C', 'move 9D col 3 -> col 7'],
-        seenDrawPileCards: ['9H', '5S'],
+        drawTimeline: ['???', '???', '{6C}', '9D'],
       }),
     );
     const recentIdx = out.indexOf('RECENT MOVES');
-    const seenIdx = out.indexOf('SEEN IN WASTE');
+    const timelineIdx = out.indexOf('DRAW TIMELINE');
     const legalIdx = out.indexOf('LEGAL MOVES');
     expect(recentIdx).toBeGreaterThan(-1);
+    expect(timelineIdx).toBeGreaterThan(-1);
     expect(legalIdx).toBeGreaterThan(-1);
-    expect(recentIdx).toBeLessThan(seenIdx);
-    expect(seenIdx).toBeLessThan(legalIdx);
+    expect(recentIdx).toBeLessThan(timelineIdx);
+    expect(timelineIdx).toBeLessThan(legalIdx);
   });
 
   it('has no trailing blank line', () => {
@@ -268,6 +289,6 @@ describe('renderHybridContext', () => {
     // two fields on a harvested interaction never disagree. See the
     // promptlayoutversion-lockstep follow-up note.
     expect(PROMPT_LAYOUT_VERSION).toMatch(/^hybrid-v\d+\.\d+$/);
-    expect(PROMPT_LAYOUT_VERSION).toBe('hybrid-v1.1');
+    expect(PROMPT_LAYOUT_VERSION).toBe('hybrid-v1.2');
   });
 });

--- a/packages/app/src/ai/context/renderContext.ts
+++ b/packages/app/src/ai/context/renderContext.ts
@@ -34,7 +34,7 @@ import type { AIMoveContext } from '../types';
  * computing `promptTemplateHash` to identify the variant. The hash stays
  * authoritative for byte-level identity.
  */
-export const PROMPT_LAYOUT_VERSION = 'hybrid-v1.1';
+export const PROMPT_LAYOUT_VERSION = 'hybrid-v1.2';
 
 /** Pad a column name's value column to keep `[index]` + type aligned. */
 const TYPE_COL_WIDTH = 24;
@@ -59,8 +59,11 @@ export function renderHybridContext(context: AIMoveContext): string {
       `C: ${f.clubs ?? '--'}   ` +
       `S: ${f.spades ?? '--'}`,
   );
+  // STOCK line carries the CYCLE counter inline (hybrid-v1.2). CYCLE: 1 is
+  // the initial pass; the first recycle moves the game into CYCLE: 2.
   lines.push(
     `STOCK: ${context.drawPileCount} cards   ` +
+      `CYCLE: ${context.cycle}   ` +
       `WASTE top: ${context.discardTop ?? '--'}   ` +
       `recycle stock: ${context.canRecycleStock ? 'yes' : 'no'}`,
   );
@@ -96,10 +99,17 @@ export function renderHybridContext(context: AIMoveContext): string {
     lines.push('');
   }
 
-  // SEEN IN WASTE — kept on one line; needed for stock-cycle decisions.
-  const seen = context.seenDrawPileCards ?? [];
-  if (seen.length > 0) {
-    lines.push(`SEEN IN WASTE THIS CYCLE: ${seen.join(' ')}`);
+  // DRAW TIMELINE (hybrid-v1.2): one linear sequence of stock + waste,
+  // left-to-right, with the current waste top wrapped as `{NOW}`. Stock
+  // cards render as `???` in cycle 1 (model has not observed them) and as
+  // their identities in cycle 2+ (perfect-recall human assumption).
+  // Replaces the previous `SEEN IN WASTE THIS CYCLE` block, which only
+  // appeared post-first-recycle and used a misleading "shrinks as you draw"
+  // label. Block is skipped entirely when no draws have happened (turn 0).
+  const timeline = context.drawTimeline;
+  if (timeline && timeline.length > 0) {
+    lines.push('DRAW TIMELINE:');
+    lines.push(`  ${timeline.join(' ')}`);
     lines.push('');
   }
 

--- a/packages/app/src/ai/context/rulesPrimer.ts
+++ b/packages/app/src/ai/context/rulesPrimer.ts
@@ -25,6 +25,18 @@ KLONDIKE SOLITAIRE RULES (this variant):
 - The game is WON when all 52 cards reach the foundations.
 NOTATION: rank+suit (A 2-9 T J Q K; H D C S). ?? = face-down. In each column the top of the stack is the rightmost card.
 
+INTERPRETING THE DRAW TIMELINE (when present in the game state):
+The DRAW TIMELINE block renders the stock and waste piles as one linear sequence
+of card identifiers. The current waste top is wrapped in {curly braces}. Tokens
+LEFT of {NOW} are cards that will be drawn next in this stock cycle: the
+immediate next draw is the token directly left of {NOW}, the draw after that is
+the token two positions left, and so on. Tokens RIGHT of {NOW} are cards drawn
+earlier in this cycle, still sitting in the waste pile beneath the current top.
+The token ??? marks a card whose identity has not yet been observed. ??? can
+only appear during the first stock cycle. After the first recycle every position
+is a known identity, because every stock card has passed through the waste at
+least once.
+
 THE GOAL: choose the single move that gives the best chance of eventually winning.`;
 
 /** Klondike strategy heuristics. Included when `includeStrategyGuidance` is on. */
@@ -34,13 +46,17 @@ export const STRATEGY_GUIDANCE = `STRATEGY GUIDANCE (heuristics, not absolute ru
 - Be cautious sending higher cards to the foundations too early — they are sometimes needed to receive tableau cards.
 - Do not empty a column unless you have a King ready to occupy it.
 - Prefer exposing new cards and creating useful sequences over shuffling cards between columns with no gain.
-- Drawing from the stock is reasonable when no productive tableau/foundation move exists.
+- Drawing from the stock is reasonable ONLY IF the DRAW TIMELINE shows an
+  upcoming card (a token left of {NOW}) that will be playable to a foundation
+  or to a tableau column once drawn. If every remaining stock card has already
+  been seen and none unlock the board, drawing wastes turns and you should
+  commit to a tableau move instead, even an imperfect one.
 - Avoid moves that simply undo a recent move or lead nowhere.`;
 
 /** Instructions describing the required JSON output. Always included. */
 export const OUTPUT_INSTRUCTION = `RESPONSE FORMAT:
-You will receive the current game as plain-text blocks (NOTATION, FOUNDATIONS, STOCK,
-TABLEAU, RECENT MOVES, SEEN IN WASTE, LEGAL MOVES, PROGRESS — some are optional). The
+You will receive the current game as plain-text blocks (FOUNDATIONS, STOCK, TABLEAU,
+RECENT MOVES, DRAW TIMELINE, LEGAL MOVES, PROGRESS — some are optional). The
 LEGAL MOVES block is a numbered list; each line begins with [index], the canonical
 move identifier you must return.
 Reason step by step, then respond with ONLY a single JSON object containing exactly

--- a/packages/app/src/ai/context/systemInstruction.test.ts
+++ b/packages/app/src/ai/context/systemInstruction.test.ts
@@ -67,12 +67,12 @@ describe('hashSystemInstruction', () => {
 describe('prompt template identity (tripwire)', () => {
   it('hash with strategy guidance is pinned', async () => {
     const hash = await hashSystemInstruction(buildSystemInstruction(configWith(true)));
-    expect(hash).toBe('8971cad00d0b6cf1ccf18baf9053742a156a02583b30d19984b524b902ff51eb');
+    expect(hash).toBe('dde52402372de11f46bba3dacc9e728e26be8f4177ac73f15df66ca98d406d57');
   });
 
   it('hash without strategy guidance is pinned', async () => {
     const hash = await hashSystemInstruction(buildSystemInstruction(configWith(false)));
-    expect(hash).toBe('35efc0b832a453bbbb5421bcbb4eb0d677245b423fa2365f1cf70194ae935b9e');
+    expect(hash).toBe('9ac8a0443d2735a37527433844258889c895dd918a54881c8399be577bd45ff1');
   });
 
   it('PROMPT_TEMPLATE_FINALISED_AT is a valid ISO 8601 UTC instant', () => {
@@ -86,6 +86,6 @@ describe('prompt template identity (tripwire)', () => {
     // restructure (`hybrid-v2.0`). The exact value is what the dataset side
     // partitions on, so it is a tripwire — bump deliberately.
     expect(PROMPT_TEMPLATE_VERSION).toMatch(/^hybrid-v\d+\.\d+$/);
-    expect(PROMPT_TEMPLATE_VERSION).toBe('hybrid-v1.1');
+    expect(PROMPT_TEMPLATE_VERSION).toBe('hybrid-v1.2');
   });
 });

--- a/packages/app/src/ai/context/systemInstruction.ts
+++ b/packages/app/src/ai/context/systemInstruction.ts
@@ -27,7 +27,7 @@ import { OUTPUT_INSTRUCTION, RULES_PRIMER, STRATEGY_GUIDANCE } from './rulesPrim
  * because the templates evolve independently of any release cadence and the
  * downstream analytics already key off ISO timestamps.
  */
-export const PROMPT_TEMPLATE_FINALISED_AT = '2026-05-26T00:00:00Z';
+export const PROMPT_TEMPLATE_FINALISED_AT = '2026-05-27T00:00:00Z';
 
 /**
  * Human-readable semantic version of the prompt template (rules + output
@@ -43,7 +43,7 @@ export const PROMPT_TEMPLATE_FINALISED_AT = '2026-05-26T00:00:00Z';
  * Adopted per the 2026-05-26 harvester-team ask in
  * `solitaire-analytics/docs/reports/20260526_harvester_team_resign_hygiene_versioning_ask.md`.
  */
-export const PROMPT_TEMPLATE_VERSION = 'hybrid-v1.1';
+export const PROMPT_TEMPLATE_VERSION = 'hybrid-v1.2';
 
 /** Build the full system instruction for a move-suggestion request. */
 export function buildSystemInstruction(config: AIConfig): string {

--- a/packages/app/src/ai/providers/GeminiProvider.test.ts
+++ b/packages/app/src/ai/providers/GeminiProvider.test.ts
@@ -18,6 +18,7 @@ const context: AIMoveContext = {
   discardTop: null,
   drawPileCount: 0,
   canRecycleStock: false,
+  cycle: 1,
   legalMoves: [
     { index: 0, type: 'draw_card', describe: 'Draw' },
     { index: 1, type: 'discard_to_foundation', describe: 'To foundation' },

--- a/packages/app/src/ai/retry.test.ts
+++ b/packages/app/src/ai/retry.test.ts
@@ -21,6 +21,7 @@ const CONTEXT: AIMoveContext = {
   discardTop: null,
   drawPileCount: 0,
   canRecycleStock: false,
+  cycle: 1,
   legalMoves: [{ index: 0, type: 'draw_card', describe: 'Draw' }],
 };
 

--- a/packages/app/src/ai/types.ts
+++ b/packages/app/src/ai/types.ts
@@ -112,6 +112,24 @@ export interface AIMoveContext {
   drawPileCount: number;
   /** Whether the waste pile can be recycled back into an empty stock. */
   canRecycleStock: boolean;
+  /**
+   * 1-based stock cycle number: cycle 1 is the initial pass, cycle 2 starts
+   * the moment the first recycle fires, and so on. Drives DRAW TIMELINE
+   * stock-identity rendering (cycle 1 hides identities as `???`; cycle 2+
+   * shows them, on the perfect-recall human assumption). hybrid-v1.2 onwards.
+   */
+  cycle: number;
+  /**
+   * Tokenised DRAW TIMELINE: one linear sequence of stock + waste positions,
+   * left to right ordered so the leftmost token is the furthest-future draw
+   * and the rightmost token is the oldest waste card from this cycle. The
+   * current waste top sits in the middle wrapped in `{}` (e.g. `{7H}`).
+   * Stock positions that the model hasn't observed yet render as `???`
+   * (only possible in cycle 1). Undefined when no draws have happened yet
+   * (turn 0), in which case the timeline block is skipped.
+   * hybrid-v1.2 onwards.
+   */
+  drawTimeline?: string[];
   /** Every legal move — the LLM must pick one by its `index`. */
   legalMoves: AILegalMove[];
 

--- a/packages/app/src/store/gameStore.ts
+++ b/packages/app/src/store/gameStore.ts
@@ -261,6 +261,7 @@ const initializeGameState = (
     initialBoardSetup,
     perceivedDifficulty: undefined, // Will be calculated below
     completionProgress: 0, // Start at 0% completion
+    recycleCount: 0,
     replayMode: false,
     replayIndex: 0,
     replayPaused: false,
@@ -330,6 +331,7 @@ function hydratePersisted(p: PersistedGameState): GameState {
     initialBoardSetup: p.initialBoardSetup,
     perceivedDifficulty: p.perceivedDifficulty,
     completionProgress: p.completionProgress,
+    recycleCount: p.recycleCount ?? 0,
     replayMode: false,
     replayIndex: 0,
     replayPaused: false,
@@ -700,12 +702,18 @@ export const useGameStore = create<GameStore>((set, get) => ({
     const state = get();
     
     if (state.drawPile.length === 0) {
-      // Reset draw pile from discard pile
+      // Reset draw pile from discard pile. Bump recycleCount; the AI prompt
+      // renders `CYCLE: N` as `1 + recycleCount` so cycle 1 is the initial
+      // pass and the first recycle moves the game into cycle 2.
       const newDrawPile = [...state.discardPile].reverse().map(card => ({
         ...card,
         faceUp: false,
       }));
-      set({ drawPile: newDrawPile, discardPile: [] });
+      set({
+        drawPile: newDrawPile,
+        discardPile: [],
+        recycleCount: (state.recycleCount ?? 0) + 1,
+      });
     } else {
       // Draw a card from draw pile to discard pile
       const card = state.drawPile[0];
@@ -755,6 +763,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
       initialBoardSetup: state.initialBoardSetup,
       perceivedDifficulty: state.perceivedDifficulty,
       completionProgress: state.completionProgress,
+      recycleCount: state.recycleCount,
       replayMode: state.replayMode,
       replayIndex: state.replayIndex,
       replayPaused: state.replayPaused,
@@ -825,6 +834,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
         initialBoardSetup: importedState.initialBoardSetup,
         perceivedDifficulty,
         completionProgress,
+        recycleCount: importedState.recycleCount ?? 0,
         replayMode: false,
         replayIndex: 0,
         replayPaused: false,
@@ -1168,12 +1178,13 @@ export const useGameStore = create<GameStore>((set, get) => ({
       tableau: JSON.parse(JSON.stringify(state.initialBoardSetup.tableau)),
       selectedCard: undefined,
       replayIndex: targetIndex,
+      recycleCount: 0,
     };
-    
+
     // Apply moves up to targetIndex
     for (let i = 0; i < targetIndex; i++) {
       const move = state.moveHistory[i];
-      
+
       switch (move.type) {
         case 'draw_card': {
           // Draw a card
@@ -1183,12 +1194,14 @@ export const useGameStore = create<GameStore>((set, get) => ({
             newState.drawPile = newState.drawPile.slice(1);
             newState.discardPile = [...(newState.discardPile || []), drawnCard];
           } else if (newState.discardPile && newState.discardPile.length > 0) {
-            // Reset draw pile from discard pile
+            // Reset draw pile from discard pile; track cycle the same way
+            // live play does.
             newState.drawPile = [...newState.discardPile].reverse().map(card => ({
               ...card,
               faceUp: false,
             }));
             newState.discardPile = [];
+            newState.recycleCount = (newState.recycleCount ?? 0) + 1;
           }
           break;
         }

--- a/packages/app/src/store/sessionPersistence.ts
+++ b/packages/app/src/store/sessionPersistence.ts
@@ -46,6 +46,7 @@ export interface PersistedGameState {
   initialBoardSetup: GameState['initialBoardSetup'];
   perceivedDifficulty: GameState['perceivedDifficulty'];
   completionProgress: GameState['completionProgress'];
+  recycleCount: GameState['recycleCount'];
   replaySpeed: GameState['replaySpeed'];
   aiConfig: GameState['aiConfig'];
   aiDecisionLog: GameState['aiDecisionLog'];
@@ -102,6 +103,7 @@ function pickPersisted(state: GameState): PersistedGameState {
     initialBoardSetup: state.initialBoardSetup,
     perceivedDifficulty: state.perceivedDifficulty,
     completionProgress: state.completionProgress,
+    recycleCount: state.recycleCount,
     replaySpeed: state.replaySpeed,
     aiConfig: state.aiConfig,
     aiDecisionLog: state.aiDecisionLog,

--- a/packages/app/src/types/index.ts
+++ b/packages/app/src/types/index.ts
@@ -92,6 +92,14 @@ export interface GameState {
   replayIndex: number; // Current index in move history during replay
   replayPaused: boolean; // True when replay is paused
   replaySpeed: number; // Speed of replay in ms per move (default 1000)
+  /**
+   * Number of times the waste pile has been recycled back into the stock in
+   * this game. Cycle 1 starts at game open with this at 0; the moment the
+   * first recycle fires the value becomes 1, which renders as `CYCLE: 2`
+   * in the AI prompt. Drives the DRAW TIMELINE block's known-vs-unknown
+   * stock identity rule (hybrid-v1.2 onwards).
+   */
+  recycleCount?: number;
 
   // --- AI Move Advisor ---
   // Optional, like the other supplemental UI fields above: the store always


### PR DESCRIPTION
## Summary

Closes the post-recycle \"discovery\" loophole the 2026-05-27 harvester ask measured at 97.9% across the existing corpus: with no legible stock contents in the prompt, the teacher was justifying post-recycle draws with hallucinated \"reveal/discover\" language. v1.2 makes the stock+waste position legible without breaking the response schema.

Three changes (one template-bump, hybrid-v1.1 → v1.2):

1. **DRAW TIMELINE block** replaces SEEN IN WASTE THIS CYCLE. Single linear render of stock + waste in draw order: leftmost = furthest-future draw; tokens left of \`{NOW}\` are upcoming draws (immediate next sits directly left of \`{NOW}\`); current waste top wrapped in \`{}\`; tokens right of \`{NOW}\` are cards drawn earlier this cycle. Cycle 1 stock positions render as \`???\` (model has not observed them); cycle 2+ surfaces identities (perfect-recall human assumption explicitly noted in the ask). Piece A (interpretation paragraph) ships in \`RULES_PRIMER\`; Piece B (data block) ships in the per-turn renderer.

2. **STOCK line CYCLE counter** added inline using the existing colon-key pattern: \`STOCK: 14 cards   CYCLE: 2   WASTE top: 2H   recycle stock: no\`. K = 1 + recycleCount.

3. **Strategy heuristic** rewritten with a hard \`ONLY IF\` predicate, replacing the old \"no productive move → draw\" line that the failed sessions were correctly following.

State + plumbing:
- New \`recycleCount?: number\` on the UI \`GameState\`. Initialised to 0, bumped in \`drawCard\`'s recycle branch + replay reconstruction, preserved via session persistence and import/export.
- New \`cycle: number\` and \`drawTimeline?: string[]\` on \`AIMoveContext\`. Renderer skips the timeline block when no draws have happened (turn 0).
- Lockstep semver: \`PROMPT_TEMPLATE_VERSION = 'hybrid-v1.2'\`, \`PROMPT_LAYOUT_VERSION = 'hybrid-v1.2'\`, \`PROMPT_TEMPLATE_FINALISED_AT = '2026-05-27T00:00:00Z'\`. Tripwire hashes refreshed.

Held items from the ask (explicitly not this cycle): PRIOR REASONING truncation (edit 4 from v1.1), state-repetition annotation, resign-trigger tightening.

Ask: \`solitaire-analytics/docs/reports/20260527_harvester_team_v1_2_draw_timeline_ask.md\`.

## Test plan

- [x] \`pnpm --filter app test:run\` — 349/349 unit tests pass (new DRAW TIMELINE shape + CYCLE-field tests, turn-0 skip test, layout-order test, refreshed tripwires)
- [x] \`pnpm --filter app lint\` clean
- [x] \`npx tsc -b --noEmit\` clean
- [x] Live MCP smoke on seed \`3263196305\` against the dev server, running the three harvester verification checks from the ask:
  - Check 1 (no info leak in cycle 1): all 19 stock positions render as \`???\`; waste-below in most-recent-first order; \`CYCLE: 1\` rendered.
  - Check 2 (cycle bump on recycle): \`recycleCount: 1 → cycle: 2\` immediately after the first recycle fires.
  - Check 3 (reading-direction sanity): token directly left of \`{7S}\` was \`6C\` and that was the next-draw waste top; two positions left was \`7H\`, matching the draw after that.
- [ ] Full Playwright e2e in CI