### PR TITLE
ui: expand AI Settings by default, move legacy toggles below the AI section

### DIFF
--- a/packages/app/e2e/ai-advisor.spec.ts
+++ b/packages/app/e2e/ai-advisor.spec.ts
@@ -85,7 +85,7 @@ test.describe('AI Move Advisor', () => {
     await page.goto('/?seed=1');
     await waitForGame(page);
 
-    await page.getByTestId('ai-settings-toggle-btn').click();
+    // AI Settings section is expanded by default; no toggle click needed.
     await page.getByTestId('ai-key-settings-btn').click();
 
     await expect(page.getByTestId('ai-key-modal')).toBeVisible();
@@ -99,7 +99,7 @@ test.describe('AI Move Advisor', () => {
     await page.goto('/?seed=1');
     await waitForGame(page);
 
-    await page.getByTestId('ai-settings-toggle-btn').click();
+    // AI Settings section is expanded by default; no toggle click needed.
     await page.getByTestId('ai-preset-select').selectOption('minimal');
 
     const ai = await page.evaluate(() => window.__solitaire!.getAIState());

--- a/packages/app/src/components/AISettingsSection.tsx
+++ b/packages/app/src/components/AISettingsSection.tsx
@@ -32,7 +32,7 @@ const AISettingsSection: React.FC = () => {
   const setAIKeyModalOpen = useGameStore((s) => s.setAIKeyModalOpen);
   const exportAIInteractions = useGameStore((s) => s.exportAIInteractions);
   const gameSessionId = useGameStore((s) => s.gameSessionId);
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(true);
 
   /** Download the full LLM interaction log as a JSON file. */
   const handleExportAILog = () => {

--- a/packages/app/src/components/ControlPanel.tsx
+++ b/packages/app/src/components/ControlPanel.tsx
@@ -238,47 +238,6 @@ const ControlPanel: React.FC = () => {
         )}
 
         <div className="border-t border-gray-300 my-2"></div>
-        
-        <button
-          data-testid="valid-moves-btn"
-          onClick={toggleValidMoves}
-          disabled={replayMode}
-          className={`w-full font-semibold py-2 px-4 rounded transition-colors text-sm ${
-            showValidMoves
-              ? 'bg-green-600 hover:bg-green-700 text-white'
-              : 'bg-gray-300 hover:bg-gray-400 text-gray-700'
-          } ${replayMode ? 'opacity-50 cursor-not-allowed' : ''}`}
-        >
-          {showValidMoves ? '✓' : '✗'} Valid Moves
-        </button>
-        
-        <button
-          data-testid="god-mode-btn"
-          onClick={toggleGodMode}
-          disabled={replayMode}
-          className={`w-full font-semibold py-2 px-4 rounded transition-colors text-sm ${
-            godMode
-              ? 'bg-purple-600 hover:bg-purple-700 text-white'
-              : 'bg-gray-300 hover:bg-gray-400 text-gray-700'
-          } ${replayMode ? 'opacity-50 cursor-not-allowed' : ''}`}
-        >
-          {godMode ? '👁️' : '👁️‍🗨️'} God Mode
-        </button>
-        
-        <button
-          data-testid="auto-play-btn"
-          onClick={toggleAutoPlay}
-          disabled={replayMode || aiAutoPlay}
-          className={`w-full font-semibold py-2 px-4 rounded transition-colors text-sm ${
-            autoPlayEnabled
-              ? 'bg-amber-600 hover:bg-amber-700 text-white'
-              : 'bg-gray-300 hover:bg-gray-400 text-gray-700'
-          } ${replayMode || aiAutoPlay ? 'opacity-50 cursor-not-allowed' : ''}`}
-        >
-          {autoPlayEnabled ? '⏸️' : '▶️'} Auto Play
-        </button>
-
-        <div className="border-t border-gray-300 my-2"></div>
 
         <button
           data-testid="ask-ai-btn"
@@ -315,6 +274,47 @@ const ControlPanel: React.FC = () => {
         </button>
 
         <AISettingsSection />
+
+        <div className="border-t border-gray-300 my-2"></div>
+
+        <button
+          data-testid="valid-moves-btn"
+          onClick={toggleValidMoves}
+          disabled={replayMode}
+          className={`w-full font-semibold py-2 px-4 rounded transition-colors text-sm ${
+            showValidMoves
+              ? 'bg-green-600 hover:bg-green-700 text-white'
+              : 'bg-gray-300 hover:bg-gray-400 text-gray-700'
+          } ${replayMode ? 'opacity-50 cursor-not-allowed' : ''}`}
+        >
+          {showValidMoves ? '✓' : '✗'} Valid Moves
+        </button>
+
+        <button
+          data-testid="god-mode-btn"
+          onClick={toggleGodMode}
+          disabled={replayMode}
+          className={`w-full font-semibold py-2 px-4 rounded transition-colors text-sm ${
+            godMode
+              ? 'bg-purple-600 hover:bg-purple-700 text-white'
+              : 'bg-gray-300 hover:bg-gray-400 text-gray-700'
+          } ${replayMode ? 'opacity-50 cursor-not-allowed' : ''}`}
+        >
+          {godMode ? '👁️' : '👁️‍🗨️'} God Mode
+        </button>
+
+        <button
+          data-testid="auto-play-btn"
+          onClick={toggleAutoPlay}
+          disabled={replayMode || aiAutoPlay}
+          className={`w-full font-semibold py-2 px-4 rounded transition-colors text-sm ${
+            autoPlayEnabled
+              ? 'bg-amber-600 hover:bg-amber-700 text-white'
+              : 'bg-gray-300 hover:bg-gray-400 text-gray-700'
+          } ${replayMode || aiAutoPlay ? 'opacity-50 cursor-not-allowed' : ''}`}
+        >
+          {autoPlayEnabled ? '⏸️' : '▶️'} Auto Play
+        </button>
       </div>
 
       <input


### PR DESCRIPTION
## Summary
- **AI Settings expanded by default** — the section now starts open so the preset, model, and API-key controls are immediately visible. The chevron still collapses it for users who prefer to hide it.
- **ControlPanel section reorder** — the AI block (Ask AI / AI Auto-Play / AI Settings) is now directly under the game-management buttons; the legacy Valid Moves / God Mode / Auto Play toggles moved below it. The AI flow is the primary surface for the harvester and advisor users; the legacy heuristic toggles are secondary.
- **e2e cleanup** — the two AI advisor specs that opened the section by clicking `ai-settings-toggle-btn` no longer click it (the click would now collapse, hiding the controls they were trying to reach).

## Test plan
- [x] `npx vitest run` — 349/349 pass
- [x] `npx tsc --noEmit -p tsconfig.app.json` clean
- [ ] CI green on this PR (Build / Lint / Test / E2E)