### PR TITLE
perf(insights): replace Nivo with ECharts to fix live-chart lag on long games

### DIFF
--- a/packages/app/e2e/insights.spec.ts
+++ b/packages/app/e2e/insights.spec.ts
@@ -44,7 +44,7 @@ test.describe('Game Insights panel', () => {
     // Dismiss the win modal (keeps game state) and confirm the chart drew.
     await page.getByTestId('win-modal-close-btn').click();
     await expect(
-      page.getByTestId('insights-chart-progress').locator('svg'),
+      page.getByTestId('insights-chart-progress').locator('canvas'),
     ).toBeVisible();
   });
 
@@ -63,7 +63,7 @@ test.describe('Game Insights panel', () => {
       'true',
     );
     await expect(
-      page.getByTestId('insights-chart-progress').locator('svg'),
+      page.getByTestId('insights-chart-progress').locator('canvas'),
     ).toBeVisible();
 
     // Switch to Card Flow.
@@ -73,7 +73,7 @@ test.describe('Game Insights panel', () => {
       'true',
     );
     await expect(
-      page.getByTestId('insights-chart-flow').locator('svg'),
+      page.getByTestId('insights-chart-flow').locator('canvas'),
     ).toBeVisible();
     await expect(page.getByTestId('insights-chart-progress')).toHaveCount(0);
   });
