### PR TITLE
feat(ai): show active API key suffix in AI Settings + restyle auto-play button

### DIFF
--- a/packages/app/src/components/AISettingsSection.tsx
+++ b/packages/app/src/components/AISettingsSection.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useGameStore } from '../store/gameStore';
 import { DEFAULT_AI_CONFIG } from '../ai';
+import { getEffectiveKey } from '../ai/keyStore';
 import { downloadJson, gameIdTag } from '../utils/download';
 import type { AIConfig, AIContextPreset } from '../ai';
 
@@ -28,11 +29,21 @@ const PRESETS: { value: AIContextPreset; label: string }[] = [
  */
 const AISettingsSection: React.FC = () => {
   const aiConfig = useGameStore((s) => s.aiConfig) ?? DEFAULT_AI_CONFIG;
+  // Re-read after the key modal closes so a freshly-saved key reflects here.
+  const keyModalOpen = useGameStore((s) => s.aiKeyModalOpen);
   const setAIConfig = useGameStore((s) => s.setAIConfig);
   const setAIKeyModalOpen = useGameStore((s) => s.setAIKeyModalOpen);
   const exportAIInteractions = useGameStore((s) => s.exportAIInteractions);
   const gameSessionId = useGameStore((s) => s.gameSessionId);
   const [expanded, setExpanded] = useState(true);
+
+  // Last 4 chars of the key that will actually be used for requests — matches
+  // getEffectiveKey(config.provider) in the game store. Lets you tell which key
+  // a given tab is on when several instances run with different .env keys.
+  // keyModalOpen is read above purely to re-render this on modal open/close.
+  void keyModalOpen;
+  const activeKey = getEffectiveKey(aiConfig.provider);
+  const keySuffix = activeKey ? activeKey.slice(-4) : null;
 
   /** Download the full LLM interaction log as a JSON file. */
   const handleExportAILog = () => {
@@ -112,6 +123,20 @@ const AISettingsSection: React.FC = () => {
 
           {/* Model + key */}
           <div className="border-t border-indigo-200 pt-2">
+            <p className="text-[10px] text-gray-500 mb-0.5">
+              Key:{' '}
+              {keySuffix ? (
+                <code
+                  data-testid="ai-active-key-suffix"
+                  className="text-[10px] text-indigo-700 font-semibold"
+                  title="Last 4 characters of the API key in use for this tab"
+                >
+                  …{keySuffix}
+                </code>
+              ) : (
+                <span className="text-amber-600">none</span>
+              )}
+            </p>
             <p className="text-[10px] text-gray-500 mb-1">
               Model: <code className="text-[10px]">{aiConfig.model}</code>
             </p>

--- a/packages/app/src/components/ControlPanel.tsx
+++ b/packages/app/src/components/ControlPanel.tsx
@@ -261,10 +261,10 @@ const ControlPanel: React.FC = () => {
           data-testid="ai-auto-play-btn"
           onClick={toggleAIAutoPlay}
           disabled={replayMode || autoPlayEnabled || gameWon}
-          className={`w-full font-semibold py-2 px-4 rounded transition-colors text-sm ${
+          className={`w-full font-semibold py-2 px-4 rounded shadow-md transition-all text-sm ${
             aiAutoPlay
-              ? 'bg-indigo-700 hover:bg-indigo-800 text-white'
-              : 'bg-gray-300 hover:bg-gray-400 text-gray-700'
+              ? 'bg-rose-600 hover:bg-rose-700 text-white'
+              : 'bg-gradient-to-r from-indigo-600 to-purple-600 hover:from-indigo-700 hover:to-purple-700 text-white'
           } ${
             replayMode || autoPlayEnabled || gameWon ? 'opacity-50 cursor-not-allowed' : ''
           }`}


### PR DESCRIPTION
## What

Two small UI changes to the AI advisor panel:

1. **Active key indicator** — a `Key: …XXXX` line in the AI Settings section showing the last 4 characters of the key `getEffectiveKey` resolves for the current provider. Makes it possible to tell which key a tab is using when running several instances with different `.env` keys. It re-reads when the key modal closes, and renders an amber `none` when no effective key exists (e.g. a production build with no stored key).
2. **Auto-play button restyle** — indigo→purple gradient when idle, rose when active, with shadow and transition.

## Testing

Verified headless against the live dev build via the `window.__solitaire` bridge + Playwright MCP:

- Key suffix tracks `getEffectiveKey`: dev fallback → `…xk8M`; save a key via the modal → `…WXYZ` (modal closes, line re-reads); clear → modal stays open + notice; close → falls back to `…xk8M`.
- Production preview (no dev key injected) renders the amber `none` branch (`amber-600`).
- Auto-play button toggles between the gradient (idle) and rose (active) states.

Local checks all green: `lint` clean · `test:run` 352 passed · `test:e2e` 57 passed · `build` succeeds.