### PR TITLE
fix(ai): drop the ONLY-IF drawing heuristic from STRATEGY_GUIDANCE (v1.2 in-place)

### DIFF
--- a/packages/app/src/ai/context/rulesPrimer.ts
+++ b/packages/app/src/ai/context/rulesPrimer.ts
@@ -46,11 +46,6 @@ export const STRATEGY_GUIDANCE = `STRATEGY GUIDANCE (heuristics, not absolute ru
 - Be cautious sending higher cards to the foundations too early — they are sometimes needed to receive tableau cards.
 - Do not empty a column unless you have a King ready to occupy it.
 - Prefer exposing new cards and creating useful sequences over shuffling cards between columns with no gain.
-- Drawing from the stock is reasonable ONLY IF the DRAW TIMELINE shows an
-  upcoming card (a token left of {NOW}) that will be playable to a foundation
-  or to a tableau column once drawn. If every remaining stock card has already
-  been seen and none unlock the board, drawing wastes turns and you should
-  commit to a tableau move instead, even an imperfect one.
 - Avoid moves that simply undo a recent move or lead nowhere.`;
 
 /** Instructions describing the required JSON output. Always included. */

--- a/packages/app/src/ai/context/systemInstruction.test.ts
+++ b/packages/app/src/ai/context/systemInstruction.test.ts
@@ -67,7 +67,7 @@ describe('hashSystemInstruction', () => {
 describe('prompt template identity (tripwire)', () => {
   it('hash with strategy guidance is pinned', async () => {
     const hash = await hashSystemInstruction(buildSystemInstruction(configWith(true)));
-    expect(hash).toBe('dde52402372de11f46bba3dacc9e728e26be8f4177ac73f15df66ca98d406d57');
+    expect(hash).toBe('645f77b252b95a1b0bdc1c12abf194ee42cef6cd0425fdbab8a5f425f5053c98');
   });
 
   it('hash without strategy guidance is pinned', async () => {


### PR DESCRIPTION
## Summary

The \"Drawing from the stock is reasonable ONLY IF the DRAW TIMELINE shows...\" bullet shipped with v1.2 stacked three injection violations in ~60 words:

1. **Procedural injection**: instructing the model to consult a specific data block before deciding.
2. **Decision-rule injection**: replacing the soft \"reasonable when...\" hedge with a hard \"ONLY IF X then Y\" predicate.
3. **Action prescription injection**: \"you should commit to a tableau move instead, even an imperfect one\" — telling the model what to do when the predicate fails. That is the model's policy being written by the prompt rather than learned.

The principle: give the model data, not procedure / decision rules / action prescriptions. The data side of v1.2 is fine (DRAW TIMELINE is stock + waste positions in draw order; CYCLE is a counter; the interpretation paragraph in \`RULES_PRIMER\` describes token semantics, not reasoning). **The correct fix is to delete the bullet, not refine it.**

The pre-v1.2 line (\"Drawing from the stock is reasonable when no productive tableau/foundation move exists\") was itself a pre-existing injection violation inherited from earlier prompt design. We don't have to perpetuate it. The remaining \`STRATEGY_GUIDANCE\` bullets are acknowledged inherited violations, out of scope for this correction.

**In-place correction:** v1.2 has not yet been adopted by the dataset side, so versions stay at \`hybrid-v1.2\` and \`PROMPT_TEMPLATE_FINALISED_AT\` stays at \`2026-05-27\`. Only the with-strategy-guidance tripwire hash needed refreshing; the without-strategy-guidance hash is unchanged because the edit lives entirely inside \`STRATEGY_GUIDANCE\`.

## Test plan

- [x] \`pnpm --filter app test:run\` — 349/349 pass
- [x] \`npx tsc -b --noEmit\` clean
- [x] \`pnpm --filter app lint\` clean