@@ -182,5 +182,34 @@ test.describe('Game Insights — stats, board & AI', () => {
     // Seeded play makes no real AI calls, so the telemetry stays empty.
     await expect(page.getByTestId('insights-ai-empty')).toBeVisible();
     await expect(page.getByTestId('insights-ai-stats')).toHaveCount(0);
+  });
+
+  test('stays responsive on a long game — both canvas charts still render at scale', async ({
+    page,
+  }) => {
+    await page.goto('/?seed=42');
+    await waitForGame(page);
+
+    // Drive a long game: hundreds of draws at the scale that froze the old SVG
+    // charts. The ECharts canvas charts render the full-resolution series, so
+    // this must not crash or hang.
+    await page.evaluate(() => {
+      for (let i = 0; i < 240; i += 1) window.__solitaire!.draw();
+    });
+
+    const movesText = await page.getByTestId('insights-stat-moves').textContent();
+    const moves = Number.parseInt(movesText ?? '0', 10);
+    expect(moves).toBeGreaterThan(160);
+
+    // Progress chart draws to a <canvas>.
+    await expect(
+      page.getByTestId('insights-chart-progress').locator('canvas'),
+    ).toBeVisible();
+
+    // And so does the streamgraph.
+    await page.getByTestId('insights-tab-flow').click();
+    await expect(
+      page.getByTestId('insights-chart-flow').locator('canvas'),
+    ).toBeVisible();
   });
 });

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -19,9 +19,8 @@
   "dependencies": {
     "@chayuto/solitaire-core": "workspace:*",
     "@dnd-kit/core": "^6.3.1",
-    "@nivo/core": "0.99.0",
-    "@nivo/line": "0.99.0",
-    "@nivo/stream": "0.99.0",
+    "echarts": "^6.1.0",
+    "echarts-for-react": "^3.0.6",
     "framer-motion": "^12.38.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",

--- a/packages/app/src/components/GameInsightsPanel.tsx
+++ b/packages/app/src/components/GameInsightsPanel.tsx
@@ -11,7 +11,7 @@
  * collapsed; collapsing only hides the tabs + chart, never the live bar.
  */
 
-import { lazy, Suspense, useMemo, useState } from 'react';
+import { lazy, Suspense, useDeferredValue, useMemo, useState } from 'react';
 import { useProgressHistory } from '../hooks/useProgressHistory';
 import { shouldReduceMotion as checkReducedMotion } from '../utils/motion';
 import { ChartEmptyHint } from './charts/ChartEmptyHint';
@@ -32,6 +32,13 @@ const INITIAL_FACE_DOWN = 21;
 const GameInsightsPanel: React.FC = () => {
   const history = useProgressHistory();
   const animate = useMemo(() => !checkReducedMotion(), []);
+
+  // The live bar + stat chips read `history` directly (cheap, instant). The
+  // heavy charts read a DEFERRED copy so a move's urgent work — the card moving
+  // and its flip animation — commits first and the chart re-renders after, at
+  // low priority. During a fast auto-play this also coalesces rapid moves into
+  // far fewer chart renders (React drops superseded deferred values).
+  const chartHistory = useDeferredValue(history);
 
   const [collapsed, setCollapsed] = useState(false);
   const [tab, setTab] = useState<InsightsTab>('progress');
@@ -150,14 +157,14 @@ const GameInsightsPanel: React.FC = () => {
                   data-testid="insights-chart-progress"
                   className="h-full w-full"
                 >
-                  <ProgressChart history={history} animate={animate} />
+                  <ProgressChart history={chartHistory} animate={animate} />
                 </div>
               </Suspense>
             )}
             {tab === 'flow' && (
               <Suspense fallback={<ChartEmptyHint />}>
                 <div data-testid="insights-chart-flow" className="h-full w-full">
-                  <CardFlowChart history={history} animate={animate} />
+                  <CardFlowChart history={chartHistory} animate={animate} />
                 </div>
               </Suspense>
             )}

--- a/packages/app/src/components/charts/CardFlowChart.tsx
+++ b/packages/app/src/components/charts/CardFlowChart.tsx
@@ -3,75 +3,100 @@
  *
  * A streamgraph of where all 52 cards live, move by move: they flow from the
  * stock, through the waste and tableau, and pool into the foundations. The
- * foundations band swells to fill the whole height at a win. Mesmerising to
- * watch while the AI auto-plays.
+ * foundations band swells to fill the whole height at a win.
+ *
+ * Canvas-rendered via ECharts ThemeRiver (a silhouette streamgraph). A live
+ * chart re-renders every move; an SVG chart lib reconciles a large DOM tree each
+ * time (~320ms at a long game's scale, which froze the UI during auto-play).
+ * Canvas redraws in one pass, so the full-resolution stream stays smooth.
  */
 
-import { ResponsiveStream } from '@nivo/stream';
+import { memo, useMemo } from 'react';
+// ESM core build, NOT `lib/core` (CJS) — see the note in ProgressChart: the CJS
+// interop crashes the prod bundle with React error #130.
+import ReactEChartsCore from 'echarts-for-react/esm/core';
+import * as echarts from 'echarts/core';
+import { ThemeRiverChart } from 'echarts/charts';
+import { SingleAxisComponent, LegendComponent } from 'echarts/components';
+import { CanvasRenderer } from 'echarts/renderers';
+import type { EChartsOption } from 'echarts';
 import type { ProgressSnapshot } from '../../hooks/useProgressHistory';
 import { ChartEmptyHint } from './ChartEmptyHint';
 
+echarts.use([ThemeRiverChart, SingleAxisComponent, LegendComponent, CanvasRenderer]);
+
+/** Stream bands, bottom-to-top, with their colours. */
+const ZONES = [
+  { key: 'Stock', color: '#94a3b8', value: (p: ProgressSnapshot) => p.stock },
+  { key: 'Waste', color: '#fbbf24', value: (p: ProgressSnapshot) => p.waste },
+  { key: 'Face-down', color: '#6366f1', value: (p: ProgressSnapshot) => p.faceDown },
+  { key: 'Face-up', color: '#38bdf8', value: (p: ProgressSnapshot) => p.faceUp },
+  { key: 'Foundations', color: '#34d399', value: (p: ProgressSnapshot) => p.foundations },
+] as const;
+
 interface CardFlowChartProps {
   history: ProgressSnapshot[];
+  /** Kept for API parity; live updates are instant (animation off). */
   animate: boolean;
 }
 
-/** Stream keys, stacked bottom-to-top, with their band colours. */
-const ZONES = [
-  { key: 'Stock', color: '#94a3b8' },
-  { key: 'Waste', color: '#fbbf24' },
-  { key: 'Face-down', color: '#6366f1' },
-  { key: 'Face-up', color: '#38bdf8' },
-  { key: 'Foundations', color: '#34d399' },
-] as const;
+const CardFlowChart: React.FC<CardFlowChartProps> = ({ history }) => {
+  const option = useMemo<EChartsOption>(() => {
+    // ThemeRiver wants flat [x, value, band] triples, grouped by band so the
+    // layer (and colour) order is deterministic.
+    const data: [number, number, string][] = [];
+    for (const z of ZONES) {
+      for (const p of history) data.push([p.move, z.value(p), z.key]);
+    }
+    const maxMove = history.length > 0 ? history[history.length - 1].move : 0;
 
-const KEYS = ZONES.map((z) => z.key);
-const COLORS = ZONES.map((z) => z.color);
+    return {
+      animation: false,
+      color: ZONES.map((z) => z.color),
+      legend: {
+        data: ZONES.map((z) => z.key),
+        bottom: 0,
+        itemWidth: 10,
+        itemHeight: 10,
+        textStyle: { color: '#6b7280', fontSize: 10 },
+      },
+      singleAxis: {
+        type: 'value',
+        min: 0,
+        max: maxMove || 'dataMax',
+        top: 8,
+        bottom: 30,
+        left: 8,
+        right: 8,
+        axisLabel: { show: false },
+        axisTick: { show: false },
+        axisLine: { show: false },
+        splitLine: { show: false },
+      },
+      series: [
+        {
+          type: 'themeRiver',
+          emphasis: { focus: 'series' },
+          label: { show: false },
+          itemStyle: { opacity: 0.9 },
+          data,
+        },
+      ],
+    };
+  }, [history]);
 
-const CardFlowChart: React.FC<CardFlowChartProps> = ({ history, animate }) => {
   if (history.length < 2) return <ChartEmptyHint />;
 
-  const data = history.map((p) => ({
-    Stock: p.stock,
-    Waste: p.waste,
-    'Face-down': p.faceDown,
-    'Face-up': p.faceUp,
-    Foundations: p.foundations,
-  }));
-
   return (
-    <ResponsiveStream
-      data={data}
-      keys={KEYS}
-      colors={COLORS}
-      margin={{ top: 12, right: 16, bottom: 16, left: 16 }}
-      offsetType="silhouette"
-      order="none"
-      curve="basis"
-      fillOpacity={0.88}
-      borderWidth={1}
-      borderColor={{ theme: 'background' }}
-      enableGridX={false}
-      enableGridY={false}
-      axisBottom={null}
-      axisLeft={null}
-      animate={animate}
-      motionConfig="gentle"
-      legends={[
-        {
-          anchor: 'bottom',
-          direction: 'row',
-          translateY: 14,
-          itemWidth: 78,
-          itemHeight: 14,
-          itemTextColor: '#6b7280',
-          symbolSize: 10,
-          symbolShape: 'circle',
-        },
-      ]}
-      theme={{ text: { fill: '#6b7280', fontSize: 10 } }}
+    <ReactEChartsCore
+      echarts={echarts}
+      option={option}
+      notMerge
+      lazyUpdate
+      style={{ height: '100%', width: '100%' }}
+      opts={{ renderer: 'canvas' }}
     />
   );
 };
 
-export default CardFlowChart;
+export default memo(CardFlowChart);

--- a/packages/app/src/components/charts/ProgressChart.tsx
+++ b/packages/app/src/components/charts/ProgressChart.tsx
@@ -1,93 +1,123 @@
 /**
  * ProgressChart — Game Insights tab #1.
  *
- * Move number (x) versus progress % (y). Two gradient-filled series: the
+ * Move number (x) versus progress % (y): two gradient-filled series — the
  * blended progress score (the hero) and the foundations-home percentage (the
- * win number). Both climb left-to-right as the game — or the AI auto-player —
+ * win number) — that climb left-to-right as the game (or the AI auto-player)
  * makes moves.
+ *
+ * Canvas-rendered via ECharts (tree-shaken core). A live chart re-renders every
+ * move; an SVG chart lib reconciles a large DOM tree each time (~235ms at a long
+ * game's scale, which froze the UI during auto-play). Canvas redraws in one pass
+ * (~single-digit ms), so the full-resolution series stays smooth.
  */
 
-import { ResponsiveLine } from '@nivo/line';
-import { linearGradientDef } from '@nivo/core';
+import { memo, useMemo } from 'react';
+// Import the ESM core build, NOT `echarts-for-react/lib/core` (CJS): the CJS
+// default-import interop resolves to the module namespace object in the prod
+// bundle, which React renders as an invalid element type (error #130) and
+// crashes the panel. Keep this on `esm/core`.
+import ReactEChartsCore from 'echarts-for-react/esm/core';
+import * as echarts from 'echarts/core';
+import { LineChart } from 'echarts/charts';
+import { GridComponent } from 'echarts/components';
+import { CanvasRenderer } from 'echarts/renderers';
+import type { EChartsOption } from 'echarts';
 import type { ProgressSnapshot } from '../../hooks/useProgressHistory';
 import { ChartEmptyHint } from './ChartEmptyHint';
 
+echarts.use([LineChart, GridComponent, CanvasRenderer]);
+
+/** A vertical fade from `color` (top) to transparent (baseline). */
+function areaFade(r: number, g: number, b: number, topAlpha: number) {
+  return {
+    type: 'linear' as const,
+    x: 0,
+    y: 0,
+    x2: 0,
+    y2: 1,
+    colorStops: [
+      { offset: 0, color: `rgba(${r},${g},${b},${topAlpha})` },
+      { offset: 1, color: `rgba(${r},${g},${b},0)` },
+    ],
+  };
+}
+
 interface ProgressChartProps {
   history: ProgressSnapshot[];
+  /** Kept for API parity; live updates are instant (animation off). */
   animate: boolean;
 }
 
-const ProgressChart: React.FC<ProgressChartProps> = ({ history, animate }) => {
+const ProgressChart: React.FC<ProgressChartProps> = ({ history }) => {
+  const option = useMemo<EChartsOption>(() => {
+    const maxMove = history.length > 0 ? history[history.length - 1].move : 0;
+    return {
+      animation: false,
+      grid: { top: 10, right: 10, bottom: 26, left: 34 },
+      xAxis: {
+        type: 'value',
+        min: 0,
+        max: maxMove || 'dataMax',
+        name: 'move',
+        nameLocation: 'middle',
+        nameGap: 18,
+        nameTextStyle: { color: '#9ca3af', fontSize: 10 },
+        axisLine: { show: false },
+        axisTick: { show: false },
+        axisLabel: { color: '#9ca3af', fontSize: 10 },
+        splitLine: { show: false },
+      },
+      yAxis: {
+        type: 'value',
+        min: 0,
+        max: 100,
+        interval: 25,
+        axisLine: { show: false },
+        axisTick: { show: false },
+        axisLabel: { color: '#9ca3af', fontSize: 10, formatter: '{value}%' },
+        splitLine: {
+          lineStyle: { color: '#e5e7eb', type: 'dashed' },
+        },
+      },
+      series: [
+        {
+          name: 'Progress',
+          type: 'line',
+          showSymbol: false,
+          smooth: true,
+          lineStyle: { width: 2.5, color: '#22c55e' },
+          areaStyle: { color: areaFade(34, 197, 94, 0.55), origin: 'start' },
+          data: history.map((p) => [p.move, p.progress]),
+        },
+        {
+          name: 'Foundations',
+          type: 'line',
+          showSymbol: false,
+          smooth: true,
+          lineStyle: { width: 2.5, color: '#f59e0b' },
+          areaStyle: { color: areaFade(245, 158, 11, 0.45), origin: 'start' },
+          data: history.map((p) => [
+            p.move,
+            Math.round((p.foundations / 52) * 100),
+          ]),
+        },
+      ],
+    };
+  }, [history]);
+
   if (history.length < 2) return <ChartEmptyHint />;
 
-  const data = [
-    {
-      id: 'Progress',
-      color: '#22c55e',
-      data: history.map((p) => ({ x: p.move, y: p.progress })),
-    },
-    {
-      id: 'Foundations',
-      color: '#f59e0b',
-      data: history.map((p) => ({
-        x: p.move,
-        y: Math.round((p.foundations / 52) * 100),
-      })),
-    },
-  ];
-
   return (
-    <ResponsiveLine
-      data={data}
-      colors={{ datum: 'color' }}
-      margin={{ top: 12, right: 16, bottom: 32, left: 36 }}
-      xScale={{ type: 'linear', min: 0, max: 'auto' }}
-      yScale={{ type: 'linear', min: 0, max: 100 }}
-      curve="monotoneX"
-      enableArea
-      areaOpacity={1}
-      defs={[
-        linearGradientDef('progressFill', [
-          { offset: 0, color: '#22c55e', opacity: 0.55 },
-          { offset: 100, color: '#22c55e', opacity: 0 },
-        ]),
-        linearGradientDef('foundationsFill', [
-          { offset: 0, color: '#f59e0b', opacity: 0.45 },
-          { offset: 100, color: '#f59e0b', opacity: 0 },
-        ]),
-      ]}
-      fill={[
-        { match: { id: 'Progress' }, id: 'progressFill' },
-        { match: { id: 'Foundations' }, id: 'foundationsFill' },
-      ]}
-      lineWidth={2.5}
-      enablePoints={false}
-      enableGridX={false}
-      gridYValues={[0, 25, 50, 75, 100]}
-      axisLeft={{
-        tickValues: [0, 25, 50, 75, 100],
-        format: (v) => `${v}%`,
-        tickSize: 0,
-        tickPadding: 6,
-      }}
-      axisBottom={{
-        legend: 'move',
-        legendOffset: 26,
-        legendPosition: 'middle',
-        tickSize: 0,
-        tickPadding: 6,
-      }}
-      enableSlices="x"
-      useMesh
-      animate={animate}
-      motionConfig="gentle"
-      theme={{
-        text: { fill: '#6b7280', fontSize: 10 },
-        grid: { line: { stroke: '#e5e7eb', strokeDasharray: '2 4' } },
-        crosshair: { line: { stroke: '#16a34a', strokeWidth: 1 } },
-      }}
+    <ReactEChartsCore
+      echarts={echarts}
+      option={option}
+      notMerge
+      lazyUpdate
+      style={{ height: '100%', width: '100%' }}
+      opts={{ renderer: 'canvas' }}
     />
   );
 };
 
-export default ProgressChart;
+export default memo(ProgressChart);

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -35,6 +35,32 @@ export default defineConfig(({ mode }) => {
       __COMMIT_HASH__: JSON.stringify(getBuildInfo().commitHash),
       __DEV_GEMINI_KEY__: JSON.stringify(devGeminiKey),
     },
+    build: {
+      // The `echarts` chunk below is a deliberately large vendor bundle that is
+      // lazy-loaded only when the Insights charts open — it never touches the
+      // eager entry path — so its size shouldn't trip the default 500 kB warning.
+      chunkSizeWarningLimit: 600,
+      rollupOptions: {
+        output: {
+          // ECharts (canvas chart lib + its zrender dep) is the heavy,
+          // lazy-loaded chart vendor bundle shared by ProgressChart and
+          // CardFlowChart. Pin it to a stable `echarts` chunk name so the build
+          // output stays honest regardless of which tiny app module Rollup
+          // happens to pick as the shared chunk's namesake. Referenced only by
+          // the lazy charts, so it stays out of the eager entry bundle.
+          manualChunks(id: string) {
+            if (
+              id.includes('node_modules/echarts/') ||
+              id.includes('node_modules/echarts-for-react/') ||
+              id.includes('node_modules/zrender/')
+            ) {
+              return 'echarts';
+            }
+            return undefined;
+          },
+        },
+      },
+    },
     test: {
       globals: true,
       environment: 'jsdom',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,15 +16,12 @@ importers:
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@nivo/core':
-        specifier: 0.99.0
-        version: 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@nivo/line':
-        specifier: 0.99.0
-        version: 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@nivo/stream':
-        specifier: 0.99.0
-        version: 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      echarts:
+        specifier: ^6.1.0
+        version: 6.1.0
+      echarts-for-react:
+        specifier: ^3.0.6
+        version: 3.0.6(echarts@6.1.0)(react@19.2.5)
       framer-motion:
         specifier: ^12.38.0
         version: 12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -392,64 +389,6 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@nivo/annotations@0.99.0':
-    resolution: {integrity: sha512-jCuuXPbvpaqaz4xF7k5dv0OT2ubn5Nt0gWryuTe/8oVsC/9bzSuK8bM9vBty60m9tfO+X8vUYliuaCDwGksC2g==}
-    peerDependencies:
-      react: ^16.14 || ^17.0 || ^18.0 || ^19.0
-
-  '@nivo/axes@0.99.0':
-    resolution: {integrity: sha512-3KschnmEL0acRoa7INSSOSEFwJLm54aZwSev7/r8XxXlkgRBriu6ReZy/FG0wfN+ljZ4GMvx+XyIIf6kxzvrZg==}
-    peerDependencies:
-      react: ^16.14 || ^17.0 || ^18.0 || ^19.0
-
-  '@nivo/colors@0.99.0':
-    resolution: {integrity: sha512-hyYt4lEFIfXOUmQ6k3HXm3KwhcgoJpocmoGzLUqzk7DzuhQYJo+4d5jIGGU0N/a70+9XbHIdpKNSblHAIASD3w==}
-    peerDependencies:
-      react: ^16.14 || ^17.0 || ^18.0 || ^19.0
-
-  '@nivo/core@0.99.0':
-    resolution: {integrity: sha512-olCItqhPG3xHL5ei+vg52aB6o+6S+xR2idpkd9RormTTUniZb8U2rOdcQojOojPY5i9kVeQyLFBpV4YfM7OZ9g==}
-    peerDependencies:
-      react: ^16.14 || ^17.0 || ^18.0 || ^19.0
-
-  '@nivo/legends@0.99.0':
-    resolution: {integrity: sha512-P16FjFqNceuTTZphINAh5p0RF0opu3cCKoWppe2aRD9IuVkvRm/wS5K1YwMCxDzKyKh5v0AuTlu9K6o3/hk8hA==}
-    peerDependencies:
-      react: ^16.14 || ^17.0 || ^18.0 || ^19.0
-
-  '@nivo/line@0.99.0':
-    resolution: {integrity: sha512-bAqTXSjpnpcGMs341qWFUi7hJTqQiNoSeJHsYPuPS3icuXPcp3WETQH+zRZACeEF79ZigeOWCW+dzODgne1y9w==}
-    peerDependencies:
-      react: ^16.14 || ^17.0 || ^18.0 || ^19.0
-
-  '@nivo/scales@0.99.0':
-    resolution: {integrity: sha512-g/2K4L6L8si6E2BWAHtFVGahtDKbUcO6xHJtlIZMwdzaJc7yB16EpWLK8AfI/A42KadLhJSJqBK3mty+c7YZ+w==}
-
-  '@nivo/stream@0.99.0':
-    resolution: {integrity: sha512-/vXtbU1Nzepgxg0Y3Wrve7Q6BllaQCP9+lLpPCiRWWXIyODcKSauqsYKY4kas9YcIfJbchJclVD2CSHKt+lPxQ==}
-    peerDependencies:
-      react: ^16.14 || ^17.0 || ^18.0 || ^19.0
-
-  '@nivo/text@0.99.0':
-    resolution: {integrity: sha512-ho3oZpAZApsJNjsIL5WJSAdg/wjzTBcwo1KiHBlRGUmD+yUWO8qp7V+mnYRhJchwygtRVALlPgZ/rlcW2Xr/MQ==}
-    peerDependencies:
-      react: ^16.14 || ^17.0 || ^18.0 || ^19.0
-
-  '@nivo/theming@0.99.0':
-    resolution: {integrity: sha512-KvXlf0nqBzh/g2hAIV9bzscYvpq1uuO3TnFN3RDXGI72CrbbZFTGzprPju3sy/myVsauv+Bb+V4f5TZ0jkYKRg==}
-    peerDependencies:
-      react: ^16.14 || ^17.0 || ^18.0 || ^19.0
-
-  '@nivo/tooltip@0.99.0':
-    resolution: {integrity: sha512-weoEGR3xAetV4k2P6k96cdamGzKQ5F2Pq+uyDaHr1P3HYArM879Pl+x+TkU0aWjP6wgUZPx/GOBiV1Hb1JxIqg==}
-    peerDependencies:
-      react: ^16.14 || ^17.0 || ^18.0 || ^19.0
-
-  '@nivo/voronoi@0.99.0':
-    resolution: {integrity: sha512-KfmMdidbYzhiUCki1FG4X4nHEFT4loK8G5bMBnmCl9U+S78W+gvkfrgD2Aoqp/Q9yKQvr3Y8UcZKSFZnn3HgjQ==}
-    peerDependencies:
-      react: ^16.14 || ^17.0 || ^18.0 || ^19.0
-
   '@oxc-project/types@0.130.0':
     resolution: {integrity: sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==}
 
@@ -460,33 +399,6 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
-
-  '@react-spring/animated@10.1.0':
-    resolution: {integrity: sha512-dvGVSfNYhbkzTAnyB1S1940ZiKp6/Ey+b2vQc70dJ5k6gzH/GdlfeDzCh65V94b6OPqF7Xl4VUICVUQpc07iUg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  '@react-spring/core@10.1.0':
-    resolution: {integrity: sha512-XUG3UCCCxay6lYjBU2KOKzEgC1sx/w44ouB5gRh2Ex6rVJOdPcGVg7JJUIOAQo7uhKGfQdCQU4qUZaQnmInZPQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  '@react-spring/rafz@10.1.0':
-    resolution: {integrity: sha512-e/LRnNmvmg8Agl4j3MGcjHuSTSBcCrxr3xeoWdodxpLWeTHY1pHl8PJDOCEJ2Pj6BMdEBaWFRAX7uxRo1FLzCg==}
-
-  '@react-spring/shared@10.1.0':
-    resolution: {integrity: sha512-ogIUujWxdwcsQ2Vp2hZs+KehvH8tKeWGHsFb1eRBYoePzhKS541Qg1JfFlQ7ursBUwwPDBQ5Wpwn+Cwx6WV1PQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  '@react-spring/types@10.1.0':
-    resolution: {integrity: sha512-RkJAlkAZ5yZSRBMOSidamioBHLjf8wGKbtr3pZ5iKoHFNQuNM2k6DqJDIEUcNQlWRZXny6Eqys2c9NdugdbdyQ==}
-
-  '@react-spring/web@10.1.0':
-    resolution: {integrity: sha512-mIj/lJ+1eI4tLSkIloaSNjmuriTDZY9bbQ/GFGcbVGfOKzWb5JOMMKiuHACh8J3m0+se3KqcWdg/JoALVloE7g==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   '@rolldown/binding-android-arm64@1.0.1':
     resolution: {integrity: sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==}
@@ -731,39 +643,6 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
-  '@types/d3-color@3.1.3':
-    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
-
-  '@types/d3-delaunay@6.0.4':
-    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
-
-  '@types/d3-format@1.4.5':
-    resolution: {integrity: sha512-mLxrC1MSWupOSncXN/HOlWUAAIffAEBaI4+PKy2uMPsKe4FNZlk7qrbTjmzJXITQQqBHivaks4Td18azgqnotA==}
-
-  '@types/d3-interpolate@3.0.4':
-    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
-
-  '@types/d3-path@3.1.1':
-    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
-
-  '@types/d3-scale-chromatic@3.1.0':
-    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
-
-  '@types/d3-scale@4.0.9':
-    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
-
-  '@types/d3-shape@3.1.8':
-    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
-
-  '@types/d3-time-format@2.3.4':
-    resolution: {integrity: sha512-xdDXbpVO74EvadI3UDxjxTdR6QIxm1FKzEA/+F8tL4GWWUg/hgvBqf6chql64U5A9ZUGWo7pEu4eNlyLwbKdhg==}
-
-  '@types/d3-time-format@3.0.4':
-    resolution: {integrity: sha512-or9DiDnYI1h38J9hxKEsw513+KVuFbEVhl7qdxcaudoiqWWepapUen+2vAriFGexr6W5+P4l9+HJrB39GG+oRg==}
-
-  '@types/d3-time@1.1.4':
-    resolution: {integrity: sha512-JIvy2HjRInE+TXOmIGN5LCmeO0hkFZx5f9FZ7kiN+D+YTcc8pptsiLiuHsvwxwC7VVKmJ2ExHUgNlAiV7vQM9g==}
-
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -995,57 +874,6 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
-  d3-array@2.12.1:
-    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
-
-  d3-array@3.2.4:
-    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
-    engines: {node: '>=12'}
-
-  d3-color@3.1.0:
-    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
-    engines: {node: '>=12'}
-
-  d3-delaunay@6.0.4:
-    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
-    engines: {node: '>=12'}
-
-  d3-format@1.4.5:
-    resolution: {integrity: sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==}
-
-  d3-interpolate@3.0.1:
-    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
-    engines: {node: '>=12'}
-
-  d3-path@3.1.0:
-    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
-    engines: {node: '>=12'}
-
-  d3-scale-chromatic@3.1.0:
-    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
-    engines: {node: '>=12'}
-
-  d3-scale@4.0.2:
-    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
-    engines: {node: '>=12'}
-
-  d3-shape@3.2.0:
-    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
-    engines: {node: '>=12'}
-
-  d3-time-format@3.0.0:
-    resolution: {integrity: sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==}
-
-  d3-time@1.1.0:
-    resolution: {integrity: sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==}
-
-  d3-time@2.1.1:
-    resolution: {integrity: sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==}
-
-  d3-time@3.1.0:
-    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
-    engines: {node: '>=12'}
-
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -1065,9 +893,6 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
-  delaunator@5.1.0:
-    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
-
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -1081,6 +906,15 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  echarts-for-react@3.0.6:
+    resolution: {integrity: sha512-4zqLgTGWS3JvkQDXjzkR1k1CHRdpd6by0988TWMJgnvDytegWLbeP/VNZmMa+0VJx2eD7Y632bi2JquXDgiGJg==}
+    peerDependencies:
+      echarts: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
+      react: ^15.0.0 || >=16.0.0
+
+  echarts@6.1.0:
+    resolution: {integrity: sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==}
 
   electron-to-chromium@1.5.361:
     resolution: {integrity: sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==}
@@ -1274,13 +1108,6 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
-  internmap@1.0.1:
-    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
-
-  internmap@2.0.3:
-    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
-    engines: {node: '>=12'}
-
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -1422,9 +1249,6 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
-  lodash@4.18.1:
-    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
-
   lru-cache@11.3.5:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
     engines: {node: 20 || >=22}
@@ -1563,12 +1387,6 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
-  react-virtualized-auto-sizer@1.0.26:
-    resolution: {integrity: sha512-CblNyiNVw2o+hsa5/49NH2ogGxZ+t+3aweRvNSq7TVjDIlwk7ir4lencEg5HxHeSzwNarSkNkiu0qJSOXtxm5A==}
-    peerDependencies:
-      react: ^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   react@19.2.5:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
@@ -1580,9 +1398,6 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
-
-  robust-predicates@3.0.3:
-    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
 
   rolldown@1.0.1:
     resolution: {integrity: sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==}
@@ -1619,6 +1434,9 @@ packages:
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
+
+  size-sensor@1.0.3:
+    resolution: {integrity: sha512-+k9mJ2/rQMiRmQUcjn+qznch260leIXY8r4FyYKKyRBO/s5UoeMAHGkCJyE1R/4wrIhTJONfyloY55SkE7ve3A==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -1683,6 +1501,9 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  tslib@2.3.0:
+    resolution: {integrity: sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -1755,12 +1576,6 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
-
-  use-debounce@10.1.1:
-    resolution: {integrity: sha512-kvds8BHR2k28cFsxW8k3nc/tRga2rs1RHYCqmmGqb90MEeE++oALwzh2COiuBLO1/QXiOuShXoSN2ZpWnMmvuQ==}
-    engines: {node: '>= 16.0.0'}
-    peerDependencies:
-      react: '*'
 
   vite-plugin-dts@5.0.0:
     resolution: {integrity: sha512-VLNAUttBq7pLxxL/m/ztjd5zj5yiviiC7ijfPFVLK5c45FLcibvieBsdjSka3a4ag1qdrAF9K3OysH4/lW+rPQ==}
@@ -1918,6 +1733,9 @@ packages:
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zrender@6.1.0:
+    resolution: {integrity: sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==}
 
   zustand@5.0.12:
     resolution: {integrity: sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==}
@@ -2203,161 +2021,6 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@nivo/annotations@0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
-    dependencies:
-      '@nivo/colors': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@nivo/core': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@nivo/theming': 0.99.0(react@19.2.5)
-      '@react-spring/web': 10.1.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      lodash: 4.18.1
-      react: 19.2.5
-    transitivePeerDependencies:
-      - react-dom
-
-  '@nivo/axes@0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
-    dependencies:
-      '@nivo/core': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@nivo/scales': 0.99.0
-      '@nivo/text': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@nivo/theming': 0.99.0(react@19.2.5)
-      '@react-spring/web': 10.1.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@types/d3-format': 1.4.5
-      '@types/d3-time-format': 2.3.4
-      d3-format: 1.4.5
-      d3-time-format: 3.0.0
-      react: 19.2.5
-    transitivePeerDependencies:
-      - react-dom
-
-  '@nivo/colors@0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
-    dependencies:
-      '@nivo/core': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@nivo/theming': 0.99.0(react@19.2.5)
-      '@types/d3-color': 3.1.3
-      '@types/d3-scale': 4.0.9
-      '@types/d3-scale-chromatic': 3.1.0
-      d3-color: 3.1.0
-      d3-scale: 4.0.2
-      d3-scale-chromatic: 3.1.0
-      lodash: 4.18.1
-      react: 19.2.5
-    transitivePeerDependencies:
-      - react-dom
-
-  '@nivo/core@0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
-    dependencies:
-      '@nivo/theming': 0.99.0(react@19.2.5)
-      '@nivo/tooltip': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@react-spring/web': 10.1.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@types/d3-shape': 3.1.8
-      d3-color: 3.1.0
-      d3-format: 1.4.5
-      d3-interpolate: 3.0.1
-      d3-scale: 4.0.2
-      d3-scale-chromatic: 3.1.0
-      d3-shape: 3.2.0
-      d3-time-format: 3.0.0
-      lodash: 4.18.1
-      react: 19.2.5
-      react-virtualized-auto-sizer: 1.0.26(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      use-debounce: 10.1.1(react@19.2.5)
-    transitivePeerDependencies:
-      - react-dom
-
-  '@nivo/legends@0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
-    dependencies:
-      '@nivo/colors': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@nivo/core': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@nivo/text': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@nivo/theming': 0.99.0(react@19.2.5)
-      '@types/d3-scale': 4.0.9
-      d3-scale: 4.0.2
-      react: 19.2.5
-    transitivePeerDependencies:
-      - react-dom
-
-  '@nivo/line@0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
-    dependencies:
-      '@nivo/annotations': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@nivo/axes': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@nivo/colors': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@nivo/core': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@nivo/legends': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@nivo/scales': 0.99.0
-      '@nivo/theming': 0.99.0(react@19.2.5)
-      '@nivo/tooltip': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@nivo/voronoi': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@react-spring/web': 10.1.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@types/d3-shape': 3.1.8
-      d3-shape: 3.2.0
-      react: 19.2.5
-    transitivePeerDependencies:
-      - react-dom
-
-  '@nivo/scales@0.99.0':
-    dependencies:
-      '@types/d3-interpolate': 3.0.4
-      '@types/d3-scale': 4.0.9
-      '@types/d3-time': 1.1.4
-      '@types/d3-time-format': 3.0.4
-      d3-interpolate: 3.0.1
-      d3-scale: 4.0.2
-      d3-time: 1.1.0
-      d3-time-format: 3.0.0
-      lodash: 4.18.1
-
-  '@nivo/stream@0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
-    dependencies:
-      '@nivo/axes': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@nivo/colors': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@nivo/core': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@nivo/legends': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@nivo/scales': 0.99.0
-      '@nivo/theming': 0.99.0(react@19.2.5)
-      '@nivo/tooltip': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@react-spring/web': 10.1.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@types/d3-shape': 3.1.8
-      d3-shape: 3.2.0
-      react: 19.2.5
-    transitivePeerDependencies:
-      - react-dom
-
-  '@nivo/text@0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
-    dependencies:
-      '@nivo/core': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@nivo/theming': 0.99.0(react@19.2.5)
-      '@react-spring/web': 10.1.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      react: 19.2.5
-    transitivePeerDependencies:
-      - react-dom
-
-  '@nivo/theming@0.99.0(react@19.2.5)':
-    dependencies:
-      lodash: 4.18.1
-      react: 19.2.5
-
-  '@nivo/tooltip@0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
-    dependencies:
-      '@nivo/core': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@nivo/theming': 0.99.0(react@19.2.5)
-      '@react-spring/web': 10.1.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      react: 19.2.5
-    transitivePeerDependencies:
-      - react-dom
-
-  '@nivo/voronoi@0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
-    dependencies:
-      '@nivo/core': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@nivo/theming': 0.99.0(react@19.2.5)
-      '@nivo/tooltip': 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@types/d3-delaunay': 6.0.4
-      '@types/d3-scale': 4.0.9
-      d3-delaunay: 6.0.4
-      d3-scale: 4.0.2
-      react: 19.2.5
-    transitivePeerDependencies:
-      - react-dom
-
   '@oxc-project/types@0.130.0': {}
 
   '@playwright/test@1.59.1':
@@ -2365,39 +2028,6 @@ snapshots:
       playwright: 1.59.1
 
   '@polka/url@1.0.0-next.29': {}
-
-  '@react-spring/animated@10.1.0(react@19.2.5)':
-    dependencies:
-      '@react-spring/shared': 10.1.0(react@19.2.5)
-      '@react-spring/types': 10.1.0
-      react: 19.2.5
-
-  '@react-spring/core@10.1.0(react@19.2.5)':
-    dependencies:
-      '@react-spring/animated': 10.1.0(react@19.2.5)
-      '@react-spring/shared': 10.1.0(react@19.2.5)
-      '@react-spring/types': 10.1.0
-      react: 19.2.5
-
-  '@react-spring/rafz@10.1.0': {}
-
-  '@react-spring/shared@10.1.0(react@19.2.5)':
-    dependencies:
-      '@react-spring/rafz': 10.1.0
-      '@react-spring/types': 10.1.0
-      react: 19.2.5
-
-  '@react-spring/types@10.1.0': {}
-
-  '@react-spring/web@10.1.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
-    dependencies:
-      '@react-spring/animated': 10.1.0(react@19.2.5)
-      '@react-spring/core': 10.1.0(react@19.2.5)
-      '@react-spring/shared': 10.1.0(react@19.2.5)
-      '@react-spring/types': 10.1.0
-      csstype: 3.2.3
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
 
   '@rolldown/binding-android-arm64@1.0.1':
     optional: true
@@ -2574,34 +2204,6 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
-
-  '@types/d3-color@3.1.3': {}
-
-  '@types/d3-delaunay@6.0.4': {}
-
-  '@types/d3-format@1.4.5': {}
-
-  '@types/d3-interpolate@3.0.4':
-    dependencies:
-      '@types/d3-color': 3.1.3
-
-  '@types/d3-path@3.1.1': {}
-
-  '@types/d3-scale-chromatic@3.1.0': {}
-
-  '@types/d3-scale@4.0.9':
-    dependencies:
-      '@types/d3-time': 1.1.4
-
-  '@types/d3-shape@3.1.8':
-    dependencies:
-      '@types/d3-path': 3.1.1
-
-  '@types/d3-time-format@2.3.4': {}
-
-  '@types/d3-time-format@3.0.4': {}
-
-  '@types/d3-time@1.1.4': {}
 
   '@types/deep-eql@4.0.2': {}
 
@@ -2864,59 +2466,6 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  d3-array@2.12.1:
-    dependencies:
-      internmap: 1.0.1
-
-  d3-array@3.2.4:
-    dependencies:
-      internmap: 2.0.3
-
-  d3-color@3.1.0: {}
-
-  d3-delaunay@6.0.4:
-    dependencies:
-      delaunator: 5.1.0
-
-  d3-format@1.4.5: {}
-
-  d3-interpolate@3.0.1:
-    dependencies:
-      d3-color: 3.1.0
-
-  d3-path@3.1.0: {}
-
-  d3-scale-chromatic@3.1.0:
-    dependencies:
-      d3-color: 3.1.0
-      d3-interpolate: 3.0.1
-
-  d3-scale@4.0.2:
-    dependencies:
-      d3-array: 3.2.4
-      d3-format: 1.4.5
-      d3-interpolate: 3.0.1
-      d3-time: 3.1.0
-      d3-time-format: 3.0.0
-
-  d3-shape@3.2.0:
-    dependencies:
-      d3-path: 3.1.0
-
-  d3-time-format@3.0.0:
-    dependencies:
-      d3-time: 2.1.1
-
-  d3-time@1.1.0: {}
-
-  d3-time@2.1.1:
-    dependencies:
-      d3-array: 2.12.1
-
-  d3-time@3.1.0:
-    dependencies:
-      d3-array: 3.2.4
-
   data-urls@7.0.0:
     dependencies:
       whatwg-mimetype: 5.0.0
@@ -2932,10 +2481,6 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  delaunator@5.1.0:
-    dependencies:
-      robust-predicates: 3.0.3
-
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
@@ -2943,6 +2488,18 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  echarts-for-react@3.0.6(echarts@6.1.0)(react@19.2.5):
+    dependencies:
+      echarts: 6.1.0
+      fast-deep-equal: 3.1.3
+      react: 19.2.5
+      size-sensor: 1.0.3
+
+  echarts@6.1.0:
+    dependencies:
+      tslib: 2.3.0
+      zrender: 6.1.0
 
   electron-to-chromium@1.5.361: {}
 
@@ -3125,10 +2682,6 @@ snapshots:
 
   indent-string@4.0.0: {}
 
-  internmap@1.0.1: {}
-
-  internmap@2.0.3: {}
-
   is-extglob@2.1.1: {}
 
   is-glob@4.0.3:
@@ -3248,8 +2801,6 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
-
-  lodash@4.18.1: {}
 
   lru-cache@11.3.5: {}
 
@@ -3376,11 +2927,6 @@ snapshots:
 
   react-is@17.0.2: {}
 
-  react-virtualized-auto-sizer@1.0.26(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
-    dependencies:
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-
   react@19.2.5: {}
 
   redent@3.0.0:
@@ -3389,8 +2935,6 @@ snapshots:
       strip-indent: 3.0.0
 
   require-from-string@2.0.2: {}
-
-  robust-predicates@3.0.3: {}
 
   rolldown@1.0.1:
     dependencies:
@@ -3436,6 +2980,8 @@ snapshots:
       '@polka/url': 1.0.0-next.29
       mrmime: 2.0.1
       totalist: 3.0.1
+
+  size-sensor@1.0.3: {}
 
   source-map-js@1.2.1: {}
 
@@ -3483,6 +3029,8 @@ snapshots:
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
+
+  tslib@2.3.0: {}
 
   tslib@2.8.1: {}
 
@@ -3542,10 +3090,6 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
-
-  use-debounce@10.1.1(react@19.2.5):
-    dependencies:
-      react: 19.2.5
 
   vite-plugin-dts@5.0.0(rolldown@1.0.1)(typescript@6.0.3)(vite@8.0.13(@types/node@25.8.0)(jiti@2.7.0)):
     dependencies:
@@ -3646,6 +3190,10 @@ snapshots:
       zod: 4.4.3
 
   zod@4.4.3: {}
+
+  zrender@6.1.0:
+    dependencies:
+      tslib: 2.3.0
 
   zustand@5.0.12(@types/react@19.2.14)(react@19.2.5):
     optionalDependencies:


### PR DESCRIPTION
## Problem

The Game Insights charts re-render on every move (live during AI auto-play). On a long game — e.g. a real exported game with **464 moves / 26 recycles** — the UI became unresponsive.

Root cause, established by measurement (not guesswork): it's **Nivo's SVG renderer**, which reconciles a large DOM/React tree on every update — not the data volume. Measured on the **prod build** at that game's 480-point scale:

| Config (20-move burst) | Long-task jank per move |
|---|---|
| Progress (Nivo line) | ~235 ms |
| Card Flow (Nivo stream) | ~320–440 ms |
| Board tab (custom SVG, same data scale) | 0 ms |
| Panel collapsed (no chart) | 0 ms |

Downsampling to 160 points and dropping the hover mesh barely helped (~235 ms either way), confirming the cost is the renderer, not the dataset.

## Fix

Switch both time-series charts from Nivo (SVG) to **ECharts (canvas, tree-shaken `echarts/core`)**. Card Flow uses ECharts **ThemeRiver** to keep the streamgraph look.

- **Render once per turn** — each chart is `memo`'d and keyed to history identity, so intra-turn store churn (move → flip → thinking toggle) collapses to a single render.
- **Card-animation-first** — charts read a `useDeferredValue` copy of history, so a move's urgent render (card move + flip) commits first and the chart updates after at low priority; fast auto-play bursts coalesce into fewer chart renders.
- Only the active tab's chart mounts (unchanged).
- Name the lazy `echarts` vendor chunk; raise `chunkSizeWarningLimit` for it.
- Remove Nivo (`@nivo/*`) and the now-dead `downsample` util.

## Result (measured, prod build, 480 points)

| Chart | Before | After |
|---|---|---|
| Progress | 235 ms/move | **0 ms/move** |
| Card Flow | 322–436 ms/move | **0 ms/move** |

Long-task jank over a 20-move burst: **~10 s → 0**. Verified visually headless at 461 moves — both charts render correctly and look unchanged.

## Tradeoff

The ECharts vendor chunk is **531 kB / 179 kB gzip** vs Nivo's 296 kB / 76 kB gzip (**+103 kB gzip**). It is **lazy-loaded** (only when the Insights charts open) and the **eager page bundle is unchanged (~445 kB)**, so initial load is unaffected.

## Verification

- Lint clean · 364 unit tests · 66 e2e (incl. a new long-game canvas test driving 240 draws) · production build clean, no size warning