### PR TITLE
feat(insights): box-score stat strip, Board topology tab, and AI telemetry tab

### DIFF
--- a/packages/app/e2e/insights.spec.ts
+++ b/packages/app/e2e/insights.spec.ts
@@ -98,3 +98,89 @@ test.describe('Game Insights panel', () => {
     await expect(page.getByTestId('insights-tab-progress')).toBeVisible();
   });
 });
+
+/**
+ * The "stat nerd" additions: the always-visible box-score strip, the Board
+ * topology tab, and the AI telemetry tab.
+ */
+test.describe('Game Insights — stats, board & AI', () => {
+  test('shows the box-score stat strip on a fresh deal', async ({ page }) => {
+    await page.goto('/?seed=42');
+    await waitForGame(page);
+
+    await expect(page.getByTestId('insights-stat-strip')).toBeVisible();
+    await expect(page.getByTestId('insights-stat-time')).toContainText('0:');
+    await expect(page.getByTestId('insights-stat-pace')).toContainText('moves/min');
+    await expect(page.getByTestId('insights-stat-recycles')).toContainText(
+      '0 recycles',
+    );
+    // No moves yet → efficiency is a dash, and the stuck-o-meter reads "flowing".
+    await expect(page.getByTestId('insights-stat-efficiency')).toContainText('—');
+    await expect(page.getByTestId('insights-stat-stuck')).toContainText('flowing');
+  });
+
+  test('updates the stat strip after a run of unproductive draws', async ({
+    page,
+  }) => {
+    await page.goto('/?seed=42');
+    await waitForGame(page);
+
+    await page.evaluate(() => {
+      for (let i = 0; i < 12; i += 1) window.__solitaire!.draw();
+    });
+
+    // Drawing never reveals a tableau card or banks one → 0% efficient and the
+    // stuck-o-meter is climbing.
+    await expect(page.getByTestId('insights-stat-efficiency')).toContainText(
+      '0% efficient',
+    );
+    await expect(page.getByTestId('insights-stat-stuck')).toContainText(
+      'since gain',
+    );
+  });
+
+  test('Board tab renders the foundation and tableau bars', async ({ page }) => {
+    await page.goto('/?seed=42');
+    await waitForGame(page);
+
+    await page.getByTestId('insights-tab-board').click();
+    await expect(page.getByTestId('insights-tab-board')).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+
+    await expect(page.getByTestId('insights-board-bars')).toBeVisible();
+
+    // Four foundations, all empty on a fresh deal.
+    for (const suit of ['spades', 'hearts', 'diamonds', 'clubs']) {
+      await expect(page.getByTestId(`insights-foundation-${suit}`)).toHaveAttribute(
+        'aria-label',
+        `${suit} foundation: 0 of 13`,
+      );
+    }
+
+    // Seven tableau columns; the last holds 7 cards with 6 face-down.
+    await expect(page.getByTestId('insights-column-0')).toBeVisible();
+    await expect(page.getByTestId('insights-column-6')).toHaveAttribute(
+      'aria-label',
+      'Column 7: 7 cards, 6 face-down',
+    );
+  });
+
+  test('AI tab shows the empty state when no model has played', async ({
+    page,
+  }) => {
+    await page.goto('/?seed=42');
+    await waitForGame(page);
+
+    await page.getByTestId('insights-tab-ai').click();
+    await expect(page.getByTestId('insights-tab-ai')).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+
+    // Seeded play makes no real AI calls, so the telemetry stays empty.
+    await expect(page.getByTestId('insights-ai-empty')).toBeVisible();
+    await expect(page.getByTestId('insights-ai-stats')).toHaveCount(0);
+  });
+});

--- a/packages/app/src/components/GameInsightsPanel.tsx
+++ b/packages/app/src/components/GameInsightsPanel.tsx
@@ -15,13 +15,16 @@ import { lazy, Suspense, useMemo, useState } from 'react';
 import { useProgressHistory } from '../hooks/useProgressHistory';
 import { shouldReduceMotion as checkReducedMotion } from '../utils/motion';
 import { ChartEmptyHint } from './charts/ChartEmptyHint';
+import StatStrip from './insights/StatStrip';
+import BoardShapeBars from './insights/BoardShapeBars';
+import AIStatsTab from './insights/AIStatsTab';
 
 // Nivo (and its d3 deps) is heavy; load the charts as a separate chunk so the
 // always-visible bar + stat chips paint without waiting on it.
 const ProgressChart = lazy(() => import('./charts/ProgressChart'));
 const CardFlowChart = lazy(() => import('./charts/CardFlowChart'));
 
