### PR TITLE
feat(ai-prompt): v1.4 strategy-guidance edits (anchor reveals to tag, fix anti-undo horizon)

### DIFF
--- a/packages/app/src/ai/context/renderContext.test.ts
+++ b/packages/app/src/ai/context/renderContext.test.ts
@@ -293,6 +293,6 @@ describe('renderHybridContext', () => {
     // two fields on a harvested interaction never disagree. See the
     // promptlayoutversion-lockstep follow-up note.
     expect(PROMPT_LAYOUT_VERSION).toMatch(/^hybrid-v\d+\.\d+$/);
-    expect(PROMPT_LAYOUT_VERSION).toBe('hybrid-v1.3');
+    expect(PROMPT_LAYOUT_VERSION).toBe('hybrid-v1.4');
   });
 });

--- a/packages/app/src/ai/context/renderContext.ts
+++ b/packages/app/src/ai/context/renderContext.ts
@@ -37,7 +37,7 @@ import type { AIMoveContext } from '../types';
  * computing `promptTemplateHash` to identify the variant. The hash stays
  * authoritative for byte-level identity.
  */
-export const PROMPT_LAYOUT_VERSION = 'hybrid-v1.3';
+export const PROMPT_LAYOUT_VERSION = 'hybrid-v1.4';
 
 /** Pad a column name's value column to keep `[index]` + type aligned. */
 const TYPE_COL_WIDTH = 24;

--- a/packages/app/src/ai/context/rulesPrimer.ts
+++ b/packages/app/src/ai/context/rulesPrimer.ts
@@ -41,13 +41,13 @@ THE GOAL: choose the single move that gives the best chance of eventually winnin
 
 /** Klondike strategy heuristics. Included when `includeStrategyGuidance` is on. */
 export const STRATEGY_GUIDANCE = `STRATEGY GUIDANCE (heuristics, not absolute rules):
-- If any legal move exposes a face-down tableau card, prefer such a move. When multiple legal moves expose a face-down card, prefer the one that exposes a card in the column with the most face-down cards remaining.
+- If any legal move is tagged "(reveals a hidden card)", prefer such a move. When several are tagged, prefer the one in the column with the most face-down (??) cards remaining.
 - Play Aces and 2s to the foundations promptly; they are rarely useful in the tableau.
 - Be cautious sending higher cards to the foundations too early — they are sometimes needed to receive tableau cards.
 - Do not empty a column unless you have a King ready to occupy it.
-- Prefer exposing new cards and creating useful sequences over shuffling cards between columns with no gain.
-- Drawing from the stock is the correct action when no legal tableau or foundation move exposes a face-down card or advances a foundation.
-- Do not move a card to a tableau column it occupied in the last 5 moves shown in RECENT MOVES.`;
+- Prefer a move tagged "(reveals a hidden card)" over a tableau move that is not tagged and only shuffles cards between columns with no gain.
+- Drawing from the stock is the correct action when no legal move is tagged "(reveals a hidden card)" and no legal move advances a foundation.
+- Do not return a card to a tableau column it occupied in any move shown in RECENT MOVES.`;
 
 /** Instructions describing the required JSON output. Always included. */
 export const OUTPUT_INSTRUCTION = `RESPONSE FORMAT:

--- a/packages/app/src/ai/context/systemInstruction.test.ts
+++ b/packages/app/src/ai/context/systemInstruction.test.ts
@@ -67,7 +67,7 @@ describe('hashSystemInstruction', () => {
 describe('prompt template identity (tripwire)', () => {
   it('hash with strategy guidance is pinned', async () => {
     const hash = await hashSystemInstruction(buildSystemInstruction(configWith(true)));
-    expect(hash).toBe('7d9ecda4cb415ec2335b3e970421d297730773f541b523666332dd024e9772bb');
+    expect(hash).toBe('818edeb2c1dbfd00c71b9311d34ec5a4c5b9454cbe5d9a26f33897b18328bec4');
   });
 
   it('hash without strategy guidance is pinned', async () => {
@@ -86,6 +86,6 @@ describe('prompt template identity (tripwire)', () => {
     // restructure (`hybrid-v2.0`). The exact value is what the dataset side
     // partitions on, so it is a tripwire — bump deliberately.
     expect(PROMPT_TEMPLATE_VERSION).toMatch(/^hybrid-v\d+\.\d+$/);
-    expect(PROMPT_TEMPLATE_VERSION).toBe('hybrid-v1.3');
+    expect(PROMPT_TEMPLATE_VERSION).toBe('hybrid-v1.4');
   });
 });

--- a/packages/app/src/ai/context/systemInstruction.ts
+++ b/packages/app/src/ai/context/systemInstruction.ts
@@ -27,7 +27,7 @@ import { OUTPUT_INSTRUCTION, RULES_PRIMER, STRATEGY_GUIDANCE } from './rulesPrim
  * because the templates evolve independently of any release cadence and the
  * downstream analytics already key off ISO timestamps.
  */
-export const PROMPT_TEMPLATE_FINALISED_AT = '2026-05-28T00:00:00Z';
+export const PROMPT_TEMPLATE_FINALISED_AT = '2026-06-04T00:00:00Z';
 
 /**
  * Human-readable semantic version of the prompt template (rules + output
@@ -43,7 +43,7 @@ export const PROMPT_TEMPLATE_FINALISED_AT = '2026-05-28T00:00:00Z';
  * Adopted per the 2026-05-26 harvester-team ask in
  * `solitaire-analytics/docs/reports/20260526_harvester_team_resign_hygiene_versioning_ask.md`.
  */
-export const PROMPT_TEMPLATE_VERSION = 'hybrid-v1.3';
+export const PROMPT_TEMPLATE_VERSION = 'hybrid-v1.4';
 
 /** Build the full system instruction for a move-suggestion request. */
 export function buildSystemInstruction(config: AIConfig): string {


### PR DESCRIPTION
Two text-only edits to the `STRATEGY_GUIDANCE` block, implementing the 2026-06-04 harvester ask (`solitaire-analytics/docs/reports/20260604_v1_4_harvester_ask.md`). No renderer changes.

## Edits
- **Edit 1 — anchor reveals to the tag (bullets 1, 5, 6):** replace the model-judged "exposes a face-down card" wording with the rendered `(reveals a hidden card)` tag, so the model cannot call a non-revealing move a reveal. Binds to an existing signal (`describeMove.ts`), so it cannot drop a genuine reveal.
- **Edit 2 — fix the anti-undo horizon (bullet 7):** `last 5 moves` → `any move shown in RECENT MOVES`. RECENT MOVES renders up to 10, so the old 5-window silently missed reversals. Self-syncing if the render length changes. No carve-out is written into the prose — the productive-return exception is deferred to the parked F1 tag, keeping decision logic out of the prompt.

## Versioning
- `PROMPT_TEMPLATE_VERSION` + `PROMPT_LAYOUT_VERSION` → `hybrid-v1.4` (lockstep, minor bump: text-only within the same layout).
- `PROMPT_TEMPLATE_FINALISED_AT` → `2026-06-04T00:00:00Z`.
- With-guidance template hash re-pinned: `7d9ecda4…` → `818edeb2…` (without-guidance hash unchanged, confirming the edit is isolated to the strategy block).

## Out of scope (parked)
F1 (anti-undo move tag) and F2 (temporal progress signal) are renderer follow-ups, not part of v1.4.

## Tests
Version + hash tripwires updated; `systemInstruction`, `renderContext`, and `GeminiProvider` suites pass (50/50).