### PR TITLE
ci(deploy): run post-deploy smoke test in the Playwright container

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,6 +71,20 @@ jobs:
     name: Post-deploy smoke test
     runs-on: ubuntu-latest
     needs: deploy
+    # Run inside the official Playwright image: chromium, the headless shell,
+    # ffmpeg and every OS dependency are baked in, so there is NO
+    # `playwright install` download step — the CDN stall that used to hang this
+    # job can't happen. Keep this tag in lockstep with the @playwright/test
+    # version in packages/app/package.json (currently 1.59.1); a mismatch makes
+    # Playwright fall back to downloading the browser again. Mirrors the e2e job
+    # in ci.yml.
+    container:
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
+    # Safety cap; with no browser download the job is fast.
+    timeout-minutes: 20
+    env:
+      # Where the image stores its preinstalled browsers.
+      PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
     permissions:
       contents: read
     steps:
@@ -88,9 +102,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Install Playwright browsers
-        run: pnpm --filter app exec playwright install chromium --with-deps
 
       - name: Run post-deploy smoke tests
         run: pnpm run test:e2e:deploy


### PR DESCRIPTION
## Problem

The **Deploy to GitHub Pages** workflow's `Post-deploy smoke test` (`verify`) job hangs on **Install Playwright browsers**. `build` and `deploy` succeed (the site deploys fine), but `verify` stalls on `playwright install chromium --with-deps` — the same CDN stall that used to hang the `e2e` job in `ci.yml`: the 170 MB browser download completes, then the headless-shell/ffmpeg fetch from `cdn.playwright.dev` stalls until the job times out.

## Fix

Run the `verify` job inside the official Playwright image `mcr.microsoft.com/playwright:v1.59.1-noble` — chromium, the headless shell, ffmpeg and OS deps are baked in, so the `playwright install` download step is removed entirely and the stall can't happen. This mirrors the `e2e` job in `ci.yml`.

Adds `PLAYWRIGHT_BROWSERS_PATH: /ms-playwright`, a 20-minute safety cap, and keeps the image tag in lockstep with `@playwright/test` (1.59.1).

## Note

The deploy workflow only runs on push to `main`, so this PR's checks (CI: lint/test/build/e2e) confirm nothing else broke; the `verify` fix itself runs on the post-merge deploy, which I'll watch to green.