-type InsightsTab = 'progress' | 'flow';
+type InsightsTab = 'progress' | 'flow' | 'board' | 'ai';
 
 /** Total face-down cards in a fresh Klondike deal. */
 const INITIAL_FACE_DOWN = 21;
@@ -104,6 +107,9 @@ const GameInsightsPanel: React.FC = () => {
         </span>
       </div>
 
+      {/* Box-score stat strip (elapsed, pace, recycles, efficiency, stuck) */}
+      <StatStrip history={history} />
+
       {!collapsed && (
         <>
           {/* Tab switcher (segmented control) */}
@@ -115,6 +121,8 @@ const GameInsightsPanel: React.FC = () => {
             {([
               { id: 'progress', label: 'Progress' },
               { id: 'flow', label: 'Card Flow' },
+              { id: 'board', label: 'Board' },
+              { id: 'ai', label: 'AI' },
             ] as const).map(({ id, label }) => (
               <button
                 key={id}
@@ -134,22 +142,35 @@ const GameInsightsPanel: React.FC = () => {
             ))}
           </div>
 
-          {/* Active chart */}
+          {/* Active chart / panel */}
           <div className="mt-2 h-52 w-full">
-            <Suspense fallback={<ChartEmptyHint />}>
-              {tab === 'progress' ? (
+            {tab === 'progress' && (
+              <Suspense fallback={<ChartEmptyHint />}>
                 <div
                   data-testid="insights-chart-progress"
                   className="h-full w-full"
                 >
                   <ProgressChart history={history} animate={animate} />
                 </div>
-              ) : (
+              </Suspense>
+            )}
+            {tab === 'flow' && (
+              <Suspense fallback={<ChartEmptyHint />}>
                 <div data-testid="insights-chart-flow" className="h-full w-full">
                   <CardFlowChart history={history} animate={animate} />
                 </div>
-              )}
-            </Suspense>
+              </Suspense>
+            )}
+            {tab === 'board' && (
+              <div data-testid="insights-chart-board" className="h-full w-full">
+                <BoardShapeBars />
+              </div>
+            )}
+            {tab === 'ai' && (
+              <div data-testid="insights-chart-ai" className="h-full w-full">
+                <AIStatsTab />
+              </div>
+            )}
           </div>
         </>
       )}

--- a/packages/app/src/components/insights/AIStatsTab.tsx
+++ b/packages/app/src/components/insights/AIStatsTab.tsx
@@ -1,0 +1,144 @@
+/**
+ * AIStatsTab — the "AI" tab: live telemetry for the model driving the game.
+ *
+ * Reads the interaction log (the same ring buffer the harvester exports),
+ * filtered to the current game session, and surfaces think-time, token burn,
+ * self-rated confidence, and the success/error/resigned tally. Updates while
+ * the AI auto-plays.
+ *
+ * The interaction log is a plain module buffer with no subscribe hook, so we
+ * poll it once a second while this tab is mounted — cheap, and only while the
+ * user is actually looking at this tab.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { useGameStore } from '../../store/gameStore';
+import { getAIInteractions } from '../../ai/interactionLog';
+import type { AIInteraction } from '../../ai/interactionLog';
+import { Sparkline } from './Sparkline';
+
+/** Compact large counts: 18234 → "18.2k". */
+function fmtNum(n: number): string {
+  if (n < 1000) return String(n);
+  return `${(n / 1000).toFixed(1)}k`;
+}
+
+/** One labelled telemetry cell. */
+const Cell: React.FC<{
+  testid: string;
+  label: string;
+  children: React.ReactNode;
+}> = ({ testid, label, children }) => (
+  <div
+    data-testid={testid}
+    className="flex flex-col gap-1 rounded-lg bg-gray-50 px-3 py-2"
+  >
+    <span className="text-[10px] uppercase tracking-wide text-gray-400">{label}</span>
+    {children}
+  </div>
+);
+
+const AIStatsTab: React.FC = () => {
+  const gameSessionId = useGameStore((s) => s.gameSessionId);
+  const aiThinking = useGameStore((s) => s.aiThinking);
+
+  // The log has no subscribe; poll while this tab is open so it stays live.
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const calls = useMemo<AIInteraction[]>(() => {
+    // `tick`/`aiThinking` are read only to re-run this memo as new rows land.
+    void tick;
+    void aiThinking;
+    return getAIInteractions().filter(
+      (i) =>
+        i.event === undefined && (!gameSessionId || i.sessionId === gameSessionId),
+    );
+  }, [gameSessionId, tick, aiThinking]);
+
+  if (calls.length === 0) {
+    return (
+      <div
+        data-testid="insights-ai-empty"
+        className="flex h-full items-center justify-center px-4 text-center text-xs text-gray-400"
+      >
+        No AI moves in this game yet — turn on AI auto-play to watch the model think.
+      </div>
+    );
+  }
+
+  const latencies = calls
+    .map((i) => i.durationMs)
+    .filter((d): d is number => Number.isFinite(d) && d > 0);
+  const avgLatencyMs =
+    latencies.length > 0
+      ? latencies.reduce((a, b) => a + b, 0) / latencies.length
+      : null;
+
+  const sum = (pick: (i: AIInteraction) => number | undefined) =>
+    calls.reduce((acc, i) => acc + (pick(i) ?? 0), 0);
+  const promptTokens = sum((i) => i.promptTokens);
+  const thoughtTokens = sum((i) => i.thoughtTokens);
+  const outputTokens = sum((i) => i.outputTokens);
+  const totalTokens =
+    sum((i) => i.totalTokens) || promptTokens + thoughtTokens + outputTokens;
+
+  const confidences = calls
+    .map((i) => i.decision?.confidence)
+    .filter((c): c is number => typeof c === 'number');
+  const lastConfidence =
+    confidences.length > 0 ? confidences[confidences.length - 1] : null;
+
+  const ok = calls.filter((i) => i.outcome === 'success').length;
+  const err = calls.filter((i) => i.outcome === 'error').length;
+  const resigned = calls.filter((i) => i.outcome === 'resigned').length;
+
+  return (
+    <div
+      data-testid="insights-ai-stats"
+      className="grid grid-cols-2 gap-2 text-gray-700"
+    >
+      <Cell testid="insights-ai-latency" label="Think time">
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-base font-bold tabular-nums">
+            {avgLatencyMs === null ? '—' : `${(avgLatencyMs / 1000).toFixed(1)}s`}
+          </span>
+          <Sparkline values={latencies} color="#f59e0b" />
+        </div>
+        <span className="text-[10px] text-gray-400">avg over {latencies.length} calls</span>
+      </Cell>
+
+      <Cell testid="insights-ai-tokens" label="Tokens">
+        <span className="text-base font-bold tabular-nums">{fmtNum(totalTokens)}</span>
+        <span className="text-[10px] text-gray-400 tabular-nums">
+          in {fmtNum(promptTokens)} · think {fmtNum(thoughtTokens)} · out{' '}
+          {fmtNum(outputTokens)}
+        </span>
+      </Cell>
+
+      <Cell testid="insights-ai-confidence" label="Confidence">
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-base font-bold tabular-nums">
+            {lastConfidence === null ? '—' : `${Math.round(lastConfidence * 100)}%`}
+          </span>
+          <Sparkline values={confidences} color="#10b981" min={0} max={1} />
+        </div>
+        <span className="text-[10px] text-gray-400">latest self-rating</span>
+      </Cell>
+
+      <Cell testid="insights-ai-outcomes" label="Outcomes">
+        <span className="text-base font-bold tabular-nums">{calls.length} moves</span>
+        <span className="text-[10px] text-gray-400 tabular-nums">
+          <span className="text-emerald-600">{ok} ok</span> ·{' '}
+          <span className="text-rose-600">{err} err</span> ·{' '}
+          <span className="text-amber-600">{resigned} resign</span>
+        </span>
+      </Cell>
+    </div>
+  );
+};
+
+export default AIStatsTab;

--- a/packages/app/src/components/insights/BoardShapeBars.tsx
+++ b/packages/app/src/components/insights/BoardShapeBars.tsx
@@ -1,0 +1,147 @@
+/**
+ * BoardShapeBars — the "Board" tab.
+ *
+ * A live, at-a-glance topology of the board: four foundation bars (each 0→13)
+ * and seven tableau column bars whose height tracks the pile size, split into a
+ * buried (face-down) base and a revealed (face-up) cap. Reads current state
+ * straight from the store, so it repaints on every move.
+ */
+
+import { useGameStore } from '../../store/gameStore';
+import type { Suit } from '../../types';
+
+const SUIT_META: { suit: Suit; glyph: string; color: string; track: string }[] = [
+  { suit: 'spades', glyph: '♠', color: 'bg-slate-700', track: 'bg-slate-100' },
+  { suit: 'hearts', glyph: '♥', color: 'bg-rose-500', track: 'bg-rose-100' },
+  { suit: 'diamonds', glyph: '♦', color: 'bg-rose-500', track: 'bg-rose-100' },
+  { suit: 'clubs', glyph: '♣', color: 'bg-slate-700', track: 'bg-slate-100' },
+];
+
+/** A foundation suit's progress, 0–13. */
+const FoundationBar: React.FC<{
+  suit: Suit;
+  glyph: string;
+  color: string;
+  track: string;
+  count: number;
+}> = ({ suit, glyph, color, track, count }) => (
+  <div className="flex flex-col items-center gap-1">
+    <div
+      data-testid={`insights-foundation-${suit}`}
+      role="img"
+      aria-label={`${suit} foundation: ${count} of 13`}
+      className={`relative w-5 h-28 rounded-md ${track} overflow-hidden flex flex-col justify-end`}
+    >
+      <div
+        className={`w-full ${color} transition-all duration-500 ease-out`}
+        style={{ height: `${(count / 13) * 100}%` }}
+      />
+    </div>
+    <span className="text-[11px] leading-none text-gray-500">{glyph}</span>
+    <span className="text-[11px] leading-none font-semibold tabular-nums text-gray-700">
+      {count}
+    </span>
+  </div>
+);
+
+/** One tableau column: buried (face-down) base + revealed (face-up) cap. */
+const ColumnBar: React.FC<{
+  index: number;
+  total: number;
+  buried: number;
+  maxTotal: number;
+}> = ({ index, total, buried, maxTotal }) => {
+  const faceUp = total - buried;
+  const fillPct = maxTotal > 0 ? (total / maxTotal) * 100 : 0;
+  const faceUpPct = total > 0 ? (faceUp / total) * 100 : 0;
+  const buriedPct = total > 0 ? (buried / total) * 100 : 0;
+
+  return (
+    <div className="flex flex-col items-center gap-1">
+      <div
+        data-testid={`insights-column-${index}`}
+        role="img"
+        aria-label={`Column ${index + 1}: ${total} cards, ${buried} face-down`}
+        className="relative w-5 h-28 rounded-md bg-gray-100 overflow-hidden flex flex-col justify-end"
+      >
+        <div
+          className="w-full flex flex-col transition-all duration-500 ease-out"
+          style={{ height: `${fillPct}%` }}
+        >
+          {/* Revealed cap on top, buried base below. */}
+          <div className="w-full bg-sky-400" style={{ height: `${faceUpPct}%` }} />
+          <div className="w-full bg-indigo-400" style={{ height: `${buriedPct}%` }} />
+        </div>
+      </div>
+      <span className="text-[11px] leading-none text-gray-400">{index + 1}</span>
+      <span className="text-[11px] leading-none font-semibold tabular-nums text-gray-700">
+        {total}
+      </span>
+    </div>
+  );
+};
+
+const BoardShapeBars: React.FC = () => {
+  const foundations = useGameStore((s) => s.foundations);
+  const tableau = useGameStore((s) => s.tableau);
+
+  const columns = tableau.map((column) => ({
+    total: column.length,
+    buried: column.reduce((n, card) => (card.faceUp ? n : n + 1), 0),
+  }));
+  const maxTotal = Math.max(1, ...columns.map((c) => c.total));
+
+  return (
+    <div
+      data-testid="insights-board-bars"
+      className="flex h-full items-start justify-center gap-5 pt-2"
+    >
+      {/* Foundations group */}
+      <div className="flex flex-col items-center gap-2">
+        <div className="flex items-end gap-2">
+          {SUIT_META.map(({ suit, glyph, color, track }) => (
+            <FoundationBar
+              key={suit}
+              suit={suit}
+              glyph={glyph}
+              color={color}
+              track={track}
+              count={foundations[suit].length}
+            />
+          ))}
+        </div>
+        <span className="text-[10px] uppercase tracking-wide text-gray-400">
+          Foundations
+        </span>
+      </div>
+
+      <div className="self-stretch w-px bg-gray-200" aria-hidden />
+
+      {/* Tableau group */}
+      <div className="flex flex-col items-center gap-2">
+        <div className="flex items-end gap-1.5">
+          {columns.map((c, i) => (
+            <ColumnBar
+              key={i}
+              index={i}
+              total={c.total}
+              buried={c.buried}
+              maxTotal={maxTotal}
+            />
+          ))}
+        </div>
+        <div className="flex items-center gap-3 text-[10px] text-gray-400">
+          <span className="uppercase tracking-wide">Tableau</span>
+          <span className="flex items-center gap-1">
+            <span className="inline-block w-2 h-2 rounded-sm bg-indigo-400" /> buried
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="inline-block w-2 h-2 rounded-sm bg-sky-400" /> up
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BoardShapeBars;

--- a/packages/app/src/components/insights/Sparkline.tsx
+++ b/packages/app/src/components/insights/Sparkline.tsx
@@ -1,0 +1,69 @@
+/**
+ * Sparkline — a tiny inline-SVG trend line for the AI stats tab.
+ *
+ * Deliberately *not* a Nivo chart: these are thumbnail-sized trends (latency,
+ * confidence) where a 200 KB charting dep would be absurd. The two hero charts
+ * (Progress, Card Flow) keep using Nivo; this stays a few lines of SVG.
+ */
+
+interface SparklineProps {
+  /** The series to draw, oldest → newest. */
+  values: number[];
+  /** Stroke colour. */
+  color?: string;
+  width?: number;
+  height?: number;
+  /** Fixed lower bound for the y-scale (otherwise auto from the data). */
+  min?: number;
+  /** Fixed upper bound for the y-scale (otherwise auto from the data). */
+  max?: number;
+}
+
+export const Sparkline: React.FC<SparklineProps> = ({
+  values,
+  color = '#16a34a',
+  width = 84,
+  height = 24,
+  min,
+  max,
+}) => {
+  if (values.length < 2) {
+    return <span className="text-gray-300 text-[11px]">—</span>;
+  }
+
+  const lo = min ?? Math.min(...values);
+  const hi = max ?? Math.max(...values);
+  const span = hi - lo || 1;
+  // Inset by 2px so the stroke and the end dot never clip the viewBox edge.
+  const pad = 2;
+  const plotW = width - pad * 2;
+  const plotH = height - pad * 2;
+
+  const points = values.map((v, i) => {
+    const x = pad + (values.length === 1 ? 0 : (i / (values.length - 1)) * plotW);
+    const y = pad + plotH - ((v - lo) / span) * plotH;
+    return [x, y] as const;
+  });
+
+  const last = points[points.length - 1];
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className="overflow-visible"
+      aria-hidden
+    >
+      <polyline
+        points={points.map(([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`).join(' ')}
+        fill="none"
+        stroke={color}
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+      <circle cx={last[0]} cy={last[1]} r={2} fill={color} />
+    </svg>
+  );
+};

--- a/packages/app/src/components/insights/StatStrip.tsx
+++ b/packages/app/src/components/insights/StatStrip.tsx
@@ -1,0 +1,101 @@
+/**
+ * StatStrip — the "box score" row under the progress bar.
+ *
+ * A compact strip of live, derived stats for the number-watcher: elapsed time,
+ * move pace, stock recycles, move efficiency, and a "stuck-o-meter" (moves
+ * since the last bit of progress). Everything is reconstructed from the
+ * progress series plus two store fields — no new state.
+ *
+ * The 1-second clock lives here, local to this subtree, so the ticking elapsed
+ * time never re-renders the (expensive) Nivo charts above it.
+ */
+
+import { useEffect, useState } from 'react';
+import { useGameStore } from '../../store/gameStore';
+import type { ProgressSnapshot } from '../../hooks/useProgressHistory';
+import { computeGameStats, computePace, formatElapsed } from './computeStats';
+
+interface StatStripProps {
+  history: ProgressSnapshot[];
+}
+
+/** One stat pill. */
+const Chip: React.FC<{
+  testid: string;
+  className?: string;
+  title?: string;
+  children: React.ReactNode;
+}> = ({ testid, className = 'bg-gray-100 text-gray-600', title, children }) => (
+  <span
+    data-testid={testid}
+    title={title}
+    className={`px-2 py-0.5 rounded-full tabular-nums ${className}`}
+  >
+    {children}
+  </span>
+);
+
+const StatStrip: React.FC<StatStripProps> = ({ history }) => {
+  const gameStartedAt = useGameStore((s) => s.gameStartedAt);
+  const recycleCount = useGameStore((s) => s.recycleCount) ?? 0;
+  const gameWon = useGameStore((s) => s.gameWon);
+
+  // Local ticking clock; freezes when the game is won so the final time sticks.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (gameWon) return;
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [gameWon]);
+
+  const stats = computeGameStats(history);
+  const elapsedMs = gameStartedAt ? Math.max(0, now - gameStartedAt) : 0;
+  const pace = computePace(stats.moves, elapsedMs);
+
+  const stuck = stats.movesSinceProgress;
+  const stuckClass =
+    stuck === 0
+      ? 'bg-emerald-100 text-emerald-700'
+      : stuck >= 10
+        ? 'bg-rose-100 text-rose-700'
+        : stuck >= 5
+          ? 'bg-amber-100 text-amber-700'
+          : 'bg-gray-100 text-gray-600';
+
+  return (
+    <div
+      data-testid="insights-stat-strip"
+      className="mt-2 flex flex-wrap gap-2 text-[11px] font-medium"
+    >
+      <Chip testid="insights-stat-time" title="Elapsed time">
+        ⏱ {formatElapsed(elapsedMs)}
+      </Chip>
+      <Chip testid="insights-stat-pace" title="Moves per minute">
+        {pace ?? '—'} <span className="text-gray-400">moves/min</span>
+      </Chip>
+      <Chip
+        testid="insights-stat-recycles"
+        className="bg-violet-100 text-violet-700"
+        title="Times the waste pile has been recycled into the stock"
+      >
+        ↻ {recycleCount} {recycleCount === 1 ? 'recycle' : 'recycles'}
+      </Chip>
+      <Chip
+        testid="insights-stat-efficiency"
+        className="bg-sky-100 text-sky-700"
+        title="Share of moves that revealed a card or sent one home"
+      >
+        ⚡ {stats.efficiencyPct === null ? '—' : `${stats.efficiencyPct}%`} efficient
+      </Chip>
+      <Chip
+        testid="insights-stat-stuck"
+        className={stuckClass}
+        title="Consecutive moves with no progress"
+      >
+        {stuck === 0 ? '✓ flowing' : `⚠ ${stuck} since gain`}
+      </Chip>
+    </div>
+  );
+};
+
+export default StatStrip;

--- a/packages/app/src/components/insights/computeStats.test.ts
+++ b/packages/app/src/components/insights/computeStats.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeGameStats,
+  computePace,
+  formatElapsed,
+} from './computeStats';
+import type { ProgressSnapshot } from '../../hooks/useProgressHistory';
+
+/** Build a snapshot with sensible defaults; override only what a test cares about. */
+function snap(p: Partial<ProgressSnapshot> & { move: number }): ProgressSnapshot {
+  return {
+    move: p.move,
+    stock: p.stock ?? 24,
+    waste: p.waste ?? 0,
+    faceDown: p.faceDown ?? 21,
+    faceUp: p.faceUp ?? 7,
+    foundations: p.foundations ?? 0,
+    progress: p.progress ?? 0,
+  };
+}
+
+describe('computeGameStats', () => {
+  it('returns zeros and a null efficiency for a fresh deal (single baseline point)', () => {
+    const stats = computeGameStats([snap({ move: 0 })]);
+    expect(stats).toEqual({
+      moves: 0,
+      transitions: 0,
+      productiveMoves: 0,
+      efficiencyPct: null,
+      movesSinceProgress: 0,
+      drawMoves: 0,
+    });
+  });
+
+  it('handles an empty history without throwing', () => {
+    expect(computeGameStats([])).toMatchObject({ moves: 0, transitions: 0 });
+  });
+
+  it('counts a revealed face-down card as a productive move', () => {
+    const stats = computeGameStats([
+      snap({ move: 0, faceDown: 21 }),
+      snap({ move: 1, faceDown: 20 }), // revealed one
+    ]);
+    expect(stats.productiveMoves).toBe(1);
+    expect(stats.efficiencyPct).toBe(100);
+    expect(stats.movesSinceProgress).toBe(0);
+  });
+
+  it('counts a card banked to a foundation as a productive move', () => {
+    const stats = computeGameStats([
+      snap({ move: 0, foundations: 0 }),
+      snap({ move: 1, foundations: 1 }), // banked one
+    ]);
+    expect(stats.productiveMoves).toBe(1);
+    expect(stats.efficiencyPct).toBe(100);
+  });
+
+  it('treats a pure draw (stock shrinks, no reveal/bank) as unproductive and counts it as a draw', () => {
+    const stats = computeGameStats([
+      snap({ move: 0, stock: 24, waste: 0 }),
+      snap({ move: 1, stock: 23, waste: 1 }), // drew one, nothing revealed
+    ]);
+    expect(stats.productiveMoves).toBe(0);
+    expect(stats.drawMoves).toBe(1);
+    expect(stats.efficiencyPct).toBe(0);
+    expect(stats.movesSinceProgress).toBe(1);
+  });
+
+  it('tracks the trailing stuck streak and resets it on the next productive move', () => {
+    const history = [
+      snap({ move: 0, foundations: 0, faceDown: 21 }),
+      snap({ move: 1, foundations: 1, faceDown: 21 }), // productive
+      snap({ move: 2, stock: 23, waste: 1 }), // draw — stuck 1
+      snap({ move: 3, stock: 22, waste: 2 }), // draw — stuck 2
+      snap({ move: 4, stock: 21, waste: 3 }), // draw — stuck 3
+    ];
+    expect(computeGameStats(history).movesSinceProgress).toBe(3);
+
+    const recovered = [...history, snap({ move: 5, foundations: 2, faceDown: 21 })];
+    expect(computeGameStats(recovered).movesSinceProgress).toBe(0);
+  });
+
+  it('computes efficiency as productive / total transitions', () => {
+    const stats = computeGameStats([
+      snap({ move: 0, foundations: 0, faceDown: 21, stock: 24, waste: 0 }),
+      snap({ move: 1, foundations: 0, faceDown: 20, stock: 24, waste: 0 }), // reveal (productive)
+      snap({ move: 2, foundations: 0, faceDown: 20, stock: 23, waste: 1 }), // draw (not)
+      snap({ move: 3, foundations: 1, faceDown: 20, stock: 23, waste: 0 }), // bank (productive)
+      snap({ move: 4, foundations: 1, faceDown: 20, stock: 22, waste: 1 }), // draw (not)
+    ]);
+    expect(stats.transitions).toBe(4);
+    expect(stats.productiveMoves).toBe(2);
+    expect(stats.efficiencyPct).toBe(50);
+    expect(stats.drawMoves).toBe(2);
+    expect(stats.moves).toBe(4);
+  });
+});
+
+describe('formatElapsed', () => {
+  it('formats minutes and zero-padded seconds', () => {
+    expect(formatElapsed(0)).toBe('0:00');
+    expect(formatElapsed(9_000)).toBe('0:09');
+    expect(formatElapsed(84_000)).toBe('1:24');
+    expect(formatElapsed(605_000)).toBe('10:05');
+  });
+
+  it('clamps negative input to zero', () => {
+    expect(formatElapsed(-500)).toBe('0:00');
+  });
+});
+
+describe('computePace', () => {
+  it('returns moves per minute once enough time has elapsed', () => {
+    expect(computePace(42, 84_000)).toBe(30); // 42 moves in 1.4 min ≈ 30/min
+  });
+
+  it('returns null at t≈0 to avoid a divide-by-near-zero spike', () => {
+    expect(computePace(5, 100)).toBeNull();
+  });
+
+  it('returns null when no moves have been made', () => {
+    expect(computePace(0, 60_000)).toBeNull();
+  });
+});

--- a/packages/app/src/components/insights/computeStats.ts
+++ b/packages/app/src/components/insights/computeStats.ts
@@ -1,0 +1,95 @@
+/**
+ * Derived "box-score" stats for the Game Insights stat strip.
+ *
+ * Pure functions over the per-move {@link ProgressSnapshot} series, so they are
+ * trivially unit-testable and carry no React/store coupling. Everything here is
+ * reconstructable from the snapshot history — no new store fields needed.
+ *
+ * @module components/insights/computeStats
+ */
+
+import type { ProgressSnapshot } from '../../hooks/useProgressHistory';
+
+/** Box-score stats derived from the progress series. */
+export interface GameStats {
+  /** Latest move number in the series. */
+  moves: number;
+  /** Number of move transitions (one less than the snapshot count). */
+  transitions: number;
+  /** Transitions that revealed a face-down card or sent a card home. */
+  productiveMoves: number;
+  /**
+   * Productive moves as a 0–100 integer (`productiveMoves / transitions`).
+   * `null` when there are no transitions yet (a fresh deal) — callers render
+   * a dash rather than a misleading 0%.
+   */
+  efficiencyPct: number | null;
+  /** Consecutive trailing moves that made no progress (the "stuck-o-meter"). */
+  movesSinceProgress: number;
+  /** Transitions that drew a card from the stock (stock shrank). */
+  drawMoves: number;
+}
+
+/** Did this transition make real progress (reveal a card or bank one home)? */
+function isProductive(prev: ProgressSnapshot, next: ProgressSnapshot): boolean {
+  const banked = next.foundations > prev.foundations;
+  const revealed = next.faceDown < prev.faceDown;
+  return banked || revealed;
+}
+
+/**
+ * Compute the box-score stats for a progress series. Safe on an empty or
+ * single-point history (a fresh deal): returns zeros and a `null` efficiency.
+ */
+export function computeGameStats(history: ProgressSnapshot[]): GameStats {
+  const moves = history.length > 0 ? history[history.length - 1].move : 0;
+  const transitions = Math.max(0, history.length - 1);
+
+  let productiveMoves = 0;
+  let drawMoves = 0;
+  let movesSinceProgress = 0;
+
+  for (let i = 1; i < history.length; i += 1) {
+    const prev = history[i - 1];
+    const next = history[i];
+
+    if (isProductive(prev, next)) {
+      productiveMoves += 1;
+      movesSinceProgress = 0;
+    } else {
+      movesSinceProgress += 1;
+    }
+
+    if (next.stock < prev.stock) drawMoves += 1;
+  }
+
+  const efficiencyPct =
+    transitions > 0 ? Math.round((productiveMoves / transitions) * 100) : null;
+
+  return {
+    moves,
+    transitions,
+    productiveMoves,
+    efficiencyPct,
+    movesSinceProgress,
+    drawMoves,
+  };
+}
+
+/** Format an elapsed-millisecond duration as `M:SS`. */
+export function formatElapsed(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = String(totalSeconds % 60).padStart(2, '0');
+  return `${minutes}:${seconds}`;
+}
+
+/**
+ * Moves-per-minute pace, or `null` when too little time has elapsed for the
+ * figure to be meaningful (avoids a divide-by-near-zero spike at t≈0).
+ */
+export function computePace(moves: number, elapsedMs: number): number | null {
+  const elapsedMinutes = elapsedMs / 60_000;
+  if (moves <= 0 || elapsedMinutes < 0.05) return null;
+  return Math.round(moves / elapsedMinutes);
+}


### PR DESCRIPTION
Three "stat nerd" additions to the **Game Insights** panel, all derived from data the store already exposes — no new store fields, and the two Nivo hero charts are untouched.

## What's new

**Box-score stat strip** (always visible, under the progress bar)
- ⏱ live elapsed time · moves/min pace · ↻ stock recycles · ⚡ move efficiency · ⚠ "stuck-o-meter" (consecutive moves with no progress, colour-graded grey→amber→rose)
- The 1-second clock lives in its own subtree, so the ticking time never re-renders the charts.
- All derivations live in a pure, unit-tested `computeStats` module.

**Board tab** — live board topology
- Four foundation bars (0→13) and seven tableau column bars, each split into a buried (face-down) base and a revealed (face-up) cap. The classic Klondike staircase, live.

**AI tab** — per-session model telemetry from the interaction log
- Think-time (avg + sparkline), token burn (prompt/thinking/output), self-rated confidence, and the success/error/resigned tally.
- The log has no subscribe hook, so the tab polls once a second while mounted; shows an empty state until a model has played.

Sparklines are lightweight inline SVG — the two hero charts keep Nivo.

## Testing
- `computeStats`: 12 new unit tests (efficiency, stuck-streak, draws, edge cases) — full suite 364 passing.
- e2e: 4 new tests — stat strip on a fresh deal, stat strip after unproductive draws, Board tab bars, AI tab empty state — `insights.spec.ts` 8 passing.
- Lint clean; production build clean (main chunk +~9.5 KB, no size warning; Nivo stays in its own chunks).
- Board tab and stat strip visually verified headless.