### PR TITLE
feat(ai): max thinking budget for gemini-3.1-flash-lite

### DIFF
--- a/packages/app/src/ai/constants.ts
+++ b/packages/app/src/ai/constants.ts
@@ -136,5 +136,18 @@ export const AI_RETRY_DELAY_CAP = 120_000;
 /** Sampling temperature for move suggestions — low, for consistent advice. */
 export const AI_TEMPERATURE = 0.3;
 
+/**
+ * Max thinking-token budget for the `gemini-3.1-flash-lite` model.
+ *
+ * Flash-lite ships with thinking essentially off by default, which made its
+ * move quality poor. We push it to the model's documented ceiling so it
+ * reasons as hard as possible before answering — trading latency for quality.
+ *
+ * Only applies to `gemini-*` models: the Gemma thinking models reason
+ * internally regardless and do not accept a `thinkingConfig` budget the same
+ * way, so we never send one to them (see {@link buildThinkingConfig}).
+ */
+export const GEMINI_FLASH_THINKING_BUDGET = 24_576;
+
 /** Base URL for the Google Generative Language REST API. */
 export const GEMINI_API_BASE = 'https://generativelanguage.googleapis.com/v1beta';

--- a/packages/app/src/ai/interactionLog.ts
+++ b/packages/app/src/ai/interactionLog.ts
@@ -60,6 +60,12 @@ export interface AIInteraction {
   inferenceParams?: {
     /** Sampling temperature passed to the provider (0 = greedy). */
     temperature?: number;
+    /**
+     * Thinking-token budget sent in `generationConfig.thinkingConfig`, when
+     * one applies (gemini-* models). Omitted for models that get no explicit
+     * budget (e.g. the Gemma thinking models).
+     */
+    thinkingBudget?: number;
   };
   /**
    * Identifier for the per-turn-prompt layout that produced this row. Mirrors

--- a/packages/app/src/ai/providers/GeminiProvider.ts
+++ b/packages/app/src/ai/providers/GeminiProvider.ts
@@ -22,6 +22,7 @@ import {
   AI_REQUEST_TIMEOUT_MS,
   AI_TEMPERATURE,
   GEMINI_API_BASE,
+  GEMINI_FLASH_THINKING_BUDGET,
 } from '../constants';
 import {
   PROMPT_LAYOUT_VERSION,
@@ -36,6 +37,28 @@ import { parseDecision } from '../decision/schema';
 import { recordAIInteraction } from '../interactionLog';
 import { uuidv7 } from '../uuid';
 import { AIError, type AIMoveDecision, type AIProvider, type AIRequest } from '../types';
+
+/** A `thinkingConfig` block for the Gemini `generationConfig`. */
+interface ThinkingConfig {
+  thinkingBudget: number;
+  includeThoughts: boolean;
+}
+
+/**
+ * Per-model thinking configuration, or `undefined` when none should be sent.
+ *
+ * Only the `gemini-*` models accept a `thinkingConfig` budget. Flash-lite
+ * defaults to almost no thinking, which gave poor move quality, so we push it
+ * to {@link GEMINI_FLASH_THINKING_BUDGET} (the model's ceiling) and ask for the
+ * thought parts back so the reasoning trail is harvested into the ai-log.
+ *
+ * The Gemma thinking models reason internally regardless and reject an explicit
+ * budget, so they get no `thinkingConfig` at all.
+ */
+function buildThinkingConfig(model: string): ThinkingConfig | undefined {
+  if (!model.startsWith('gemini-')) return undefined;
+  return { thinkingBudget: GEMINI_FLASH_THINKING_BUDGET, includeThoughts: true };
+}
 
 /** Shape of a single content part in a Gemini API response. */
 interface GeminiPart {
@@ -193,6 +216,11 @@ export const geminiProvider: AIProvider = {
     // call, before any network IO, so both the success and error branches can
     // stamp it without recomputing. SHA-256 on ~3 KB is sub-ms.
     const promptTemplateHash = await hashSystemInstruction(request.systemInstruction);
+    // Thinking budget is per-model: only gemini-* models accept it, and
+    // flash-lite needs it pushed to the ceiling for usable move quality.
+    // Declared outside the try so both the success and error log branches can
+    // stamp `thinkingBudget` into inferenceParams.
+    const thinkingConfig = buildThinkingConfig(request.model);
     let rawResponse: string | undefined;
     let thinkingText: string | undefined;
     let httpStatus: number | undefined;
@@ -200,7 +228,10 @@ export const geminiProvider: AIProvider = {
     try {
       const body = {
         contents: [{ role: 'user', parts: [{ text: prompt }] }],
-        generationConfig: { temperature: AI_TEMPERATURE },
+        generationConfig: {
+          temperature: AI_TEMPERATURE,
+          ...(thinkingConfig ? { thinkingConfig } : {}),
+        },
       };
 
       // Combine our timeout with any caller-supplied abort signal.
@@ -299,7 +330,10 @@ export const geminiProvider: AIProvider = {
         promptTemplateHash,
         promptTemplateFinalisedAt: PROMPT_TEMPLATE_FINALISED_AT,
         promptTemplateVersion: PROMPT_TEMPLATE_VERSION,
-        inferenceParams: { temperature: AI_TEMPERATURE },
+        inferenceParams: {
+          temperature: AI_TEMPERATURE,
+          ...(thinkingConfig ? { thinkingBudget: thinkingConfig.thinkingBudget } : {}),
+        },
         promptLayoutVersion: PROMPT_LAYOUT_VERSION,
         rawResponse,
         thinkingText,
@@ -329,7 +363,10 @@ export const geminiProvider: AIProvider = {
         promptTemplateHash,
         promptTemplateFinalisedAt: PROMPT_TEMPLATE_FINALISED_AT,
         promptTemplateVersion: PROMPT_TEMPLATE_VERSION,
-        inferenceParams: { temperature: AI_TEMPERATURE },
+        inferenceParams: {
+          temperature: AI_TEMPERATURE,
+          ...(thinkingConfig ? { thinkingBudget: thinkingConfig.thinkingBudget } : {}),
+        },
         promptLayoutVersion: PROMPT_LAYOUT_VERSION,
         rawResponse,
         thinkingText,


### PR DESCRIPTION
## Why

\`gemini-3.1-flash-lite\` ships with thinking effectively **off** — verified live against the API, it returned **0** thought tokens on a trivial prompt. That's why its move quality has been poor.

## What

Send \`generationConfig.thinkingConfig\` for \`gemini-*\` models, pushing flash-lite to the model's **ceiling budget (24576)** with \`includeThoughts: true\` so it reasons hard before answering and the reasoning trail is harvested into the ai-log.

- \`constants.ts\` — \`GEMINI_FLASH_THINKING_BUDGET = 24_576\`
- \`GeminiProvider.ts\` — \`buildThinkingConfig(model)\`; injected into \`generationConfig\`. **Per-model**: only \`gemini-*\` get it. The Gemma thinking models reason internally regardless and reject an explicit budget, so they get none.
- \`interactionLog.ts\` — \`inferenceParams.thinkingBudget\` stamped into the ai-log (success + error rows).

## Verification

Live probe of flash-lite:

| | thought tokens (trivial prompt) |
|---|---|
| Old (no config) | 0 |
| New (budget 24576) | 223 |

HTTP 200 — budget accepted; \`includeThoughts\` returns a separate thought part that \`extractAnswer()\` already splits out. Typecheck clean, 165 AI unit tests pass.

High thinking-token usage is expected and acceptable here; the existing 240s timeout covers the added latency.