### PR TITLE
feat(insights): live Game Insights dashboard with Progress + Card Flow charts

### DIFF
--- a/packages/app/e2e/insights.spec.ts
+++ b/packages/app/e2e/insights.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect } from '@playwright/test';
+import { waitForGame, loadScenario } from './helpers';
+
+/**
+ * Game Insights dashboard: the live progress bar + the Progress / Card Flow
+ * charts that track a game (or the AI auto-player) move by move.
+ */
+test.describe('Game Insights panel', () => {
+  test('renders a live progress bar and an empty-state hint on a fresh deal', async ({
+    page,
+  }) => {
+    await page.goto('/?seed=42');
+    await waitForGame(page);
+
+    await expect(page.getByTestId('game-insights-panel')).toBeVisible();
+
+    const bar = page.getByTestId('insights-progress-bar');
+    await expect(bar).toHaveAttribute('aria-valuenow', '0');
+    await expect(page.getByTestId('insights-stat-moves')).toHaveText('0 moves');
+
+    // One baseline point → not enough to plot a trend yet.
+    await expect(page.getByTestId('insights-chart-empty')).toBeVisible();
+  });
+
+  test('fills the progress bar to 100% as the game is auto-completed', async ({
+    page,
+  }) => {
+    await page.goto('/?seed=42');
+    await waitForGame(page);
+
+    await loadScenario(page, 'autoCompleteReady');
+    await page.evaluate(() => window.__solitaire!.toggleAutoPlay());
+    await page.waitForFunction(() => window.__solitaire!.getSummary().gameWon);
+
+    await expect(page.getByTestId('insights-progress-bar')).toHaveAttribute(
+      'aria-valuenow',
+      '100',
+    );
+    await expect(page.getByTestId('insights-progress-value')).toHaveText('100%');
+    await expect(page.getByTestId('insights-stat-foundations')).toContainText(
+      '52/52',
+    );
+
+    // Dismiss the win modal (keeps game state) and confirm the chart drew.
+    await page.getByTestId('win-modal-close-btn').click();
+    await expect(
+      page.getByTestId('insights-chart-progress').locator('svg'),
+    ).toBeVisible();
+  });
+
+  test('switches between the Progress and Card Flow tabs', async ({ page }) => {
+    await page.goto('/?seed=42');
+    await waitForGame(page);
+
+    // A handful of draws gives the charts something to plot.
+    await page.evaluate(() => {
+      for (let i = 0; i < 20; i += 1) window.__solitaire!.draw();
+    });
+
+    // Progress is the default tab.
+    await expect(page.getByTestId('insights-tab-progress')).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    await expect(
+      page.getByTestId('insights-chart-progress').locator('svg'),
+    ).toBeVisible();
+
+    // Switch to Card Flow.
+    await page.getByTestId('insights-tab-flow').click();
+    await expect(page.getByTestId('insights-tab-flow')).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    await expect(
+      page.getByTestId('insights-chart-flow').locator('svg'),
+    ).toBeVisible();
+    await expect(page.getByTestId('insights-chart-progress')).toHaveCount(0);
+  });
+
+  test('collapsing hides the charts but keeps the live bar', async ({
+    page,
+  }) => {
+    await page.goto('/?seed=42');
+    await waitForGame(page);
+
+    await page.getByTestId('insights-collapse-btn').click();
+
+    // The live bar stays (its 0%-wide fill has no box on a fresh deal, so assert
+    // the always-visible value label and that the bar element is still mounted).
+    await expect(page.getByTestId('insights-progress-value')).toBeVisible();
+    await expect(page.getByTestId('insights-progress-bar')).toHaveCount(1);
+    await expect(page.getByTestId('insights-tab-progress')).toHaveCount(0);
+    await expect(page.getByTestId('insights-chart-progress')).toHaveCount(0);
+
+    // Expand again.
+    await page.getByTestId('insights-collapse-btn').click();
+    await expect(page.getByTestId('insights-tab-progress')).toBeVisible();
+  });
+});

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -19,6 +19,9 @@
   "dependencies": {
     "@chayuto/solitaire-core": "workspace:*",
     "@dnd-kit/core": "^6.3.1",
+    "@nivo/core": "0.99.0",
+    "@nivo/line": "0.99.0",
+    "@nivo/stream": "0.99.0",
     "framer-motion": "^12.38.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",

--- a/packages/app/src/components/GameBoard.tsx
+++ b/packages/app/src/components/GameBoard.tsx
@@ -6,6 +6,7 @@ import DiscardPile from './DiscardPile';
 import FoundationPile from './FoundationPile';
 import TableauColumn from './TableauColumn';
 import ControlPanel from './ControlPanel';
+import GameInsightsPanel from './GameInsightsPanel';
 import ActivityLog from './ActivityLog';
 import AIAdvisorPanel from './AIAdvisorPanel';
 import AIKeyModal from './AIKeyModal';
@@ -138,6 +139,9 @@ const GameBoard: React.FC = () => {
                 ))}
               </div>
             </div>
+
+            {/* Live progress dashboard — charts the game / AI auto-play */}
+            <GameInsightsPanel />
           </div>
         </div>
 

