### PR TITLE
fix(ui): tab title shows 🏳️ when the AI resigned, not 🤖

### DIFF
--- a/packages/app/e2e/ai-advisor.spec.ts
+++ b/packages/app/e2e/ai-advisor.spec.ts
@@ -81,6 +81,34 @@ test.describe('AI Move Advisor', () => {
     expect((await summary(page)).moveCount).toBe(before);
   });
 
+  test('flags an AI resignation in the tab title', async ({ page }) => {
+    // seed=7 opens with >1 legal move, so the stub is actually consulted.
+    await page.goto('/?seed=7');
+    await waitForGame(page);
+
+    // `move_index: -1` is the resignation sentinel — the harness applies no
+    // move, records `moveType: 'resign'`, and the tab title flips to 🏳️ so a
+    // resigned tab can be triaged from the tab strip.
+    await page.evaluate(() => {
+      window.__solitaire!.setAIProviderStub(() => ({
+        moveIndex: -1,
+        reasoning: 'E2E stub: resigning.',
+        confidence: 0.9,
+      }));
+    });
+
+    const before = (await summary(page)).moveCount;
+    await page.getByTestId('ask-ai-btn').click();
+
+    await page.waitForFunction(() => window.__solitaire!.getAIState().decisionCount === 1);
+
+    const ai = await page.evaluate(() => window.__solitaire!.getAIState());
+    expect(ai.lastDecision?.describe).toBe('AI resigned');
+    // The board is untouched and the title carries the resignation flag.
+    expect((await summary(page)).moveCount).toBe(before);
+    await expect(page).toHaveTitle(/^🏳️/);
+  });
+
   test('opens and closes the API key modal', async ({ page }) => {
     await page.goto('/?seed=1');
     await waitForGame(page);

--- a/packages/app/src/components/GameBoard.tsx
+++ b/packages/app/src/components/GameBoard.tsx
@@ -36,7 +36,8 @@ const GameBoard: React.FC = () => {
     : null;
 
   // Tab-title status flag, so many unattended tabs can be triaged at a glance:
-  //  🏆 game won · ⚠️ AI stopped and needs attention · 🤖 AI on.
+  //  🏆 game won · ⚠️ AI stopped and needs attention · 🏳️ AI resigned ·
+  //  🤖 AI on.
   // "AI on" = an API key is available for this tab (env fallback or a saved
   // key). When on, we append just the model's colour emoji (no name — tab
   // space is tight; see modelEmoji) so several tabs each running a different
@@ -52,6 +53,16 @@ const GameBoard: React.FC = () => {
   void aiKeyModalOpen;
   const aiOn = Boolean(getEffectiveKey(aiConfig.provider));
   const aiStopped = Boolean(aiError) && !aiThinking && !aiAutoPlay;
+  // Resignation is read off the decision log rather than a transient flag so
+  // the 🏳️ survives a reload (the log is persisted). A newer decision —
+  // including an in-flight request — supersedes it.
+  const aiResignedLast = useGameStore((s) => {
+    const log = s.aiDecisionLog;
+    return log && log.length > 0
+      ? log[log.length - 1].moveType === 'resign'
+      : false;
+  });
+  const aiResigned = aiResignedLast && !aiThinking;
   // The model tag carries its own trailing space so the prefix omits it cleanly
   // when no model is known.
   const modelTag = aiOn && aiConfig.model ? `${modelEmoji(aiConfig.model)} ` : '';
@@ -59,9 +70,11 @@ const GameBoard: React.FC = () => {
     ? '🏆 '
     : aiStopped
       ? `⚠️ ${modelTag}`
-      : aiOn
-        ? `🤖 ${modelTag}`
-        : '';
+      : aiResigned
+        ? `🏳️ ${modelTag}`
+        : aiOn
+          ? `🤖 ${modelTag}`
+          : '';
 
   useEffect(() => {
     const base = gameLabel ? `Solitaire ${gameLabel}` : 'Solitaire';


### PR DESCRIPTION
## Problem

When the AI resigns (`move_index: -1`), the browser tab title kept showing the 🤖 prefix. The resign path clears `aiError` and only sets a status string, so the title logic fell through to the plain "AI on" branch — a resigned tab could not be triaged from the tab strip.

## Change

- Derive a resigned flag in `GameBoard` from the last `aiDecisionLog` entry (`moveType === 'resign'`). The log is persisted with the session and travels with exports, so the flag survives a reload; any newer decision (including an in-flight request) clears it.
- Title priority: 🏆 won → ⚠️ error → 🏳️ resigned → 🤖 AI on, model colour emoji still appended (e.g. `🏳️ 🔵 Solitaire #7256a3 · seed 42`).

## Testing

- New e2e test drives a real resignation through the provider stub (seed 7, `moveIndex: -1`) and asserts the title, the untouched board, and the logged decision.
- Lint clean, 375 unit tests pass, all 67 e2e tests pass, production build succeeds.