### PR TITLE
feat(ui): tag AI models with colour emoji to tell them apart

### DIFF
--- a/packages/app/src/components/AIAdvisorPanel.tsx
+++ b/packages/app/src/components/AIAdvisorPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useGameStore } from '../store/gameStore';
 import { AI_REQUEST_TIMEOUT_MS } from '../ai';
+import { modelLabel } from '../utils/modelLabel';
 
 /** Format a millisecond duration as `M:SS`. */
 function formatElapsed(ms: number): string {
@@ -208,7 +209,7 @@ const AIAdvisorPanel: React.FC = () => {
             )}
 
             <p className="mt-2 text-[10px] text-gray-400 font-mono">
-              {lastDecision.model} · {new Date(lastDecision.timestamp).toLocaleTimeString()}
+              {modelLabel(lastDecision.model)} · {new Date(lastDecision.timestamp).toLocaleTimeString()}
             </p>
           </div>
         )}

--- a/packages/app/src/components/AIKeyModal.tsx
+++ b/packages/app/src/components/AIKeyModal.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useGameStore } from '../store/gameStore';
 import { DEFAULT_AI_CONFIG, listProviders } from '../ai';
 import { clearKey, getDevFallbackKey, getKey, hasUserKey, setKey } from '../ai/keyStore';
+import { modelLabel } from '../utils/modelLabel';
 import type { AIProviderId } from '../ai';
 
 /**
@@ -95,7 +96,7 @@ const AIKeyModalContent: React.FC = () => {
             : [model, ...provider.availableModels]
           ).map((m) => (
             <option key={m} value={m}>
-              {m}
+              {modelLabel(m)}
             </option>
           ))}
         </select>

--- a/packages/app/src/components/AISettingsSection.tsx
+++ b/packages/app/src/components/AISettingsSection.tsx
@@ -3,6 +3,7 @@ import { useGameStore } from '../store/gameStore';
 import { DEFAULT_AI_CONFIG } from '../ai';
 import { getEffectiveKey } from '../ai/keyStore';
 import { downloadJson, gameIdTag } from '../utils/download';
+import { modelLabel } from '../utils/modelLabel';
 import type { AIConfig, AIContextPreset } from '../ai';
 
 /** A boolean context toggle exposed in the Custom preset. */
@@ -138,7 +139,7 @@ const AISettingsSection: React.FC = () => {
               )}
             </p>
             <p className="text-[10px] text-gray-500 mb-1">
-              Model: <code className="text-[10px]">{aiConfig.model}</code>
+              Model: <code className="text-[10px]">{modelLabel(aiConfig.model)}</code>
             </p>
             <button
               data-testid="ai-key-settings-btn"

--- a/packages/app/src/utils/modelLabel.ts
+++ b/packages/app/src/utils/modelLabel.ts
@@ -1,0 +1,24 @@
+/**
+ * UI-only model labelling. Maps a raw model ID to a short colour-emoji tag so
+ * the different models are easy to tell apart at a glance in the UI.
+ *
+ * IMPORTANT: this is purely presentational. The raw model ID is what gets sent
+ * to the provider API — never pass a labelled string back into a request.
+ */
+
+/** Colour emoji per known model. Unknown models fall back to ⚪. */
+const MODEL_EMOJI: Record<string, string> = {
+  'gemma-4-31b-it': '🔵',
+  'gemma-4-26b-a4b-it': '🟢',
+  'gemini-3.1-flash-lite': '🟡',
+};
+
+/** The colour emoji for a model ID, or ⚪ if unrecognised. */
+export function modelEmoji(modelId: string): string {
+  return MODEL_EMOJI[modelId] ?? '⚪';
+}
+
+/** `"<model-id> <emoji>"` — the model ID with its colour emoji appended. */
+export function modelLabel(modelId: string): string {
+  return `${modelId} ${modelEmoji(modelId)}`;
+}


### PR DESCRIPTION
## What

Adds a small **UI-only** helper that appends a colour emoji to each AI model ID so the models are easy to distinguish at a glance:

- 🔵 \`gemma-4-31b-it\`
- 🟢 \`gemma-4-26b-a4b-it\`
- 🟡 \`gemini-3.1-flash-lite\`
- ⚪ fallback for any unrecognised model

## Where

New helper \`packages/app/src/utils/modelLabel.ts\` (\`modelLabel()\` / \`modelEmoji()\`), used in the three places a model name is shown:

- Model dropdown in \`AIKeyModal\` (the \`<option>\` text only — \`value\` stays the raw ID)
- The \`Model:\` readout in \`AISettingsSection\`
- The last-decision footer in \`AIAdvisorPanel\`

## Not touched

Purely presentational. The raw model ID is unchanged in stored config, outgoing API requests, and the ai-log export — nothing labelled is ever fed back into a request.