--- a/packages/app/src/components/GameInsightsPanel.tsx
+++ b/packages/app/src/components/GameInsightsPanel.tsx
@@ -1,0 +1,160 @@
+/**
+ * GameInsightsPanel — a live, modern dashboard for watching a game (or the AI
+ * auto-player) progress.
+ *
+ * Always-visible header carries a live progress bar and a few stat chips that
+ * update on every move. Below, a tabbed chart area:
+ *   • Progress  — move number vs progress % (gradient area line).
+ *   • Card Flow — a streamgraph of all 52 cards flowing toward the foundations.
+ *
+ * The panel stays mounted so its per-move history keeps accumulating even while
+ * collapsed; collapsing only hides the tabs + chart, never the live bar.
+ */
+
+import { lazy, Suspense, useMemo, useState } from 'react';
+import { useProgressHistory } from '../hooks/useProgressHistory';
+import { shouldReduceMotion as checkReducedMotion } from '../utils/motion';
+import { ChartEmptyHint } from './charts/ChartEmptyHint';
+
+// Nivo (and its d3 deps) is heavy; load the charts as a separate chunk so the
+// always-visible bar + stat chips paint without waiting on it.
+const ProgressChart = lazy(() => import('./charts/ProgressChart'));
+const CardFlowChart = lazy(() => import('./charts/CardFlowChart'));
+
+type InsightsTab = 'progress' | 'flow';
+
+/** Total face-down cards in a fresh Klondike deal. */
+const INITIAL_FACE_DOWN = 21;
+
+const GameInsightsPanel: React.FC = () => {
+  const history = useProgressHistory();
+  const animate = useMemo(() => !checkReducedMotion(), []);
+
+  const [collapsed, setCollapsed] = useState(false);
+  const [tab, setTab] = useState<InsightsTab>('progress');
+
+  const latest = history[history.length - 1];
+  const progress = latest?.progress ?? 0;
+  const foundations = latest?.foundations ?? 0;
+  const revealed = INITIAL_FACE_DOWN - (latest?.faceDown ?? INITIAL_FACE_DOWN);
+  const moves = latest?.move ?? 0;
+
+  return (
+    <div
+      data-testid="game-insights-panel"
+      className="mt-6 lg:mt-8 bg-white/90 backdrop-blur-sm rounded-lg shadow-xl p-4"
+    >
+      {/* Header: title + collapse toggle */}
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-sm font-bold text-gray-800 flex items-center gap-2">
+          <span aria-hidden>📈</span> Game Insights
+        </h2>
+        <button
+          type="button"
+          data-testid="insights-collapse-btn"
+          onClick={() => setCollapsed((c) => !c)}
+          aria-expanded={!collapsed}
+          className="text-gray-400 hover:text-gray-700 transition-colors text-xs font-medium"
+        >
+          {collapsed ? 'Show ▾' : 'Hide ▴'}
+        </button>
+      </div>
+
+      {/* Always-visible live progress bar */}
+      <div className="flex items-center gap-3">
+        <div className="flex-1 h-3 bg-gray-200 rounded-full overflow-hidden">
+          <div
+            data-testid="insights-progress-bar"
+            role="progressbar"
+            aria-valuenow={progress}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-label="Game progress"
+            className="h-full rounded-full bg-gradient-to-r from-green-400 via-emerald-500 to-green-600 transition-all duration-500 ease-out"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+        <span
+          data-testid="insights-progress-value"
+          className="text-sm font-bold text-emerald-700 tabular-nums w-10 text-right"
+        >
+          {progress}%
+        </span>
+      </div>
+
+      {/* Stat chips */}
+      <div className="mt-2 flex flex-wrap gap-2 text-[11px] font-medium">
+        <span
+          data-testid="insights-stat-moves"
+          className="px-2 py-0.5 rounded-full bg-gray-100 text-gray-600"
+        >
+          {moves} moves
+        </span>
+        <span
+          data-testid="insights-stat-foundations"
+          className="px-2 py-0.5 rounded-full bg-emerald-100 text-emerald-700"
+        >
+          ♦ {foundations}/52 home
+        </span>
+        <span
+          data-testid="insights-stat-revealed"
+          className="px-2 py-0.5 rounded-full bg-sky-100 text-sky-700"
+        >
+          {revealed}/{INITIAL_FACE_DOWN} revealed
+        </span>
+      </div>
+
+      {!collapsed && (
+        <>
+          {/* Tab switcher (segmented control) */}
+          <div
+            role="tablist"
+            aria-label="Game Insights charts"
+            className="mt-4 inline-flex rounded-lg bg-gray-100 p-0.5 text-xs font-semibold"
+          >
+            {([
+              { id: 'progress', label: 'Progress' },
+              { id: 'flow', label: 'Card Flow' },
+            ] as const).map(({ id, label }) => (
+              <button
+                key={id}
+                type="button"
+                role="tab"
+                aria-selected={tab === id}
+                data-testid={`insights-tab-${id}`}
+                onClick={() => setTab(id)}
+                className={`px-3 py-1 rounded-md transition-colors ${
+                  tab === id
+                    ? 'bg-white text-green-700 shadow-sm'
+                    : 'text-gray-500 hover:text-gray-700'
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+
+          {/* Active chart */}
+          <div className="mt-2 h-52 w-full">
+            <Suspense fallback={<ChartEmptyHint />}>
+              {tab === 'progress' ? (
+                <div
+                  data-testid="insights-chart-progress"
+                  className="h-full w-full"
+                >
+                  <ProgressChart history={history} animate={animate} />
+                </div>
+              ) : (
+                <div data-testid="insights-chart-flow" className="h-full w-full">
+                  <CardFlowChart history={history} animate={animate} />
+                </div>
+              )}
+            </Suspense>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default GameInsightsPanel;

--- a/packages/app/src/components/charts/CardFlowChart.tsx
+++ b/packages/app/src/components/charts/CardFlowChart.tsx
@@ -1,0 +1,77 @@
+/**
+ * CardFlowChart — Game Insights tab #2.
+ *
+ * A streamgraph of where all 52 cards live, move by move: they flow from the
+ * stock, through the waste and tableau, and pool into the foundations. The
+ * foundations band swells to fill the whole height at a win. Mesmerising to
+ * watch while the AI auto-plays.
+ */
+
+import { ResponsiveStream } from '@nivo/stream';
+import type { ProgressSnapshot } from '../../hooks/useProgressHistory';
+import { ChartEmptyHint } from './ChartEmptyHint';
+
+interface CardFlowChartProps {
+  history: ProgressSnapshot[];
+  animate: boolean;
+}
+
+/** Stream keys, stacked bottom-to-top, with their band colours. */
+const ZONES = [
+  { key: 'Stock', color: '#94a3b8' },
+  { key: 'Waste', color: '#fbbf24' },
+  { key: 'Face-down', color: '#6366f1' },
+  { key: 'Face-up', color: '#38bdf8' },
+  { key: 'Foundations', color: '#34d399' },
+] as const;
+
+const KEYS = ZONES.map((z) => z.key);
+const COLORS = ZONES.map((z) => z.color);
+
+const CardFlowChart: React.FC<CardFlowChartProps> = ({ history, animate }) => {
+  if (history.length < 2) return <ChartEmptyHint />;
+
+  const data = history.map((p) => ({
+    Stock: p.stock,
+    Waste: p.waste,
+    'Face-down': p.faceDown,
+    'Face-up': p.faceUp,
+    Foundations: p.foundations,
+  }));
+
+  return (
+    <ResponsiveStream
+      data={data}
+      keys={KEYS}
+      colors={COLORS}
+      margin={{ top: 12, right: 16, bottom: 16, left: 16 }}
+      offsetType="silhouette"
+      order="none"
+      curve="basis"
+      fillOpacity={0.88}
+      borderWidth={1}
+      borderColor={{ theme: 'background' }}
+      enableGridX={false}
+      enableGridY={false}
+      axisBottom={null}
+      axisLeft={null}
+      animate={animate}
+      motionConfig="gentle"
+      legends={[
+        {
+          anchor: 'bottom',
+          direction: 'row',
+          translateY: 14,
+          itemWidth: 78,
+          itemHeight: 14,
+          itemTextColor: '#6b7280',
+          symbolSize: 10,
+          symbolShape: 'circle',
+        },
+      ]}
+      theme={{ text: { fill: '#6b7280', fontSize: 10 } }}
+    />
+  );
+};
+
+export default CardFlowChart;

--- a/packages/app/src/components/charts/ChartEmptyHint.tsx
+++ b/packages/app/src/components/charts/ChartEmptyHint.tsx
@@ -1,0 +1,9 @@
+/** Placeholder shown until a game has enough moves to plot a trend. */
+export const ChartEmptyHint: React.FC = () => (
+  <div
+    data-testid="insights-chart-empty"
+    className="flex h-full items-center justify-center px-4 text-center text-xs text-gray-400"
+  >
+    Make a few moves — or start AI auto-play — to watch the game unfold here.
+  </div>
+);

--- a/packages/app/src/components/charts/ProgressChart.tsx
+++ b/packages/app/src/components/charts/ProgressChart.tsx
@@ -1,0 +1,93 @@
+/**
+ * ProgressChart — Game Insights tab #1.
+ *
+ * Move number (x) versus progress % (y). Two gradient-filled series: the
+ * blended progress score (the hero) and the foundations-home percentage (the
+ * win number). Both climb left-to-right as the game — or the AI auto-player —
+ * makes moves.
+ */
+
+import { ResponsiveLine } from '@nivo/line';
+import { linearGradientDef } from '@nivo/core';
+import type { ProgressSnapshot } from '../../hooks/useProgressHistory';
+import { ChartEmptyHint } from './ChartEmptyHint';
+
+interface ProgressChartProps {
+  history: ProgressSnapshot[];
+  animate: boolean;
+}
+
+const ProgressChart: React.FC<ProgressChartProps> = ({ history, animate }) => {
+  if (history.length < 2) return <ChartEmptyHint />;
+
+  const data = [
+    {
+      id: 'Progress',
+      color: '#22c55e',
+      data: history.map((p) => ({ x: p.move, y: p.progress })),
+    },
+    {
+      id: 'Foundations',
+      color: '#f59e0b',
+      data: history.map((p) => ({
+        x: p.move,
+        y: Math.round((p.foundations / 52) * 100),
+      })),
+    },
+  ];
+
+  return (
+    <ResponsiveLine
+      data={data}
+      colors={{ datum: 'color' }}
+      margin={{ top: 12, right: 16, bottom: 32, left: 36 }}
+      xScale={{ type: 'linear', min: 0, max: 'auto' }}
+      yScale={{ type: 'linear', min: 0, max: 100 }}
+      curve="monotoneX"
+      enableArea
+      areaOpacity={1}
+      defs={[
+        linearGradientDef('progressFill', [
+          { offset: 0, color: '#22c55e', opacity: 0.55 },
+          { offset: 100, color: '#22c55e', opacity: 0 },
+        ]),
+        linearGradientDef('foundationsFill', [
+          { offset: 0, color: '#f59e0b', opacity: 0.45 },
+          { offset: 100, color: '#f59e0b', opacity: 0 },
+        ]),
+      ]}
+      fill={[
+        { match: { id: 'Progress' }, id: 'progressFill' },
+        { match: { id: 'Foundations' }, id: 'foundationsFill' },
+      ]}
+      lineWidth={2.5}
+      enablePoints={false}
+      enableGridX={false}
+      gridYValues={[0, 25, 50, 75, 100]}
+      axisLeft={{
+        tickValues: [0, 25, 50, 75, 100],
+        format: (v) => `${v}%`,
+        tickSize: 0,
+        tickPadding: 6,
+      }}
+      axisBottom={{
+        legend: 'move',
+        legendOffset: 26,
+        legendPosition: 'middle',
+        tickSize: 0,
+        tickPadding: 6,
+      }}
+      enableSlices="x"
+      useMesh
+      animate={animate}
+      motionConfig="gentle"
+      theme={{
+        text: { fill: '#6b7280', fontSize: 10 },
+        grid: { line: { stroke: '#e5e7eb', strokeDasharray: '2 4' } },
+        crosshair: { line: { stroke: '#16a34a', strokeWidth: 1 } },
+      }}
+    />
+  );
+};
+
+export default ProgressChart;

--- a/packages/app/src/hooks/useProgressHistory.ts
+++ b/packages/app/src/hooks/useProgressHistory.ts
@@ -1,0 +1,97 @@
+/**
+ * useProgressHistory — a live, per-move time-series of game progress.
+ *
+ * Solitaire's store keeps a flat `moveHistory` but never snapshots the *board
+ * shape* at each move, so there is nothing to chart over time. This hook
+ * subscribes to the store and accumulates one lightweight snapshot per move:
+ * where the 52 cards sit (stock / waste / face-down / face-up / foundations)
+ * plus the blended progress score. It feeds the Game Insights charts and
+ * updates live as the AI auto-plays — the "fish bowl" effect.
+ *
+ * Lifecycle:
+ *  - resets to a single baseline point whenever a new game starts (the
+ *    `gameSessionId` changes — new deal, import, or scenario load);
+ *  - appends a point each time `moveHistory` grows;
+ *  - trims trailing points if `moveHistory` shrinks (undo / replay rewind).
+ *
+ * @module hooks/useProgressHistory
+ */
+
+import { useEffect, useState } from 'react';
+import { useGameStore } from '../store/gameStore';
+import { computeProgressComponents } from '../ai/progressMetric';
+import type { GameState } from '../types';
+
+/** One per-move snapshot of the board. The five zone counts sum to 52. */
+export interface ProgressSnapshot {
+  /** Move number this snapshot was taken at (`moveHistory.length`). */
+  move: number;
+  /** Cards in the stock / draw pile. */
+  stock: number;
+  /** Cards in the waste / discard pile. */
+  waste: number;
+  /** Face-down tableau cards (21 in a fresh deal, down to 0). */
+  faceDown: number;
+  /** Face-up tableau cards. */
+  faceUp: number;
+  /** Cards on the four foundations (0–52). */
+  foundations: number;
+  /** Blended progress score (0–100): fresh deal 0, win 100. */
+  progress: number;
+}
+
+/** Build a snapshot from the current game state at a given move number. */
+function snapshot(state: GameState, move: number): ProgressSnapshot {
+  const { foundationCards, faceDownTotal, progressScore } =
+    computeProgressComponents(state);
+
+  let tableauTotal = 0;
+  for (const column of state.tableau) tableauTotal += column.length;
+
+  return {
+    move,
+    stock: state.drawPile.length,
+    waste: state.discardPile.length,
+    faceDown: faceDownTotal,
+    faceUp: tableauTotal - faceDownTotal,
+    foundations: foundationCards,
+    progress: progressScore,
+  };
+}
+
+/**
+ * Accumulate the per-move progress series for the active game. The returned
+ * array always has at least one (baseline) point and grows as moves are made.
+ */
+export function useProgressHistory(): ProgressSnapshot[] {
+  const [history, setHistory] = useState<ProgressSnapshot[]>(() => {
+    const state = useGameStore.getState() as GameState;
+    return [snapshot(state, state.moveHistory.length)];
+  });
+
+  useEffect(() => {
+    const unsubscribe = useGameStore.subscribe((state, prev) => {
+      // New game / import / scenario load → start a fresh series.
+      if (state.gameSessionId !== prev.gameSessionId) {
+        setHistory([snapshot(state as GameState, state.moveHistory.length)]);
+        return;
+      }
+
+      const move = state.moveHistory.length;
+      if (move === prev.moveHistory.length) return; // not a move change
+
+      setHistory((points) => {
+        const next = snapshot(state as GameState, move);
+        // Rewind (undo / replay jump): drop points at or past the new move
+        // count, then re-anchor with the current state.
+        if (points.length > 0 && points[points.length - 1].move >= move) {
+          return [...points.filter((p) => p.move < move), next];
+        }
+        return [...points, next];
+      });
+    });
+    return unsubscribe;
+  }, []);
+
+  return history;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,15 @@ importers:
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@nivo/core':
+        specifier: 0.99.0
+        version: 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@nivo/line':
+        specifier: 0.99.0
+        version: 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@nivo/stream':
+        specifier: 0.99.0
+        version: 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       framer-motion:
         specifier: ^12.38.0
         version: 12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -383,6 +392,64 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
+  '@nivo/annotations@0.99.0':
+    resolution: {integrity: sha512-jCuuXPbvpaqaz4xF7k5dv0OT2ubn5Nt0gWryuTe/8oVsC/9bzSuK8bM9vBty60m9tfO+X8vUYliuaCDwGksC2g==}
+    peerDependencies:
+      react: ^16.14 || ^17.0 || ^18.0 || ^19.0
+
+  '@nivo/axes@0.99.0':
+    resolution: {integrity: sha512-3KschnmEL0acRoa7INSSOSEFwJLm54aZwSev7/r8XxXlkgRBriu6ReZy/FG0wfN+ljZ4GMvx+XyIIf6kxzvrZg==}
+    peerDependencies:
+      react: ^16.14 || ^17.0 || ^18.0 || ^19.0
+
+  '@nivo/colors@0.99.0':
+    resolution: {integrity: sha512-hyYt4lEFIfXOUmQ6k3HXm3KwhcgoJpocmoGzLUqzk7DzuhQYJo+4d5jIGGU0N/a70+9XbHIdpKNSblHAIASD3w==}
+    peerDependencies:
+      react: ^16.14 || ^17.0 || ^18.0 || ^19.0
+
+  '@nivo/core@0.99.0':
+    resolution: {integrity: sha512-olCItqhPG3xHL5ei+vg52aB6o+6S+xR2idpkd9RormTTUniZb8U2rOdcQojOojPY5i9kVeQyLFBpV4YfM7OZ9g==}
+    peerDependencies:
+      react: ^16.14 || ^17.0 || ^18.0 || ^19.0
+
+  '@nivo/legends@0.99.0':
+    resolution: {integrity: sha512-P16FjFqNceuTTZphINAh5p0RF0opu3cCKoWppe2aRD9IuVkvRm/wS5K1YwMCxDzKyKh5v0AuTlu9K6o3/hk8hA==}
+    peerDependencies:
+      react: ^16.14 || ^17.0 || ^18.0 || ^19.0
+
+  '@nivo/line@0.99.0':
+    resolution: {integrity: sha512-bAqTXSjpnpcGMs341qWFUi7hJTqQiNoSeJHsYPuPS3icuXPcp3WETQH+zRZACeEF79ZigeOWCW+dzODgne1y9w==}
+    peerDependencies:
+      react: ^16.14 || ^17.0 || ^18.0 || ^19.0
+
+  '@nivo/scales@0.99.0':
+    resolution: {integrity: sha512-g/2K4L6L8si6E2BWAHtFVGahtDKbUcO6xHJtlIZMwdzaJc7yB16EpWLK8AfI/A42KadLhJSJqBK3mty+c7YZ+w==}
+
+  '@nivo/stream@0.99.0':
+    resolution: {integrity: sha512-/vXtbU1Nzepgxg0Y3Wrve7Q6BllaQCP9+lLpPCiRWWXIyODcKSauqsYKY4kas9YcIfJbchJclVD2CSHKt+lPxQ==}
+    peerDependencies:
+      react: ^16.14 || ^17.0 || ^18.0 || ^19.0
+
+  '@nivo/text@0.99.0':
+    resolution: {integrity: sha512-ho3oZpAZApsJNjsIL5WJSAdg/wjzTBcwo1KiHBlRGUmD+yUWO8qp7V+mnYRhJchwygtRVALlPgZ/rlcW2Xr/MQ==}
+    peerDependencies:
+      react: ^16.14 || ^17.0 || ^18.0 || ^19.0
+
+  '@nivo/theming@0.99.0':
+    resolution: {integrity: sha512-KvXlf0nqBzh/g2hAIV9bzscYvpq1uuO3TnFN3RDXGI72CrbbZFTGzprPju3sy/myVsauv+Bb+V4f5TZ0jkYKRg==}
+    peerDependencies:
+      react: ^16.14 || ^17.0 || ^18.0 || ^19.0
+
+  '@nivo/tooltip@0.99.0':
+    resolution: {integrity: sha512-weoEGR3xAetV4k2P6k96cdamGzKQ5F2Pq+uyDaHr1P3HYArM879Pl+x+TkU0aWjP6wgUZPx/GOBiV1Hb1JxIqg==}
+    peerDependencies:
+      react: ^16.14 || ^17.0 || ^18.0 || ^19.0
+
+  '@nivo/voronoi@0.99.0':
+    resolution: {integrity: sha512-KfmMdidbYzhiUCki1FG4X4nHEFT4loK8G5bMBnmCl9U+S78W+gvkfrgD2Aoqp/Q9yKQvr3Y8UcZKSFZnn3HgjQ==}
+    peerDependencies:
+      react: ^16.14 || ^17.0 || ^18.0 || ^19.0
+
   '@oxc-project/types@0.130.0':
     resolution: {integrity: sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==}
 
@@ -393,6 +460,33 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@react-spring/animated@10.1.0':
+    resolution: {integrity: sha512-dvGVSfNYhbkzTAnyB1S1940ZiKp6/Ey+b2vQc70dJ5k6gzH/GdlfeDzCh65V94b6OPqF7Xl4VUICVUQpc07iUg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@react-spring/core@10.1.0':
+    resolution: {integrity: sha512-XUG3UCCCxay6lYjBU2KOKzEgC1sx/w44ouB5gRh2Ex6rVJOdPcGVg7JJUIOAQo7uhKGfQdCQU4qUZaQnmInZPQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@react-spring/rafz@10.1.0':
+    resolution: {integrity: sha512-e/LRnNmvmg8Agl4j3MGcjHuSTSBcCrxr3xeoWdodxpLWeTHY1pHl8PJDOCEJ2Pj6BMdEBaWFRAX7uxRo1FLzCg==}
+
+  '@react-spring/shared@10.1.0':
+    resolution: {integrity: sha512-ogIUujWxdwcsQ2Vp2hZs+KehvH8tKeWGHsFb1eRBYoePzhKS541Qg1JfFlQ7ursBUwwPDBQ5Wpwn+Cwx6WV1PQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@react-spring/types@10.1.0':
+    resolution: {integrity: sha512-RkJAlkAZ5yZSRBMOSidamioBHLjf8wGKbtr3pZ5iKoHFNQuNM2k6DqJDIEUcNQlWRZXny6Eqys2c9NdugdbdyQ==}
+
+  '@react-spring/web@10.1.0':
+    resolution: {integrity: sha512-mIj/lJ+1eI4tLSkIloaSNjmuriTDZY9bbQ/GFGcbVGfOKzWb5JOMMKiuHACh8J3m0+se3KqcWdg/JoALVloE7g==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   '@rolldown/binding-android-arm64@1.0.1':
     resolution: {integrity: sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==}
@@ -637,6 +731,39 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-format@1.4.5':
+    resolution: {integrity: sha512-mLxrC1MSWupOSncXN/HOlWUAAIffAEBaI4+PKy2uMPsKe4FNZlk7qrbTjmzJXITQQqBHivaks4Td18azgqnotA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@2.3.4':
+    resolution: {integrity: sha512-xdDXbpVO74EvadI3UDxjxTdR6QIxm1FKzEA/+F8tL4GWWUg/hgvBqf6chql64U5A9ZUGWo7pEu4eNlyLwbKdhg==}
+
+  '@types/d3-time-format@3.0.4':
+    resolution: {integrity: sha512-or9DiDnYI1h38J9hxKEsw513+KVuFbEVhl7qdxcaudoiqWWepapUen+2vAriFGexr6W5+P4l9+HJrB39GG+oRg==}
+
+  '@types/d3-time@1.1.4':
+    resolution: {integrity: sha512-JIvy2HjRInE+TXOmIGN5LCmeO0hkFZx5f9FZ7kiN+D+YTcc8pptsiLiuHsvwxwC7VVKmJ2ExHUgNlAiV7vQM9g==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -868,6 +995,57 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-format@1.4.5:
+    resolution: {integrity: sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@3.0.0:
+    resolution: {integrity: sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==}
+
+  d3-time@1.1.0:
+    resolution: {integrity: sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==}
+
+  d3-time@2.1.1:
+    resolution: {integrity: sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -886,6 +1064,9 @@ packages:
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -1093,6 +1274,13 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -1234,6 +1422,9 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
   lru-cache@11.3.5:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
     engines: {node: 20 || >=22}
@@ -1372,6 +1563,12 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
+  react-virtualized-auto-sizer@1.0.26:
+    resolution: {integrity: sha512-CblNyiNVw2o+hsa5/49NH2ogGxZ+t+3aweRvNSq7TVjDIlwk7ir4lencEg5HxHeSzwNarSkNkiu0qJSOXtxm5A==}
+    peerDependencies:
+      react: ^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   react@19.2.5:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
@@ -1383,6 +1580,9 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
 
   rolldown@1.0.1:
     resolution: {integrity: sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==}
@@ -1555,6 +1755,12 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  use-debounce@10.1.1:
+    resolution: {integrity: sha512-kvds8BHR2k28cFsxW8k3nc/tRga2rs1RHYCqmmGqb90MEeE++oALwzh2COiuBLO1/QXiOuShXoSN2ZpWnMmvuQ==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      react: '*'
 
   vite-plugin-dts@5.0.0:
     resolution: {integrity: sha512-VLNAUttBq7pLxxL/m/ztjd5zj5yiviiC7ijfPFVLK5c45FLcibvieBsdjSka3a4ag1qdrAF9K3OysH4/lW+rPQ==}
@@ -1997,6 +2203,161 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
+  '@nivo/annotations@0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@nivo/colors': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@nivo/core': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@nivo/theming': 0.99.0(react@19.2.5)
+      '@react-spring/web': 10.1.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      lodash: 4.18.1
+      react: 19.2.5
+    transitivePeerDependencies:
+      - react-dom
+
+  '@nivo/axes@0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@nivo/core': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@nivo/scales': 0.99.0
+      '@nivo/text': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@nivo/theming': 0.99.0(react@19.2.5)
+      '@react-spring/web': 10.1.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@types/d3-format': 1.4.5
+      '@types/d3-time-format': 2.3.4
+      d3-format: 1.4.5
+      d3-time-format: 3.0.0
+      react: 19.2.5
+    transitivePeerDependencies:
+      - react-dom
+
+  '@nivo/colors@0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@nivo/core': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@nivo/theming': 0.99.0(react@19.2.5)
+      '@types/d3-color': 3.1.3
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      d3-color: 3.1.0
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      lodash: 4.18.1
+      react: 19.2.5
+    transitivePeerDependencies:
+      - react-dom
+
+  '@nivo/core@0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@nivo/theming': 0.99.0(react@19.2.5)
+      '@nivo/tooltip': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@react-spring/web': 10.1.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@types/d3-shape': 3.1.8
+      d3-color: 3.1.0
+      d3-format: 1.4.5
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-shape: 3.2.0
+      d3-time-format: 3.0.0
+      lodash: 4.18.1
+      react: 19.2.5
+      react-virtualized-auto-sizer: 1.0.26(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      use-debounce: 10.1.1(react@19.2.5)
+    transitivePeerDependencies:
+      - react-dom
+
+  '@nivo/legends@0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@nivo/colors': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@nivo/core': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@nivo/text': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@nivo/theming': 0.99.0(react@19.2.5)
+      '@types/d3-scale': 4.0.9
+      d3-scale: 4.0.2
+      react: 19.2.5
+    transitivePeerDependencies:
+      - react-dom
+
+  '@nivo/line@0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@nivo/annotations': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@nivo/axes': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@nivo/colors': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@nivo/core': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@nivo/legends': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@nivo/scales': 0.99.0
+      '@nivo/theming': 0.99.0(react@19.2.5)
+      '@nivo/tooltip': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@nivo/voronoi': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@react-spring/web': 10.1.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@types/d3-shape': 3.1.8
+      d3-shape: 3.2.0
+      react: 19.2.5
+    transitivePeerDependencies:
+      - react-dom
+
+  '@nivo/scales@0.99.0':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-time': 1.1.4
+      '@types/d3-time-format': 3.0.4
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-time: 1.1.0
+      d3-time-format: 3.0.0
+      lodash: 4.18.1
+
+  '@nivo/stream@0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@nivo/axes': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@nivo/colors': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@nivo/core': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@nivo/legends': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@nivo/scales': 0.99.0
+      '@nivo/theming': 0.99.0(react@19.2.5)
+      '@nivo/tooltip': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@react-spring/web': 10.1.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@types/d3-shape': 3.1.8
+      d3-shape: 3.2.0
+      react: 19.2.5
+    transitivePeerDependencies:
+      - react-dom
+
+  '@nivo/text@0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@nivo/core': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@nivo/theming': 0.99.0(react@19.2.5)
+      '@react-spring/web': 10.1.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+    transitivePeerDependencies:
+      - react-dom
+
+  '@nivo/theming@0.99.0(react@19.2.5)':
+    dependencies:
+      lodash: 4.18.1
+      react: 19.2.5
+
+  '@nivo/tooltip@0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@nivo/core': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@nivo/theming': 0.99.0(react@19.2.5)
+      '@react-spring/web': 10.1.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+    transitivePeerDependencies:
+      - react-dom
+
+  '@nivo/voronoi@0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@nivo/core': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@nivo/theming': 0.99.0(react@19.2.5)
+      '@nivo/tooltip': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-scale': 4.0.9
+      d3-delaunay: 6.0.4
+      d3-scale: 4.0.2
+      react: 19.2.5
+    transitivePeerDependencies:
+      - react-dom
+
   '@oxc-project/types@0.130.0': {}
 
   '@playwright/test@1.59.1':
@@ -2004,6 +2365,39 @@ snapshots:
       playwright: 1.59.1
 
   '@polka/url@1.0.0-next.29': {}
+
+  '@react-spring/animated@10.1.0(react@19.2.5)':
+    dependencies:
+      '@react-spring/shared': 10.1.0(react@19.2.5)
+      '@react-spring/types': 10.1.0
+      react: 19.2.5
+
+  '@react-spring/core@10.1.0(react@19.2.5)':
+    dependencies:
+      '@react-spring/animated': 10.1.0(react@19.2.5)
+      '@react-spring/shared': 10.1.0(react@19.2.5)
+      '@react-spring/types': 10.1.0
+      react: 19.2.5
+
+  '@react-spring/rafz@10.1.0': {}
+
+  '@react-spring/shared@10.1.0(react@19.2.5)':
+    dependencies:
+      '@react-spring/rafz': 10.1.0
+      '@react-spring/types': 10.1.0
+      react: 19.2.5
+
+  '@react-spring/types@10.1.0': {}
+
+  '@react-spring/web@10.1.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@react-spring/animated': 10.1.0(react@19.2.5)
+      '@react-spring/core': 10.1.0(react@19.2.5)
+      '@react-spring/shared': 10.1.0(react@19.2.5)
+      '@react-spring/types': 10.1.0
+      csstype: 3.2.3
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
   '@rolldown/binding-android-arm64@1.0.1':
     optional: true
@@ -2180,6 +2574,34 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-format@1.4.5': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 1.1.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@2.3.4': {}
+
+  '@types/d3-time-format@3.0.4': {}
+
+  '@types/d3-time@1.1.4': {}
 
   '@types/deep-eql@4.0.2': {}
 
@@ -2442,6 +2864,59 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-format@1.4.5: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 1.4.5
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 3.0.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@3.0.0:
+    dependencies:
+      d3-time: 2.1.1
+
+  d3-time@1.1.0: {}
+
+  d3-time@2.1.1:
+    dependencies:
+      d3-array: 2.12.1
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
   data-urls@7.0.0:
     dependencies:
       whatwg-mimetype: 5.0.0
@@ -2456,6 +2931,10 @@ snapshots:
   decimal.js@10.6.0: {}
 
   deep-is@0.1.4: {}
+
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
 
   dequal@2.0.3: {}
 
@@ -2646,6 +3125,10 @@ snapshots:
 
   indent-string@4.0.0: {}
 
+  internmap@1.0.1: {}
+
+  internmap@2.0.3: {}
+
   is-extglob@2.1.1: {}
 
   is-glob@4.0.3:
@@ -2765,6 +3248,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash@4.18.1: {}
 
   lru-cache@11.3.5: {}
 
@@ -2891,6 +3376,11 @@ snapshots:
 
   react-is@17.0.2: {}
 
+  react-virtualized-auto-sizer@1.0.26(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
   react@19.2.5: {}
 
   redent@3.0.0:
@@ -2899,6 +3389,8 @@ snapshots:
       strip-indent: 3.0.0
 
   require-from-string@2.0.2: {}
+
+  robust-predicates@3.0.3: {}
 
   rolldown@1.0.1:
     dependencies:
@@ -3050,6 +3542,10 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-debounce@10.1.1(react@19.2.5):
+    dependencies:
+      react: 19.2.5
 
   vite-plugin-dts@5.0.0(rolldown@1.0.1)(typescript@6.0.3)(vite@8.0.13(@types/node@25.8.0)(jiti@2.7.0)):
     dependencies:


### PR DESCRIPTION
## What

A modern, always-live dashboard under the board that charts how a game — or the AI auto-player — progresses move by move.

- **Live progress bar + stat chips** (always visible, even when collapsed): blended progress %, `moves`, `♦ x/52 home`, `y/21 revealed`.
- **Two tabbed charts:**
  - **Progress** — gradient-area line: move number vs progress %, with the foundations-home % overlaid.
  - **Card Flow** — a streamgraph of all 52 cards flowing stock → waste → tableau → foundations; the foundations band fills the height at a win.

Both update on every move, so the panel animates alongside the board during auto-play.

## How

- `useProgressHistory` hook subscribes to the store and accumulates one lightweight snapshot per move (the five zone counts + blended progress score). Resets on a new game; trims on undo/replay rewind.
- Charts use Nivo (`@nivo/line`, `@nivo/stream`) and are `React.lazy`-loaded, so the d3 weight splits into its own chunk — the main bundle stays ~444 KB (gzip 136 KB) and the >500 KB build warning is gone.
- Lives in the center column, directly below the tableau; collapsing hides the tabs/chart but keeps the live bar.

## Tests

- New seeded e2e spec (`e2e/insights.spec.ts`): bar fills to 100% on auto-complete, tab switching, empty-state hint, collapse keeps the bar.
- Full suite green locally: lint clean, 352 unit, 61 e2e, production build.

Every new interactive element carries a `data-testid`.