### PR TITLE
feat(ai-prompt): v1.6 — fix DRAW TIMELINE {NOW} prose, log recycle in RECENT MOVES

### DIFF
--- a/packages/app/e2e/insights.spec.ts
+++ b/packages/app/e2e/insights.spec.ts
@@ -43,12 +43,13 @@ test.describe('Game Insights panel', () => {
 
     // Dismiss the win modal (keeps game state) and confirm the chart drew.
     await page.getByTestId('win-modal-close-btn').click();
+    await page.getByTestId('insights-tab-progress').click();
     await expect(
       page.getByTestId('insights-chart-progress').locator('canvas'),
     ).toBeVisible();
   });
 
-  test('switches between the Progress and Card Flow tabs', async ({ page }) => {
+  test('switches between the Card Flow and Progress tabs', async ({ page }) => {
     await page.goto('/?seed=42');
     await waitForGame(page);
 
@@ -57,17 +58,7 @@ test.describe('Game Insights panel', () => {
       for (let i = 0; i < 20; i += 1) window.__solitaire!.draw();
     });
 
-    // Progress is the default tab.
-    await expect(page.getByTestId('insights-tab-progress')).toHaveAttribute(
-      'aria-selected',
-      'true',
-    );
-    await expect(
-      page.getByTestId('insights-chart-progress').locator('canvas'),
-    ).toBeVisible();
-
-    // Switch to Card Flow.
-    await page.getByTestId('insights-tab-flow').click();
+    // Card Flow is the default tab.
     await expect(page.getByTestId('insights-tab-flow')).toHaveAttribute(
       'aria-selected',
       'true',
@@ -75,7 +66,17 @@ test.describe('Game Insights panel', () => {
     await expect(
       page.getByTestId('insights-chart-flow').locator('canvas'),
     ).toBeVisible();
-    await expect(page.getByTestId('insights-chart-progress')).toHaveCount(0);
+
+    // Switch to Progress.
+    await page.getByTestId('insights-tab-progress').click();
+    await expect(page.getByTestId('insights-tab-progress')).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    await expect(
+      page.getByTestId('insights-chart-progress').locator('canvas'),
+    ).toBeVisible();
+    await expect(page.getByTestId('insights-chart-flow')).toHaveCount(0);
   });
 
   test('collapsing hides the charts but keeps the live bar', async ({
@@ -198,15 +199,15 @@ test.describe('Game Insights — stats, board & AI', () => {
     const moves = Number.parseInt(movesText ?? '0', 10);
     expect(moves).toBeGreaterThan(160);
 
-    // Progress chart draws to a <canvas>.
-    await expect(
-      page.getByTestId('insights-chart-progress').locator('canvas'),
-    ).toBeVisible();
-
-    // And so does the streamgraph.
-    await page.getByTestId('insights-tab-flow').click();
+    // The streamgraph (default tab) draws to a <canvas>.
     await expect(
       page.getByTestId('insights-chart-flow').locator('canvas'),
+    ).toBeVisible();
+
+    // And so does the progress chart.
+    await page.getByTestId('insights-tab-progress').click();
+    await expect(
+      page.getByTestId('insights-chart-progress').locator('canvas'),
     ).toBeVisible();
   });
 });

--- a/packages/app/src/ai/context/buildContext.test.ts
+++ b/packages/app/src/ai/context/buildContext.test.ts
@@ -17,6 +17,12 @@ const card = (suit: Suit, rank: Rank, faceUp = true): Card => ({
 
 const drawMove = (c: Card): Move => ({ type: 'draw_card', timestamp: 0, card: c });
 
+const recycleMove = (): Move => ({
+  type: 'recycle_stock',
+  timestamp: 0,
+  card: card('hearts', 'A'),
+});
+
 function makeState(overrides: Partial<GameState> = {}): GameState {
   return {
     drawPile: [],
@@ -106,6 +112,17 @@ describe('buildContext', () => {
       turnsSinceCardRevealed: 2,
     });
     expect(ctx.recentMoves).toEqual(['draw 4C', 'draw 7S']);
+  });
+
+  it('records a recycle between the surrounding draws in RECENT MOVES', () => {
+    // Without the recycle entry this would read as two identical draws with the
+    // recycle invisible between them; the marker makes the history honest.
+    const sevenD = card('diamonds', '7');
+    const state = makeState({
+      moveHistory: [drawMove(sevenD), recycleMove(), drawMove(sevenD)],
+    });
+    const ctx = buildContext(state, LEGAL_MOVES, applyPreset(DEFAULT_AI_CONFIG, 'standard'));
+    expect(ctx.recentMoves).toEqual(['draw 7D', 'recycle stock', 'draw 7D']);
   });
 
   it('reports only seen stock cards (player-fair) when seeHiddenCards is off', () => {

--- a/packages/app/src/ai/context/describeMove.test.ts
+++ b/packages/app/src/ai/context/describeMove.test.ts
@@ -132,6 +132,15 @@ describe('summarizeHistoryMove', () => {
     expect(summarizeHistoryMove(move)).toBe('draw TD');
   });
 
+  it('summarizes a recycle as a plain "recycle stock" entry', () => {
+    const move: Move = {
+      type: 'recycle_stock',
+      timestamp: 0,
+      card: card('hearts', 'A'),
+    };
+    expect(summarizeHistoryMove(move)).toBe('recycle stock');
+  });
+
   it('summarizes a tableau-to-foundation move', () => {
     const move: Move = {
       type: 'tableau_to_foundation',

--- a/packages/app/src/ai/context/describeMove.ts
+++ b/packages/app/src/ai/context/describeMove.ts
@@ -84,6 +84,8 @@ export function summarizeHistoryMove(move: Move): string {
   switch (move.type) {
     case 'draw_card':
       return `draw ${card}`;
+    case 'recycle_stock':
+      return 'recycle stock';
     case 'tableau_to_tableau':
       return `move ${card} col ${(move.from?.columnIndex ?? 0) + 1} -> col ${(move.to?.columnIndex ?? 0) + 1}`;
     case 'tableau_to_foundation':

--- a/packages/app/src/ai/context/renderContext.test.ts
+++ b/packages/app/src/ai/context/renderContext.test.ts
@@ -300,6 +300,6 @@ describe('renderHybridContext', () => {
     // two fields on a harvested interaction never disagree. See the
     // promptlayoutversion-lockstep follow-up note.
     expect(PROMPT_LAYOUT_VERSION).toMatch(/^hybrid-v\d+\.\d+$/);
-    expect(PROMPT_LAYOUT_VERSION).toBe('hybrid-v1.5');
+    expect(PROMPT_LAYOUT_VERSION).toBe('hybrid-v1.6');
   });
 });

--- a/packages/app/src/ai/context/renderContext.ts
+++ b/packages/app/src/ai/context/renderContext.ts
@@ -37,7 +37,7 @@ import type { AIMoveContext } from '../types';
  * computing `promptTemplateHash` to identify the variant. The hash stays
  * authoritative for byte-level identity.
  */
-export const PROMPT_LAYOUT_VERSION = 'hybrid-v1.5';
+export const PROMPT_LAYOUT_VERSION = 'hybrid-v1.6';
 
 /** Pad a column name's value column to keep `[index]` + type aligned. */
 const TYPE_COL_WIDTH = 24;

--- a/packages/app/src/ai/context/rulesPrimer.ts
+++ b/packages/app/src/ai/context/rulesPrimer.ts
@@ -27,11 +27,12 @@ NOTATION: rank+suit (A 2-9 T J Q K; H D C S). ?? = face-down. In each column the
 
 INTERPRETING THE DRAW TIMELINE (when present in the game state):
 The DRAW TIMELINE block renders the stock and waste piles as one linear sequence
-of card identifiers. The current waste top is wrapped in {curly braces}. Tokens
-LEFT of {NOW} are cards that will be drawn next in this stock cycle: the
-immediate next draw is the token directly left of {NOW}, the draw after that is
-the token two positions left, and so on. Tokens RIGHT of {NOW} are cards drawn
-earlier in this cycle, still sitting in the waste pile beneath the current top.
+of card identifiers. The current waste top is wrapped in {curly braces}; it marks
+the current position in the cycle. Tokens to its LEFT are cards that will be drawn
+next in this stock cycle: the immediate next draw is the token directly to its
+left, the draw after that is the token two positions to its left, and so on.
+Tokens to its RIGHT are cards drawn earlier in this cycle, still sitting in the
+waste pile beneath the current top.
 The token ??? marks a card whose identity has not yet been observed. ??? can
 only appear during the first stock cycle. After the first recycle every position
 is a known identity, because every stock card has passed through the waste at

--- a/packages/app/src/ai/context/systemInstruction.test.ts
+++ b/packages/app/src/ai/context/systemInstruction.test.ts
@@ -67,12 +67,12 @@ describe('hashSystemInstruction', () => {
 describe('prompt template identity (tripwire)', () => {
   it('hash with strategy guidance is pinned', async () => {
     const hash = await hashSystemInstruction(buildSystemInstruction(configWith(true)));
-    expect(hash).toBe('8a46ca22bc36c14eed0cdb5c3090f17c09ed8adc91cf0c3d13dfd8ac2e8fe337');
+    expect(hash).toBe('7d2c6cada62d3faae6c830941fcae78dfa6435bcda44b12838890c69615a987a');
   });
 
   it('hash without strategy guidance is pinned', async () => {
     const hash = await hashSystemInstruction(buildSystemInstruction(configWith(false)));
-    expect(hash).toBe('9ac8a0443d2735a37527433844258889c895dd918a54881c8399be577bd45ff1');
+    expect(hash).toBe('e9fe1aa25b2bc868d4407dd4417428b6a360fd562d498a5b85bb90b056f61470');
   });
 
   it('PROMPT_TEMPLATE_FINALISED_AT is a valid ISO 8601 UTC instant', () => {
@@ -86,6 +86,6 @@ describe('prompt template identity (tripwire)', () => {
     // restructure (`hybrid-v2.0`). The exact value is what the dataset side
     // partitions on, so it is a tripwire — bump deliberately.
     expect(PROMPT_TEMPLATE_VERSION).toMatch(/^hybrid-v\d+\.\d+$/);
-    expect(PROMPT_TEMPLATE_VERSION).toBe('hybrid-v1.5');
+    expect(PROMPT_TEMPLATE_VERSION).toBe('hybrid-v1.6');
   });
 });

--- a/packages/app/src/ai/context/systemInstruction.ts
+++ b/packages/app/src/ai/context/systemInstruction.ts
@@ -27,7 +27,7 @@ import { OUTPUT_INSTRUCTION, RULES_PRIMER, STRATEGY_GUIDANCE } from './rulesPrim
  * because the templates evolve independently of any release cadence and the
  * downstream analytics already key off ISO timestamps.
  */
-export const PROMPT_TEMPLATE_FINALISED_AT = '2026-06-06T00:00:00Z';
+export const PROMPT_TEMPLATE_FINALISED_AT = '2026-06-07T00:00:00Z';
 
 /**
  * Human-readable semantic version of the prompt template (rules + output
@@ -43,7 +43,7 @@ export const PROMPT_TEMPLATE_FINALISED_AT = '2026-06-06T00:00:00Z';
  * Adopted per the 2026-05-26 harvester-team ask in
  * `solitaire-analytics/docs/reports/20260526_harvester_team_resign_hygiene_versioning_ask.md`.
  */
-export const PROMPT_TEMPLATE_VERSION = 'hybrid-v1.5';
+export const PROMPT_TEMPLATE_VERSION = 'hybrid-v1.6';
 
 /** Build the full system instruction for a move-suggestion request. */
 export function buildSystemInstruction(config: AIConfig): string {

--- a/packages/app/src/components/ActivityLog.tsx
+++ b/packages/app/src/components/ActivityLog.tsx
@@ -107,6 +107,9 @@ const ActivityLog: React.FC = () => {
       case 'draw_card':
         return `${time} - Drew ${cardStr} from draw pile`;
 
+      case 'recycle_stock':
+        return `${time} - 🔁 Recycled the waste pile back into the stock`;
+
       case 'tableau_to_tableau':
         return `${time} - Moved ${cardStr} from column ${(move.from?.columnIndex ?? 0) + 1} to column ${(move.to?.columnIndex ?? 0) + 1}`;
 

--- a/packages/app/src/components/GameInsightsPanel.tsx
+++ b/packages/app/src/components/GameInsightsPanel.tsx
@@ -41,7 +41,7 @@ const GameInsightsPanel: React.FC = () => {
   const chartHistory = useDeferredValue(history);
 
   const [collapsed, setCollapsed] = useState(false);
-  const [tab, setTab] = useState<InsightsTab>('progress');
+  const [tab, setTab] = useState<InsightsTab>('flow');
 
   const latest = history[history.length - 1];
   const progress = latest?.progress ?? 0;
@@ -126,8 +126,8 @@ const GameInsightsPanel: React.FC = () => {
             className="mt-4 inline-flex rounded-lg bg-gray-100 p-0.5 text-xs font-semibold"
           >
             {([
-              { id: 'progress', label: 'Progress' },
               { id: 'flow', label: 'Card Flow' },
+              { id: 'progress', label: 'Progress' },
               { id: 'moves', label: 'Move Mix' },
               { id: 'ai', label: 'AI' },
             ] as const).map(({ id, label }) => (

--- a/packages/app/src/store/gameStore.ts
+++ b/packages/app/src/store/gameStore.ts
@@ -720,10 +720,28 @@ export const useGameStore = create<GameStore>((set, get) => ({
         ...card,
         faceUp: false,
       }));
+      // Record the recycle as an action in move history so RECENT MOVES (and
+      // the activity log) read `draw / recycle stock / draw` instead of two
+      // consecutive draws with the recycle invisible between them. Recycle has
+      // no single card, so it carries a marker card like the autoplay events.
+      // Only logged when there is a waste pile to recycle (a no-op recycle on
+      // a fully empty stock+waste records nothing).
+      const newMoveHistory =
+        state.discardPile.length > 0
+          ? [
+              ...state.moveHistory,
+              {
+                type: 'recycle_stock',
+                timestamp: Date.now(),
+                card: { suit: 'hearts', rank: 'A', faceUp: true, id: 'recycle-marker' },
+              } as Move,
+            ]
+          : state.moveHistory;
       set({
         drawPile: newDrawPile,
         discardPile: [],
         recycleCount: (state.recycleCount ?? 0) + 1,
+        moveHistory: newMoveHistory,
       });
     } else {
       // Draw a card from draw pile to discard pile
@@ -1216,7 +1234,23 @@ export const useGameStore = create<GameStore>((set, get) => ({
           }
           break;
         }
-        
+
+        case 'recycle_stock': {
+          // Explicit recycle: reset the stock from the waste, matching live
+          // play. Older histories (no recycle_stock entry) still recycle via
+          // the draw_card branch above; new histories recycle here, then the
+          // following draw_card sees a full stock and just draws.
+          if (newState.discardPile && newState.discardPile.length > 0) {
+            newState.drawPile = [...newState.discardPile].reverse().map(card => ({
+              ...card,
+              faceUp: false,
+            }));
+            newState.discardPile = [];
+            newState.recycleCount = (newState.recycleCount ?? 0) + 1;
+          }
+          break;
+        }
+
         case 'tableau_to_tableau': {
           if (move.from?.columnIndex !== undefined && move.to?.columnIndex !== undefined && newState.tableau) {
             const sourceColumn = [...newState.tableau[move.from.columnIndex]];

--- a/packages/app/src/types/index.ts
+++ b/packages/app/src/types/index.ts
@@ -13,8 +13,9 @@ export interface Card {
   id: string;
 }
 
-export type MoveType = 
+export type MoveType =
   | 'draw_card'
+  | 'recycle_stock'
   | 'tableau_to_tableau'
   | 'tableau_to_foundation'
   | 'discard_to_tableau'


### PR DESCRIPTION
Implements the [v1.6 harvester ask](../blob/main/docs/reports/20260607_v1_6_harvester_ask.md) (two state-not-logic fidelity fixes), plus a small Insights tweak.

## Item 1 — DRAW TIMELINE `{NOW}` prose (prose only)
The paragraph defined the position marker as `{curly braces}`, then referred to it three times as `{NOW}` — a token that never appears in the rendered data. Reworded LEFT/RIGHT to point at the braced token actually shown. The braces, the timeline data, and the `???` sentence are unchanged.

## Item 2 — record the recycle in RECENT MOVES (render)
`recycle stock` was chosen and executed but never written to move history, so the history read as two identical `draw 7D` with the recycle invisible between them (a false self-undo signal). Now recorded as a move so the history reads `draw 7D / recycle stock / draw 7D`.

- Recorded in `drawCard` (covers manual draw-pile clicks **and** AI moves, which route through `applyMoveCommand` → `drawCard`).
- Summarized as `recycle stock` in RECENT MOVES, shown as a line in the activity log, and reversed correctly in replay. Older histories with no recycle entry still recycle via the existing `draw_card` branch, so no double-recycle.
- A recycle has no single card, so it carries a marker card like the existing autoplay events.

## Versioning
- `PROMPT_TEMPLATE_VERSION` / `PROMPT_LAYOUT_VERSION` → `hybrid-v1.6`
- `PROMPT_TEMPLATE_FINALISED_AT` → `2026-06-07`
- Re-pinned the two template hash tripwires.

## Also
- Card Flow is now the first / default Insights tab.

## Validation
- All unit tests pass (373); added coverage for the recycle summary and for RECENT MOVES rendering `draw / recycle stock / draw`.
- Full local e2e suite green; an end-to-end bridge check confirms a real game records `draw_card → recycle_stock → draw_card`.
- `lint`, `build`, and typecheck clean.