### PR TITLE
feat(ai-log): embed the initial deal (initialBoardSetup) in the ai-log export

### DIFF
--- a/packages/app/src/ai/interactionLog.test.ts
+++ b/packages/app/src/ai/interactionLog.test.ts
@@ -12,6 +12,7 @@ import {
   type AIInteraction,
 } from './interactionLog';
 import { AI_INTERACTION_LOG_LIMIT } from './constants';
+import type { InitialBoardSetup } from '../types';
 
 const base: AIInteraction = {
   id: 'id-1',
@@ -173,7 +174,7 @@ describe('interactionLog', () => {
 
   it('exportAIInteractions embeds the initial deal so the deck is recoverable for losses', () => {
     recordAIInteraction(base);
-    const initialBoardSetup = {
+    const initialBoardSetup: InitialBoardSetup = {
       drawPile: [{ suit: 'clubs', rank: '9', faceUp: false, id: 'clubs-9' }],
       discardPile: [],
       foundations: { hearts: [], diamonds: [], clubs: [], spades: [] },

--- a/packages/app/src/ai/interactionLog.test.ts
+++ b/packages/app/src/ai/interactionLog.test.ts
@@ -171,6 +171,36 @@ describe('interactionLog', () => {
     expect(parsed.session).toBeUndefined();
   });
 
+  it('exportAIInteractions embeds the initial deal so the deck is recoverable for losses', () => {
+    recordAIInteraction(base);
+    const initialBoardSetup = {
+      drawPile: [{ suit: 'clubs', rank: '9', faceUp: false, id: 'clubs-9' }],
+      discardPile: [],
+      foundations: { hearts: [], diamonds: [], clubs: [], spades: [] },
+      tableau: [[{ suit: 'clubs', rank: 'J', faceUp: true, id: 'clubs-J' }]],
+    };
+    const parsed = JSON.parse(
+      exportAIInteractions(
+        {
+          sessionId: 'session-abcdef12',
+          seed: 12345,
+          model: 'gemma-4-31b-it',
+          outcome: 'lost',
+          finalProgress: 30,
+          moveCount: 80,
+        },
+        initialBoardSetup,
+      ),
+    );
+    expect(parsed.initialBoardSetup).toEqual(initialBoardSetup);
+  });
+
+  it('exportAIInteractions omits initialBoardSetup when the deal is unavailable', () => {
+    recordAIInteraction(base);
+    const parsed = JSON.parse(exportAIInteractions());
+    expect('initialBoardSetup' in parsed).toBe(false);
+  });
+
   it('accepts stalled_auto_terminated as a session outcome', () => {
     recordAIInteraction(base);
     const parsed = JSON.parse(

--- a/packages/app/src/ai/interactionLog.ts
+++ b/packages/app/src/ai/interactionLog.ts
@@ -11,6 +11,7 @@
  */
 
 import { APP_BUILD_TIME, APP_COMMIT } from '../buildInfo';
+import type { InitialBoardSetup } from '../types';
 import { AI_INTERACTION_LOG_LIMIT } from './constants';
 import type { AIConfig, AIErrorKind, AIMoveDecision } from './types';
 
@@ -268,14 +269,26 @@ export function clearAIInteractions(): void {
  * @param session - Outcome summary of the game active at export time, when
  *   available. Describes the current session only; individual interactions
  *   carry their own `sessionId` for multi-game buffers.
+ * @param initialBoardSetup - The complete turn-0 deal (true identities of all
+ *   52 cards, `drawPile` in draw order). Embedded so the ai-log is a
+ *   self-contained, replayable record — and, critically, so the deck is
+ *   recoverable for plain losses, which emit no win/game file. Omitted only
+ *   when the deal is unavailable (e.g. an imported game with no setup
+ *   snapshot); the field is then absent and treated as nullable downstream.
  */
-export function exportAIInteractions(session?: AISessionSummary): string {
+export function exportAIInteractions(
+  session?: AISessionSummary,
+  initialBoardSetup?: InitialBoardSetup,
+): string {
   return JSON.stringify(
     {
       exportedAt: new Date().toISOString(),
       appCommit: APP_COMMIT,
       appBuildTime: APP_BUILD_TIME,
       session,
+      // The same object emitted in the win/game files, reused verbatim so there
+      // is one canonical deal schema and no new computation.
+      initialBoardSetup,
       count: buffer.length,
       interactions: buffer,
     },

--- a/packages/app/src/store/gameStore.ts
+++ b/packages/app/src/store/gameStore.ts
@@ -1883,14 +1883,20 @@ export const useGameStore = create<GameStore>((set, get) => ({
           : aiAutoStalled
             ? 'stalled_auto_terminated'
             : 'incomplete';
-    return serializeAIInteractions({
-      sessionId: state.gameSessionId ?? '',
-      seed: state.seed,
-      model: (state.aiConfig ?? DEFAULT_AI_CONFIG).model,
-      outcome,
-      finalProgress: Math.round(state.completionProgress),
-      moveCount: state.moveHistory.length,
-    });
+    return serializeAIInteractions(
+      {
+        sessionId: state.gameSessionId ?? '',
+        seed: state.seed,
+        model: (state.aiConfig ?? DEFAULT_AI_CONFIG).model,
+        outcome,
+        finalProgress: Math.round(state.completionProgress),
+        moveCount: state.moveHistory.length,
+      },
+      // Embed the turn-0 deal so the ai-log alone can reconstruct the board —
+      // the only way we recover the deck for plain losses, which emit no
+      // win/game file.
+      state.initialBoardSetup,
+    );
   },
 
   dismissWinModal: () => {

--- a/packages/app/src/testBridge.ts
+++ b/packages/app/src/testBridge.ts
@@ -23,7 +23,6 @@ import { scenarios, scenarioNames, isScenarioName } from './testScenarios';
 import {
   createStubProvider,
   DEFAULT_AI_CONFIG,
-  exportAIInteractions as serializeAIInteractions,
   getAIInteractions as readAIInteractions,
   setProviderOverride,
 } from './ai';
@@ -283,7 +282,10 @@ export function installTestBridge(): void {
     },
     askAI: () => useGameStore.getState().askAIForMove(),
     getAIInteractions: () => [...readAIInteractions()],
-    exportAIInteractions: () => serializeAIInteractions(),
+    // Route through the store method (not the raw serializer) so the bridge
+    // export carries the same session summary and initialBoardSetup the real
+    // "Export AI Log" button writes.
+    exportAIInteractions: () => useGameStore.getState().exportAIInteractions(),
     toggleAIAutoPlay: () => useGameStore.getState().toggleAIAutoPlay(),
     cancelAI: () => useGameStore.getState().cancelAIRequest(),
     setAIConfig: (patch) => useGameStore.getState().setAIConfig(patch),

--- a/packages/app/src/types/index.ts
+++ b/packages/app/src/types/index.ts
@@ -48,6 +48,25 @@ export interface Move {
   aiConfidence?: number;
 }
 
+/**
+ * The complete turn-0 deal, with the true identity of every card (face-down
+ * cards included). Snapshotted at deal time and carried with the game so the
+ * exact starting board can be reconstructed and replayed. Also embedded in the
+ * win/game and ai-log exports as the canonical record of the deck a game was
+ * played on.
+ */
+export interface InitialBoardSetup {
+  drawPile: Card[];
+  discardPile: Card[];
+  foundations: {
+    hearts: Card[];
+    diamonds: Card[];
+    clubs: Card[];
+    spades: Card[];
+  };
+  tableau: Card[][];
+}
+
 export interface GameState {
   drawPile: Card[];
   discardPile: Card[];
@@ -76,17 +95,7 @@ export interface GameState {
   gameStartedAt?: number; // Timestamp the session's deal was created
   gameWon: boolean; // True when all cards are in foundations
   winModalDismissed?: boolean; // True when the user closed the win modal without starting a new game
-  initialBoardSetup?: {
-    drawPile: Card[];
-    discardPile: Card[];
-    foundations: {
-      hearts: Card[];
-      diamonds: Card[];
-      clubs: Card[];
-      spades: Card[];
-    };
-    tableau: Card[][];
-  };
+  initialBoardSetup?: InitialBoardSetup;
   perceivedDifficulty?: number; // Calculated difficulty score based on initial board setup (0-100, undefined if no initial setup)
   completionProgress: number; // Game completion percentage (0-100)
   replayMode: boolean; // True when in replay mode


### PR DESCRIPTION
Implements the [ai-log initial-deck harvester ask](../blob/main/docs/reports/20260607_harvester_ask_ailog_initial_deck.md). Logging-only, additive, and independent of the prompt-version track — ships with any build, no `hybrid-vX` bump.

## The ask
Add the complete turn-0 deal as a top-level `initialBoardSetup` key on every `solitaire-ai-log-*.json` export, reusing the exact object already emitted in the win/game files (no new file, no new computation).

## Why
The ai-log records every decision but not the deck it was played on. Won/abandoned games carry the deal via a win/game file, but a plain **loss** produces only an ai-log, so the losing deck is currently unrecoverable. Embedding the deal:
- makes the ai-log a self-contained, replayable record, and
- is the only way we get the deck for losses — unlocking dead-deal-vs-winnable classification, won-vs-lost difficulty comparison, and exact-board training reconstruction.

## Implementation
- Extracted the inline deal shape into a named `InitialBoardSetup` type and reused it across `GameState` and the exporter.
- `exportAIInteractions(session, initialBoardSetup)` now emits the deal as a top-level key (placed next to `session`, mirroring the win/game files). When the deal is unavailable (e.g. an imported game with no snapshot) the key is simply absent — nullable downstream, exactly as the ask specifies.
- Routed the test bridge's `exportAIInteractions` through the store method so a bridge export matches the real **Export AI Log** button (carries both the session summary and the deal).

## Cost / risk
~3.6 KB on a ~5.5 MB ai-log (**0.06%**). No prompt change, no change to what the model sees, no change to move selection. `appCommit` / `appBuildTime` change as usual.

## Validation
- New unit tests: the deal is embedded when supplied, and the key is omitted when unavailable.
- End-to-end bridge check confirmed the exported ai-log carries a complete 52-card deal: 24 in `drawPile` + tableau columns `[1..7]`, all ids unique across every suit/rank, empty discard/foundations, four-key card objects, and `draw_card` surfacing `drawPile[0]` first (draw order).
- Full unit suite (375), `ai-advisor`/`insights` e2e, lint, build, and typecheck all green.