### PR TITLE
feat(ai): ship hybrid-v1.3 prompt (P0/P1 fix bundle for v1.2 regression)

### DIFF
--- a/packages/app/src/ai/context/renderContext.test.ts
+++ b/packages/app/src/ai/context/renderContext.test.ts
@@ -204,7 +204,12 @@ describe('renderHybridContext', () => {
     expect(out).toContain('PROGRESS: foundation=6/52, face-down remaining=12, completion=12%');
   });
 
-  it('carries PRIOR REASONING forward with the soft-de-emphasis header', () => {
+  it('does NOT render PRIOR REASONING even when reasoningTrail is supplied (hybrid-v1.3)', () => {
+    // hybrid-v1.3 drops the block per the v1.3 candidate spec: feeding the
+    // model its own prior rationales reinforces any doom-loop in progress
+    // (Halawi et al. 2023). The field on AIMoveContext is still accepted —
+    // analytics and any future re-enablement experiment can populate it —
+    // but the renderer ignores it.
     const out = renderHybridContext(
       baseContext({
         reasoningTrail: [
@@ -213,10 +218,9 @@ describe('renderHybridContext', () => {
         ],
       }),
     );
-    expect(out).toContain('PRIOR REASONING (may be obsolete; verify against current state):');
-    expect(out).toContain('  1. move: Draw the next card');
-    expect(out).toContain('     why: No productive tableau move.');
-    expect(out).toContain('  2. move: Play AC to clubs');
+    expect(out).not.toContain('PRIOR REASONING');
+    expect(out).not.toContain('No productive tableau move.');
+    expect(out).not.toContain('Aces always go up early.');
   });
 
   it('places RECENT MOVES before DRAW TIMELINE before LEGAL MOVES', () => {
@@ -289,6 +293,6 @@ describe('renderHybridContext', () => {
     // two fields on a harvested interaction never disagree. See the
     // promptlayoutversion-lockstep follow-up note.
     expect(PROMPT_LAYOUT_VERSION).toMatch(/^hybrid-v\d+\.\d+$/);
-    expect(PROMPT_LAYOUT_VERSION).toBe('hybrid-v1.2');
+    expect(PROMPT_LAYOUT_VERSION).toBe('hybrid-v1.3');
   });
 });

--- a/packages/app/src/ai/context/renderContext.ts
+++ b/packages/app/src/ai/context/renderContext.ts
@@ -12,9 +12,12 @@
  * sample produced offline matches the wire format byte-for-byte (modulo
  * trailing-whitespace conventions).
  *
- * `reasoningTrail` is carried forward under a soft-de-emphasis header, as the
- * layout-ask doc recommends — the change is about the board / moves layout,
- * not the trail. The decision to keep, relocate, or drop it is a separate ask.
+ * `reasoningTrail` is intentionally NOT rendered in hybrid-v1.3: feeding the
+ * model its own last-N rationales reinforces in-context any doom-loop already
+ * underway (Halawi et al. 2023, "Overthinking the Truth"; the v1.2 corpus is
+ * the catalogued real-world example). The field on {@link AIMoveContext} is
+ * left intact for analytics and any future re-enablement experiment; the
+ * per-turn prompt simply ignores it.
  *
  * @module ai/context/renderContext
  */
@@ -34,7 +37,7 @@ import type { AIMoveContext } from '../types';
  * computing `promptTemplateHash` to identify the variant. The hash stays
  * authoritative for byte-level identity.
  */
-export const PROMPT_LAYOUT_VERSION = 'hybrid-v1.2';
+export const PROMPT_LAYOUT_VERSION = 'hybrid-v1.3';
 
 /** Pad a column name's value column to keep `[index]` + type aligned. */
 const TYPE_COL_WIDTH = 24;
@@ -145,17 +148,9 @@ export function renderHybridContext(context: AIMoveContext): string {
     lines.push('');
   }
 
-  // PRIOR REASONING — carried forward with the layout-ask doc's
-  // soft-de-emphasis label. Not dropped: that decision is a separate ask.
-  const trail = context.reasoningTrail ?? [];
-  if (trail.length > 0) {
-    lines.push('PRIOR REASONING (may be obsolete; verify against current state):');
-    trail.forEach((t, i) => {
-      lines.push(`  ${i + 1}. move: ${t.move}`);
-      lines.push(`     why: ${t.reasoning}`);
-    });
-    lines.push('');
-  }
+  // PRIOR REASONING — intentionally dropped in hybrid-v1.3 (see module
+  // docstring). `context.reasoningTrail` is still populated by buildContext
+  // when the user toggles it on, but is not surfaced to the model.
 
   // Trim trailing blank line for cleanliness.
   while (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();

--- a/packages/app/src/ai/context/rulesPrimer.ts
+++ b/packages/app/src/ai/context/rulesPrimer.ts
@@ -41,12 +41,13 @@ THE GOAL: choose the single move that gives the best chance of eventually winnin
 
 /** Klondike strategy heuristics. Included when `includeStrategyGuidance` is on. */
 export const STRATEGY_GUIDANCE = `STRATEGY GUIDANCE (heuristics, not absolute rules):
-- Prioritize moves that turn over (reveal) a face-down tableau card — hidden cards are the main obstacle.
+- If any legal move exposes a face-down tableau card, prefer such a move. When multiple legal moves expose a face-down card, prefer the one that exposes a card in the column with the most face-down cards remaining.
 - Play Aces and 2s to the foundations promptly; they are rarely useful in the tableau.
 - Be cautious sending higher cards to the foundations too early — they are sometimes needed to receive tableau cards.
 - Do not empty a column unless you have a King ready to occupy it.
 - Prefer exposing new cards and creating useful sequences over shuffling cards between columns with no gain.
-- Avoid moves that simply undo a recent move or lead nowhere.`;
+- Drawing from the stock is the correct action when no legal tableau or foundation move exposes a face-down card or advances a foundation.
+- Do not move a card to a tableau column it occupied in the last 5 moves shown in RECENT MOVES.`;
 
 /** Instructions describing the required JSON output. Always included. */
 export const OUTPUT_INSTRUCTION = `RESPONSE FORMAT:

--- a/packages/app/src/ai/context/systemInstruction.test.ts
+++ b/packages/app/src/ai/context/systemInstruction.test.ts
@@ -67,7 +67,7 @@ describe('hashSystemInstruction', () => {
 describe('prompt template identity (tripwire)', () => {
   it('hash with strategy guidance is pinned', async () => {
     const hash = await hashSystemInstruction(buildSystemInstruction(configWith(true)));
-    expect(hash).toBe('645f77b252b95a1b0bdc1c12abf194ee42cef6cd0425fdbab8a5f425f5053c98');
+    expect(hash).toBe('7d9ecda4cb415ec2335b3e970421d297730773f541b523666332dd024e9772bb');
   });
 
   it('hash without strategy guidance is pinned', async () => {
@@ -86,6 +86,6 @@ describe('prompt template identity (tripwire)', () => {
     // restructure (`hybrid-v2.0`). The exact value is what the dataset side
     // partitions on, so it is a tripwire — bump deliberately.
     expect(PROMPT_TEMPLATE_VERSION).toMatch(/^hybrid-v\d+\.\d+$/);
-    expect(PROMPT_TEMPLATE_VERSION).toBe('hybrid-v1.2');
+    expect(PROMPT_TEMPLATE_VERSION).toBe('hybrid-v1.3');
   });
 });

--- a/packages/app/src/ai/context/systemInstruction.ts
+++ b/packages/app/src/ai/context/systemInstruction.ts
@@ -27,7 +27,7 @@ import { OUTPUT_INSTRUCTION, RULES_PRIMER, STRATEGY_GUIDANCE } from './rulesPrim
  * because the templates evolve independently of any release cadence and the
  * downstream analytics already key off ISO timestamps.
  */
-export const PROMPT_TEMPLATE_FINALISED_AT = '2026-05-27T00:00:00Z';
+export const PROMPT_TEMPLATE_FINALISED_AT = '2026-05-28T00:00:00Z';
 
 /**
  * Human-readable semantic version of the prompt template (rules + output
@@ -43,7 +43,7 @@ export const PROMPT_TEMPLATE_FINALISED_AT = '2026-05-27T00:00:00Z';
  * Adopted per the 2026-05-26 harvester-team ask in
  * `solitaire-analytics/docs/reports/20260526_harvester_team_resign_hygiene_versioning_ask.md`.
  */
-export const PROMPT_TEMPLATE_VERSION = 'hybrid-v1.2';
+export const PROMPT_TEMPLATE_VERSION = 'hybrid-v1.3';
 
 /** Build the full system instruction for a move-suggestion request. */
 export function buildSystemInstruction(config: AIConfig): string {


### PR DESCRIPTION
## Summary
- Applies the four prompt-level changes from `solitaire-analytics/docs/reports/20260528_prompt_v1_3_candidate_spec.md` (D arm = full v1.3) to address the monotonic same-seed regression hybrid-v1.0 -> v1.1 -> v1.2 (seed 2967897202: 100% -> 29% -> 17% finalProgress) and the 94-turn flat plateau on the second known-winnable seed under v1.2.

## Changes
**`rulesPrimer.ts` (STRATEGY_GUIDANCE)**
- **2.4** Bullet #1 rewritten from a superlative ("hidden cards are the main obstacle") to a conditional predicate with a deepest-column tie-break. The superlative was being parroted into reveal-narrative fabrications when no real reveal was on offer.
- **2.1** Restored the drawing-permission bullet (deleted in v1.2 `cef6291`) with stronger "is the correct action" phrasing. Without an explicit escape valve the model fabricates reveal-justifications for shuffles; the v1.2 corpus shows the `8D/9S col1<->col3` oscillation 165 times in one session.
- **2.2** Replaced soft "Avoid moves that simply undo a recent move or lead nowhere" with the falsifiable predicate "Do not move a card to a tableau column it occupied in the last 5 moves shown in RECENT MOVES". The 5-move window fits inside the existing 10-move RECENT MOVES block so the predicate is verifiable against state the prompt already renders. The soft form was violated 165 times in `6b491a` — empirical proof it is non-binding.

**`renderContext.ts`**
- **2.3** PRIOR REASONING block dropped from the per-turn prompt. Feeding the model its own last-N rationales reinforces in-context any doom-loop already underway (Halawi et al. 2023, "Overthinking the Truth"; the v1.2 corpus is the catalogued real-world example). The `reasoningTrail` field on `AIMoveContext` is left intact for analytics and any future re-enablement experiment; the renderer simply ignores it.

**Version stamps bumped in lockstep**
- `PROMPT_TEMPLATE_VERSION` -> `hybrid-v1.3`
- `PROMPT_LAYOUT_VERSION`   -> `hybrid-v1.3`
- `PROMPT_TEMPLATE_FINALISED_AT` -> `2026-05-28T00:00:00Z`

**Tripwire tests**
- Pinned hash for the with-strategy variant recomputed (`7d9ecda…`).
- PRIOR REASONING test inverted to assert non-rendering.
- Version pins bumped on both sides.
- The without-strategy hash is **unchanged**, confirming only `STRATEGY_GUIDANCE` moved (RULES_PRIMER + OUTPUT_INSTRUCTION are byte-identical).

## Deferred (per spec section 3, to preserve single-variable attribution when the four-arm bench runs)
Schema collapse; DRAW TIMELINE direction flip; role priming; research-derived heuristic additions; foundation-evacuation predicate; echo-back of chosen move; resign-trigger rewrite. The `cef6291` auto-terminator regression (spec 2.5) is a separate harvester-team ask, not a prompt edit.

## Test plan
- [x] `npx vitest run src/ai` (161 tests pass)
- [x] `npx tsc --noEmit -p tsconfig.app.json` clean
- [ ] CI green on this PR
- [ ] Post-merge: harvester runs the four-arm bench in spec section 4 against seeds 2967897202 + 3263196305 + 8 fresh; results land in `solitaire-analytics/docs/reports/20260530_v1_3_bench_result.md`.