### PR TITLE
feat(ai-prompt): v1.5 — delete draw-directive, surface stall counts

### DIFF
--- a/packages/app/src/ai/context/buildContext.test.ts
+++ b/packages/app/src/ai/context/buildContext.test.ts
@@ -93,6 +93,8 @@ describe('buildContext', () => {
     // foundationCards/faceDownTotal/progressScore are raw progress components
     // (this fixture has empty tableau columns => no face-down cards, so all 21
     // deal cards read as "revealed" and progressScore is 0.35 * 100 = 35).
+    // Two draw moves, no foundation move and no reveal yet, so both stall
+    // counts equal the number of player moves so far (2).
     expect(ctx.metrics).toEqual({
       completionProgress: 25,
       perceivedDifficulty: 0,
@@ -100,6 +102,8 @@ describe('buildContext', () => {
       foundationCards: 0,
       faceDownTotal: 0,
       progressScore: 35,
+      turnsSinceFoundationGrew: 2,
+      turnsSinceCardRevealed: 2,
     });
     expect(ctx.recentMoves).toEqual(['draw 4C', 'draw 7S']);
   });

--- a/packages/app/src/ai/context/buildContext.ts
+++ b/packages/app/src/ai/context/buildContext.ts
@@ -11,7 +11,7 @@
 
 import type { MoveCommand } from '@chayuto/solitaire-core';
 import { getPerceivedDifficulty } from '@chayuto/solitaire-core';
-import type { GameState, Suit } from '../../types';
+import type { GameState, Move, Suit } from '../../types';
 import type { AIConfig, AIDecisionRecord, AILegalMove, AIMoveContext } from '../types';
 import { uiToCore } from '../../adapters/coreAdapter';
 import { cardShort } from '../cardNotation';
@@ -30,6 +30,44 @@ const NON_PLAYER_MOVE_TYPES = new Set([
   'autoplay_deadend',
   'autoplay_loop_detected',
 ]);
+
+/** Player-move types that advance a foundation. */
+const FOUNDATION_MOVE_TYPES = new Set(['tableau_to_foundation', 'discard_to_foundation']);
+
+/**
+ * Count, in player-move units (the same unit RECENT MOVES uses), how long the
+ * game has gone without a foundation advancing and without a face-down card
+ * being revealed.
+ *
+ * These are facts — counts of true past events — not directives: the RECENT
+ * MOVES window shows only the last N moves, so a long dry spell (e.g. 40
+ * consecutive draws) is invisible to the model; these counts restore exactly
+ * what the window hides. They carry no threshold and no recommended action
+ * (hybrid-v1.5; see the v1.5 harvester ask). A reveal is a `flip_card`
+ * bookkeeping entry, so we stop at it but count only the player moves since.
+ */
+function computeStallCounts(moveHistory: readonly Move[]): {
+  turnsSinceFoundationGrew: number;
+  turnsSinceCardRevealed: number;
+} {
+  let turnsSinceFoundationGrew = 0;
+  for (let i = moveHistory.length - 1; i >= 0; i--) {
+    const type = moveHistory[i].type;
+    if (NON_PLAYER_MOVE_TYPES.has(type)) continue;
+    if (FOUNDATION_MOVE_TYPES.has(type)) break;
+    turnsSinceFoundationGrew += 1;
+  }
+
+  let turnsSinceCardRevealed = 0;
+  for (let i = moveHistory.length - 1; i >= 0; i--) {
+    const type = moveHistory[i].type;
+    if (type === 'flip_card') break;
+    if (NON_PLAYER_MOVE_TYPES.has(type)) continue;
+    turnsSinceCardRevealed += 1;
+  }
+
+  return { turnsSinceFoundationGrew, turnsSinceCardRevealed };
+}
 
 /**
  * Match a {@link MoveCommand} to a scored {@link PossibleMove} from the
@@ -218,6 +256,7 @@ export function buildContext(
     // repeated every turn carries no per-turn signal. `moveCount` is omitted
     // here: it duplicates the interaction log's `turnIndex` exactly.
     const progress = computeProgressComponents(state);
+    const stall = computeStallCounts(state.moveHistory);
     context.metrics = {
       completionProgress: Math.round(state.completionProgress),
       perceivedDifficulty: getPerceivedDifficulty(uiToCore(state)),
@@ -225,6 +264,8 @@ export function buildContext(
       foundationCards: progress.foundationCards,
       faceDownTotal: progress.faceDownTotal,
       progressScore: progress.progressScore,
+      turnsSinceFoundationGrew: stall.turnsSinceFoundationGrew,
+      turnsSinceCardRevealed: stall.turnsSinceCardRevealed,
     };
   }
 

--- a/packages/app/src/ai/context/renderContext.test.ts
+++ b/packages/app/src/ai/context/renderContext.test.ts
@@ -198,10 +198,15 @@ describe('renderHybridContext', () => {
           foundationCards: 6,
           faceDownTotal: 12,
           progressScore: 35,
+          turnsSinceFoundationGrew: 63,
+          turnsSinceCardRevealed: 47,
         },
       }),
     );
-    expect(out).toContain('PROGRESS: foundation=6/52, face-down remaining=12, completion=12%');
+    expect(out).toContain(
+      'PROGRESS: foundation=6/52, face-down remaining=12, completion=12%, ' +
+        'turns since foundation grew: 63, turns since a card was revealed: 47',
+    );
   });
 
   it('does NOT render PRIOR REASONING even when reasoningTrail is supplied (hybrid-v1.3)', () => {
@@ -281,6 +286,8 @@ describe('renderHybridContext', () => {
         foundationCards: 6,
         faceDownTotal: 12,
         progressScore: 35,
+        turnsSinceFoundationGrew: 63,
+        turnsSinceCardRevealed: 47,
       },
     });
     const hybridChars = renderHybridContext(ctx).length;
@@ -293,6 +300,6 @@ describe('renderHybridContext', () => {
     // two fields on a harvested interaction never disagree. See the
     // promptlayoutversion-lockstep follow-up note.
     expect(PROMPT_LAYOUT_VERSION).toMatch(/^hybrid-v\d+\.\d+$/);
-    expect(PROMPT_LAYOUT_VERSION).toBe('hybrid-v1.4');
+    expect(PROMPT_LAYOUT_VERSION).toBe('hybrid-v1.5');
   });
 });

--- a/packages/app/src/ai/context/renderContext.ts
+++ b/packages/app/src/ai/context/renderContext.ts
@@ -37,7 +37,7 @@ import type { AIMoveContext } from '../types';
  * computing `promptTemplateHash` to identify the variant. The hash stays
  * authoritative for byte-level identity.
  */
-export const PROMPT_LAYOUT_VERSION = 'hybrid-v1.4';
+export const PROMPT_LAYOUT_VERSION = 'hybrid-v1.5';
 
 /** Pad a column name's value column to keep `[index]` + type aligned. */
 const TYPE_COL_WIDTH = 24;
@@ -137,13 +137,18 @@ export function renderHybridContext(context: AIMoveContext): string {
   }
   lines.push('');
 
-  // PROGRESS — game metrics in a single line.
+  // PROGRESS — game metrics in a single line. The two "turns since" counts
+  // (hybrid-v1.5) are facts the 10-move RECENT MOVES window hides: a long dry
+  // spell of draws is otherwise invisible. Rendered as bare counts, with no
+  // threshold and no action attached — the decision stays with the model.
   const metrics = context.metrics;
   if (metrics) {
     lines.push(
       `PROGRESS: foundation=${metrics.foundationCards}/52, ` +
         `face-down remaining=${metrics.faceDownTotal}, ` +
-        `completion=${metrics.completionProgress}%`,
+        `completion=${metrics.completionProgress}%, ` +
+        `turns since foundation grew: ${metrics.turnsSinceFoundationGrew}, ` +
+        `turns since a card was revealed: ${metrics.turnsSinceCardRevealed}`,
     );
     lines.push('');
   }

--- a/packages/app/src/ai/context/rulesPrimer.ts
+++ b/packages/app/src/ai/context/rulesPrimer.ts
@@ -46,7 +46,6 @@ export const STRATEGY_GUIDANCE = `STRATEGY GUIDANCE (heuristics, not absolute ru
 - Be cautious sending higher cards to the foundations too early — they are sometimes needed to receive tableau cards.
 - Do not empty a column unless you have a King ready to occupy it.
 - Prefer a move tagged "(reveals a hidden card)" over a tableau move that is not tagged and only shuffles cards between columns with no gain.
-- Drawing from the stock is the correct action when no legal move is tagged "(reveals a hidden card)" and no legal move advances a foundation.
 - Do not return a card to a tableau column it occupied in any move shown in RECENT MOVES.`;
 
 /** Instructions describing the required JSON output. Always included. */

--- a/packages/app/src/ai/context/systemInstruction.test.ts
+++ b/packages/app/src/ai/context/systemInstruction.test.ts
@@ -67,7 +67,7 @@ describe('hashSystemInstruction', () => {
 describe('prompt template identity (tripwire)', () => {
   it('hash with strategy guidance is pinned', async () => {
     const hash = await hashSystemInstruction(buildSystemInstruction(configWith(true)));
-    expect(hash).toBe('818edeb2c1dbfd00c71b9311d34ec5a4c5b9454cbe5d9a26f33897b18328bec4');
+    expect(hash).toBe('8a46ca22bc36c14eed0cdb5c3090f17c09ed8adc91cf0c3d13dfd8ac2e8fe337');
   });
 
   it('hash without strategy guidance is pinned', async () => {
@@ -86,6 +86,6 @@ describe('prompt template identity (tripwire)', () => {
     // restructure (`hybrid-v2.0`). The exact value is what the dataset side
     // partitions on, so it is a tripwire — bump deliberately.
     expect(PROMPT_TEMPLATE_VERSION).toMatch(/^hybrid-v\d+\.\d+$/);
-    expect(PROMPT_TEMPLATE_VERSION).toBe('hybrid-v1.4');
+    expect(PROMPT_TEMPLATE_VERSION).toBe('hybrid-v1.5');
   });
 });

--- a/packages/app/src/ai/context/systemInstruction.ts
+++ b/packages/app/src/ai/context/systemInstruction.ts
@@ -27,7 +27,7 @@ import { OUTPUT_INSTRUCTION, RULES_PRIMER, STRATEGY_GUIDANCE } from './rulesPrim
  * because the templates evolve independently of any release cadence and the
  * downstream analytics already key off ISO timestamps.
  */
-export const PROMPT_TEMPLATE_FINALISED_AT = '2026-06-04T00:00:00Z';
+export const PROMPT_TEMPLATE_FINALISED_AT = '2026-06-06T00:00:00Z';
 
 /**
  * Human-readable semantic version of the prompt template (rules + output
@@ -43,7 +43,7 @@ export const PROMPT_TEMPLATE_FINALISED_AT = '2026-06-04T00:00:00Z';
  * Adopted per the 2026-05-26 harvester-team ask in
  * `solitaire-analytics/docs/reports/20260526_harvester_team_resign_hygiene_versioning_ask.md`.
  */
-export const PROMPT_TEMPLATE_VERSION = 'hybrid-v1.4';
+export const PROMPT_TEMPLATE_VERSION = 'hybrid-v1.5';
 
 /** Build the full system instruction for a move-suggestion request. */
 export function buildSystemInstruction(config: AIConfig): string {

--- a/packages/app/src/ai/types.ts
+++ b/packages/app/src/ai/types.ts
@@ -149,6 +149,17 @@ export interface AIMoveContext {
     faceDownTotal: number;
     /** Blended progress score (0–100): weighted foundations + revealed cards. */
     progressScore: number;
+    /**
+     * Player moves since a foundation last grew (same unit as RECENT MOVES).
+     * A true count of past events the 10-move window hides; rendered with no
+     * threshold and no action attached. hybrid-v1.5 onwards.
+     */
+    turnsSinceFoundationGrew: number;
+    /**
+     * Player moves since a face-down tableau card was last revealed (same unit
+     * as RECENT MOVES). hybrid-v1.5 onwards.
+     */
+    turnsSinceCardRevealed: number;
   };
   /** Recent moves, most-recent last (when `includeMoveHistory`). */
   recentMoves?: string[];


### PR DESCRIPTION
## Summary

Two state-side changes to the hybrid AI prompt, implementing the v1.5 harvester ask (`solitaire-analytics/docs/reports/20260606_v1_5_harvester_ask.md`). No new decision logic — we remove one verdict from the guidance and add two facts to the state. Both version fields move to `hybrid-v1.5` in lockstep.

### 1. Delete the draw-directive (`STRATEGY GUIDANCE`)
Removed the bullet *"Drawing from the stock is the correct action when no legal move is tagged (reveals a hidden card) and no legal move advances a foundation."* On a locked board that condition is true **every** turn, so the model draws to the cap and the already-working resign path is never tested. Deleting the bullet removes injected logic — it biases toward nothing and hands the draw/resign choice back to the model. Every other bullet (v1.4 reveal-tag anchoring, anti-undo) is left exactly as is.

### 2. Surface two stall counts on the `PROGRESS` line
Added two true counts, rendered as bare numbers with **no threshold and no action attached**:

```
PROGRESS: foundation=…/52, face-down remaining=…, completion=…%, turns since foundation grew: N, turns since a card was revealed: N
```

They are facts the 10-move `RECENT MOVES` window hides — a long draw dry spell is otherwise invisible — counted in the same player-move unit as `RECENT MOVES`. Same category as `foundation=11/52`.

## Versioning / hash
- `PROMPT_TEMPLATE_VERSION` and `PROMPT_LAYOUT_VERSION` → `hybrid-v1.5` (lockstep)
- `PROMPT_TEMPLATE_FINALISED_AT` → `2026-06-06T00:00:00Z`
- Strategy-guidance hash tripwire updated to the new SHA-256
- `AIMoveContext.metrics` type extended with `turnsSinceFoundationGrew` / `turnsSinceCardRevealed`

## Testing
- `pnpm --filter app test:run` — 371 passed
- `tsc -b` (app) + `pnpm -r typecheck` — clean
- `pnpm --filter app lint` — clean