### PR TITLE
feat(ai): add TokenRouter provider (MiniMax-M3)

### DIFF
--- a/packages/app/src/ai/constants.ts
+++ b/packages/app/src/ai/constants.ts
@@ -151,3 +151,6 @@ export const GEMINI_FLASH_THINKING_BUDGET = 24_576;
 
 /** Base URL for the Google Generative Language REST API. */
 export const GEMINI_API_BASE = 'https://generativelanguage.googleapis.com/v1beta';
+
+/** Base URL for the TokenRouter OpenAI-compatible gateway. */
+export const TOKENROUTER_API_BASE = 'https://api.tokenrouter.com/v1';

--- a/packages/app/src/ai/keyStore.ts
+++ b/packages/app/src/ai/keyStore.ts
@@ -27,13 +27,20 @@ function getStorage(): Storage | null {
 }
 
 /**
- * Dev-only fallback key, injected from the repo-root `.env` at build time.
- * Empty string in production builds. Lets `pnpm dev` use a `.env` key without
- * pasting it into the UI. See `vite.config.ts`.
+ * Dev-only fallback key for a provider, injected from the repo-root `.env` at
+ * build time. Empty string in production builds. Lets `pnpm dev` use a `.env`
+ * key without pasting it into the UI. See `vite.config.ts`.
  */
-export function getDevFallbackKey(): string {
+export function getDevFallbackKey(provider: AIProviderId): string {
   try {
-    return typeof __DEV_GEMINI_KEY__ === 'string' ? __DEV_GEMINI_KEY__ : '';
+    switch (provider) {
+      case 'gemini':
+        return typeof __DEV_GEMINI_KEY__ === 'string' ? __DEV_GEMINI_KEY__ : '';
+      case 'tokenrouter':
+        return typeof __DEV_TOKENROUTER_KEY__ === 'string' ? __DEV_TOKENROUTER_KEY__ : '';
+      default:
+        return '';
+    }
   } catch {
     return '';
   }
@@ -54,7 +61,7 @@ export function getKey(provider: AIProviderId): string | null {
 export function getEffectiveKey(provider: AIProviderId): string | null {
   const stored = getKey(provider);
   if (stored) return stored;
-  const fallback = getDevFallbackKey();
+  const fallback = getDevFallbackKey(provider);
   return fallback.length > 0 ? fallback : null;
 }
 

--- a/packages/app/src/ai/providers/TokenRouterProvider.test.ts
+++ b/packages/app/src/ai/providers/TokenRouterProvider.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Tests for the TokenRouter provider — HTTP and response handling are
+ * exercised against a mocked `fetch`.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { tokenRouterProvider } from './TokenRouterProvider';
+import { AI_TEMPERATURE, TOKENROUTER_API_BASE } from '../constants';
+import { clearAIInteractions, getLastAIInteraction } from '../interactionLog';
+import { AIError, type AIMoveContext, type AIRequest } from '../types';
+
+const context: AIMoveContext = {
+  notation: 'test',
+  foundations: { hearts: null, diamonds: null, clubs: null, spades: null },
+  tableau: [],
+  discardTop: null,
+  drawPileCount: 0,
+  canRecycleStock: false,
+  cycle: 1,
+  legalMoves: [
+    { index: 0, type: 'draw_card', describe: 'Draw' },
+    { index: 1, type: 'discard_to_foundation', describe: 'To foundation' },
+  ],
+};
+
+const request: AIRequest = {
+  apiKey: 'test-key',
+  model: 'MiniMax-M3',
+  systemInstruction: 'Be a solitaire advisor.',
+  context,
+};
+
+const DECISION_JSON =
+  '{"board_analysis":"An ace is playable.",' +
+  '"strategic_plan":"Bank the card.",' +
+  '"final_decision":{"move_index":1,"confidence":0.9}}';
+
+/** Build a minimal `Response`-like object. */
+function mockResponse(
+  status: number,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Headers(headers),
+    json: async () => body,
+  } as Response;
+}
+
+/** A successful chat-completions body wrapping `content`. */
+function completion(content: string, extra: Record<string, unknown> = {}): unknown {
+  return {
+    choices: [{ message: { content, ...extra }, finish_reason: 'stop' }],
+    usage: {
+      prompt_tokens: 183,
+      completion_tokens: 28,
+      total_tokens: 211,
+      completion_tokens_details: { reasoning_tokens: 30 },
+    },
+  };
+}
+
+describe('tokenRouterProvider.suggestMove', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+    clearAIInteractions();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('rejects when no API key is supplied', async () => {
+    await expect(
+      tokenRouterProvider.suggestMove({ ...request, apiKey: '' }),
+    ).rejects.toMatchObject({ kind: 'no_key' });
+  });
+
+  it('sends an OpenAI-style request with Bearer auth, model, and temperature', async () => {
+    vi.mocked(fetch).mockResolvedValue(mockResponse(200, completion(DECISION_JSON)));
+    await tokenRouterProvider.suggestMove(request);
+
+    const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${TOKENROUTER_API_BASE}/chat/completions`);
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer test-key');
+    const body = JSON.parse(init.body as string) as {
+      model: string;
+      temperature: number;
+      messages: { role: string; content: string }[];
+    };
+    expect(body.model).toBe('MiniMax-M3');
+    expect(body.temperature).toBe(AI_TEMPERATURE);
+    expect(body.messages).toHaveLength(1);
+    expect(body.messages[0].role).toBe('user');
+    expect(body.messages[0].content).toContain('Be a solitaire advisor.');
+  });
+
+  it('strips an inline <think> block and logs it as the thinking text', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse(
+        200,
+        completion(`<think>\nWeighing the foundation play...\n</think>\n\n${DECISION_JSON}`),
+      ),
+    );
+
+    const decision = await tokenRouterProvider.suggestMove(request);
+    expect(decision.moveIndex).toBe(1);
+    expect(decision.reasoning).toBe('Bank the card.');
+    expect(decision.boardAnalysis).toBe('An ace is playable.');
+
+    const last = getLastAIInteraction();
+    expect(last?.thinkingText).toBe('Weighing the foundation play...');
+    expect(last?.rawResponse).toBe(DECISION_JSON);
+  });
+
+  it('captures a distinct reasoning_content field when present', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse(
+        200,
+        completion(DECISION_JSON, { reasoning_content: 'Separate reasoning channel.' }),
+      ),
+    );
+    await tokenRouterProvider.suggestMove(request);
+    expect(getLastAIInteraction()?.thinkingText).toBe('Separate reasoning channel.');
+  });
+
+  it('records OpenAI-style usage tokens on the logged interaction', async () => {
+    vi.mocked(fetch).mockResolvedValue(mockResponse(200, completion(DECISION_JSON)));
+    await tokenRouterProvider.suggestMove(request);
+
+    const last = getLastAIInteraction();
+    expect(last?.provider).toBe('tokenrouter');
+    expect(last?.outcome).toBe('success');
+    expect(last?.promptTokens).toBe(183);
+    expect(last?.outputTokens).toBe(28);
+    expect(last?.thoughtTokens).toBe(30);
+    expect(last?.totalTokens).toBe(211);
+  });
+
+  it('records a resignation (move_index -1) with outcome "resigned"', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse(
+        200,
+        completion(
+          '{"board_analysis":"No outs.","strategic_plan":"Resign.",' +
+            '"final_decision":{"move_index":-1}}',
+        ),
+      ),
+    );
+    const decision = await tokenRouterProvider.suggestMove(request);
+    expect(decision.moveIndex).toBe(-1);
+    expect(getLastAIInteraction()?.outcome).toBe('resigned');
+  });
+
+  it('maps HTTP 401 to invalid_key', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse(401, { error: { message: 'invalid api key' } }),
+    );
+    await expect(tokenRouterProvider.suggestMove(request)).rejects.toMatchObject({
+      kind: 'invalid_key',
+    });
+    expect(getLastAIInteraction()?.outcome).toBe('error');
+  });
+
+  it('maps HTTP 429 to rate_limited, honouring a Retry-After header', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse(429, { error: { message: 'slow down' } }, { 'retry-after': '17' }),
+    );
+    await expect(tokenRouterProvider.suggestMove(request)).rejects.toMatchObject({
+      kind: 'rate_limited',
+      retryAfterMs: 17_000,
+    });
+  });
+
+  it('maps HTTP 404 to config (unknown model)', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse(404, { error: { message: 'model not found' } }),
+    );
+    await expect(tokenRouterProvider.suggestMove(request)).rejects.toMatchObject({
+      kind: 'config',
+    });
+  });
+
+  it('maps HTTP 5xx to unavailable', async () => {
+    vi.mocked(fetch).mockResolvedValue(mockResponse(503, null));
+    await expect(tokenRouterProvider.suggestMove(request)).rejects.toMatchObject({
+      kind: 'unavailable',
+    });
+  });
+
+  it('maps a network failure to a typed network error', async () => {
+    vi.mocked(fetch).mockRejectedValue(new TypeError('Failed to fetch'));
+    await expect(tokenRouterProvider.suggestMove(request)).rejects.toMatchObject({
+      kind: 'network',
+    });
+  });
+
+  it('rejects with bad_response when the body is not JSON', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      json: async () => {
+        throw new SyntaxError('Unexpected token');
+      },
+    } as unknown as Response);
+    await expect(tokenRouterProvider.suggestMove(request)).rejects.toMatchObject({
+      kind: 'bad_response',
+    });
+  });
+
+  it('rejects with bad_response when the answer is empty after <think> stripping', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse(200, completion('<think>all thinking, no answer</think>')),
+    );
+    await expect(tokenRouterProvider.suggestMove(request)).rejects.toBeInstanceOf(AIError);
+    await expect(
+      tokenRouterProvider.suggestMove(request),
+    ).rejects.toMatchObject({ kind: 'bad_response' });
+  });
+
+  it('surfaces an abort during the response-body read as aborted, not bad JSON', async () => {
+    const controller = new AbortController();
+    vi.mocked(fetch).mockImplementation(async () => {
+      controller.abort();
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        json: async () => {
+          throw new DOMException('Aborted', 'AbortError');
+        },
+      } as unknown as Response;
+    });
+    await expect(
+      tokenRouterProvider.suggestMove({ ...request, signal: controller.signal }),
+    ).rejects.toMatchObject({ kind: 'aborted' });
+  });
+});

--- a/packages/app/src/ai/providers/TokenRouterProvider.ts
+++ b/packages/app/src/ai/providers/TokenRouterProvider.ts
@@ -1,0 +1,321 @@
+/**
+ * TokenRouter provider for the AI Move Advisor.
+ *
+ * TokenRouter (https://www.tokenrouter.com) is a unified OpenAI-compatible
+ * gateway in front of many hosted models. The app calls its
+ * `/chat/completions` endpoint directly from the browser with the user's own
+ * API key (Bearer auth, permissive CORS) — there is no backend.
+ *
+ * Design notes:
+ * - Same single-user-message prompt as the Gemini provider: system
+ *   instruction + hybrid game context concatenated. One code path, one
+ *   prompt-template hash, regardless of gateway-side model.
+ * - `MiniMax-M3` is a thinking model that emits its reasoning *inline* as a
+ *   `<think>…</think>` block at the start of `message.content` (TokenRouter
+ *   does not split it into a separate field). The block is stripped before
+ *   decision parsing and captured as the interaction's `thinkingText`. A
+ *   separate `reasoning_content` field, when a gateway model provides one,
+ *   is honoured too.
+ *
+ * @module ai/providers/TokenRouterProvider
+ */
+
+import {
+  AI_RATE_LIMIT_FALLBACK_DELAY,
+  AI_REQUEST_TIMEOUT_MS,
+  AI_TEMPERATURE,
+  TOKENROUTER_API_BASE,
+} from '../constants';
+import {
+  PROMPT_LAYOUT_VERSION,
+  renderHybridContext,
+} from '../context/renderContext';
+import {
+  PROMPT_TEMPLATE_FINALISED_AT,
+  PROMPT_TEMPLATE_VERSION,
+  hashSystemInstruction,
+} from '../context/systemInstruction';
+import { parseDecision } from '../decision/schema';
+import { recordAIInteraction } from '../interactionLog';
+import { uuidv7 } from '../uuid';
+import { AIError, type AIMoveDecision, type AIProvider, type AIRequest } from '../types';
+
+/** Token-usage block from an OpenAI-compatible response. */
+interface TokenRouterUsage {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+  completion_tokens_details?: { reasoning_tokens?: number };
+}
+
+/** Minimal shape of the `/chat/completions` response we rely on. */
+interface TokenRouterResponse {
+  choices?: {
+    message?: { content?: string; reasoning_content?: string };
+    finish_reason?: string;
+  }[];
+  usage?: TokenRouterUsage;
+  error?: { code?: number | string; message?: string; type?: string };
+}
+
+/** Parse a `Retry-After` header (delta-seconds form) into milliseconds. */
+function retryAfterMsFromHeader(response: Response): number | undefined {
+  let raw: string | null;
+  try {
+    raw = response.headers?.get('retry-after') ?? null;
+  } catch {
+    return undefined;
+  }
+  if (!raw) return undefined;
+  const seconds = Number(raw.trim());
+  if (!Number.isFinite(seconds) || seconds <= 0) return undefined;
+  return Math.round(seconds * 1000);
+}
+
+/** Map a non-OK HTTP response to a typed {@link AIError}. */
+function errorFromHttp(
+  status: number,
+  body: TokenRouterResponse | null,
+  retryAfterMs?: number,
+): AIError {
+  const message = body?.error?.message ?? '';
+  const lower = message.toLowerCase();
+
+  if (status === 429) {
+    // Honor the server's Retry-After; otherwise wait long enough to clear a
+    // per-minute window (a short retry would just hit the limit again).
+    const delay = retryAfterMs ?? AI_RATE_LIMIT_FALLBACK_DELAY;
+    return new AIError(
+      'rate_limited',
+      `TokenRouter rate limit reached (retry in ~${Math.round(delay / 1000)}s).`,
+      delay,
+    );
+  }
+  if (status === 401 || status === 403) {
+    return new AIError('invalid_key', 'TokenRouter rejected the API key. Check that it is valid.');
+  }
+  if (status === 400) {
+    if (lower.includes('api key') || lower.includes('api_key')) {
+      return new AIError('invalid_key', 'TokenRouter rejected the API key. Check that it is valid.');
+    }
+    return new AIError(
+      'bad_response',
+      `TokenRouter rejected the request: ${message || 'bad request'}.`,
+    );
+  }
+  if (status === 404) {
+    return new AIError(
+      'config',
+      `Model not found (404). ${message || 'Check the model id in AI settings.'}`,
+    );
+  }
+  if (status >= 500) {
+    return new AIError('unavailable', 'TokenRouter is temporarily unavailable. Try again shortly.');
+  }
+  return new AIError('network', `TokenRouter request failed (HTTP ${status}). ${message}`.trim());
+}
+
+/**
+ * Extract the model's answer and reasoning trace from a response.
+ *
+ * Thinking models routed through TokenRouter prepend their internal
+ * reasoning to `message.content` as a `<think>…</think>` block; some models
+ * instead return a distinct `reasoning_content` field. Both are captured.
+ */
+function extractAnswer(data: TokenRouterResponse): { text: string; thinking: string } {
+  const choice = data.choices?.[0];
+  const content = choice?.message?.content;
+  if (typeof content !== 'string') {
+    throw new AIError('bad_response', 'TokenRouter returned no message content.');
+  }
+
+  const thinkBlocks: string[] = [];
+  const answer = content
+    .replace(/<think>([\s\S]*?)<\/think>/g, (_, inner: string) => {
+      thinkBlocks.push(inner.trim());
+      return '';
+    })
+    .trim();
+
+  const thinking = [choice?.message?.reasoning_content?.trim(), ...thinkBlocks]
+    .filter((t): t is string => Boolean(t && t.length > 0))
+    .join('\n')
+    .trim();
+
+  if (answer.length === 0) {
+    throw new AIError(
+      'bad_response',
+      `TokenRouter returned an empty answer (finish_reason: ${choice?.finish_reason ?? 'unknown'}).`,
+    );
+  }
+  return { text: answer, thinking };
+}
+
+/** The TokenRouter provider. */
+export const tokenRouterProvider: AIProvider = {
+  id: 'tokenrouter',
+  displayName: 'TokenRouter',
+  requiresKey: true,
+  defaultModel: 'MiniMax-M3',
+  availableModels: ['MiniMax-M3'],
+  apiKeyUrl: 'https://www.tokenrouter.com/',
+
+  async suggestMove(request: AIRequest): Promise<AIMoveDecision> {
+    if (!request.apiKey) {
+      throw new AIError('no_key', 'No TokenRouter API key configured.');
+    }
+
+    const startedAt = Date.now();
+    // Single user message: system instruction + hybrid game context — same
+    // prompt construction as the Gemini provider so the harvested log stays
+    // comparable across providers (layout contract in `context/renderContext`).
+    const prompt =
+      `${request.systemInstruction}\n\n` +
+      `CURRENT GAME:\n${renderHybridContext(request.context)}\n\n` +
+      'Now choose the best move and reply with only the JSON object.';
+    const promptTemplateHash = await hashSystemInstruction(request.systemInstruction);
+    let rawResponse: string | undefined;
+    let thinkingText: string | undefined;
+    let httpStatus: number | undefined;
+
+    try {
+      const body = {
+        model: request.model,
+        messages: [{ role: 'user', content: prompt }],
+        temperature: AI_TEMPERATURE,
+      };
+
+      // Combine our timeout with any caller-supplied abort signal.
+      const controller = new AbortController();
+      let timedOut = false;
+      const timer = setTimeout(() => {
+        timedOut = true;
+        controller.abort();
+      }, AI_REQUEST_TIMEOUT_MS);
+      const onParentAbort = () => controller.abort();
+      request.signal?.addEventListener('abort', onParentAbort);
+
+      // The timeout must cover the *whole* operation — the fetch AND the
+      // response-body read (a stalled body read is otherwise unbounded), so
+      // `response.json()` stays inside the timed/abortable section.
+      let response: Response | undefined;
+      let data: TokenRouterResponse | null = null;
+      try {
+        response = await fetch(`${TOKENROUTER_API_BASE}/chat/completions`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${request.apiKey}`,
+          },
+          body: JSON.stringify(body),
+          signal: controller.signal,
+        });
+        httpStatus = response.status;
+        try {
+          data = (await response.json()) as TokenRouterResponse;
+        } catch (jsonErr) {
+          // An abort during the body read must surface as a timeout/cancel,
+          // not be swallowed as "malformed JSON".
+          if (jsonErr instanceof DOMException && jsonErr.name === 'AbortError') {
+            throw jsonErr;
+          }
+          data = null;
+        }
+      } catch (err) {
+        if (err instanceof DOMException && err.name === 'AbortError') {
+          throw new AIError(
+            timedOut ? 'timeout' : 'aborted',
+            timedOut
+              ? `The model did not respond within ${Math.round(AI_REQUEST_TIMEOUT_MS / 1000)}s.`
+              : 'The AI request was cancelled.',
+          );
+        }
+        throw new AIError('network', 'Could not reach TokenRouter. Check your network connection.');
+      } finally {
+        clearTimeout(timer);
+        request.signal?.removeEventListener('abort', onParentAbort);
+      }
+
+      if (!response) {
+        throw new AIError('network', 'Could not reach TokenRouter.');
+      }
+      if (!response.ok) {
+        throw errorFromHttp(response.status, data, retryAfterMsFromHeader(response));
+      }
+      if (!data) {
+        throw new AIError('bad_response', 'TokenRouter returned a response that was not JSON.');
+      }
+      if (data.error) {
+        const code = typeof data.error.code === 'number' ? data.error.code : 500;
+        throw errorFromHttp(code, data);
+      }
+
+      const answer = extractAnswer(data);
+      rawResponse = answer.text;
+      thinkingText = answer.thinking || undefined;
+      const decision = parseDecision(rawResponse, request.context.legalMoves.length);
+
+      // Log the full interaction: prompt, response, thinking, decision, tokens.
+      // `moveIndex === -1` is the resignation signal — recorded as `resigned`,
+      // no move is applied (same contract as the Gemini provider).
+      const usage = data.usage;
+      const isResign = decision.moveIndex === -1;
+      recordAIInteraction({
+        id: uuidv7(),
+        requestId: request.requestId ?? uuidv7(),
+        sessionId: request.sessionId ?? '',
+        attempt: request.attempt ?? 1,
+        timestamp: Date.now(),
+        provider: 'tokenrouter',
+        model: request.model,
+        seed: request.seed,
+        turnIndex: request.turnIndex,
+        config: request.config,
+        outcome: isResign ? 'resigned' : 'success',
+        durationMs: Date.now() - startedAt,
+        prompt,
+        promptTemplateHash,
+        promptTemplateFinalisedAt: PROMPT_TEMPLATE_FINALISED_AT,
+        promptTemplateVersion: PROMPT_TEMPLATE_VERSION,
+        inferenceParams: { temperature: AI_TEMPERATURE },
+        promptLayoutVersion: PROMPT_LAYOUT_VERSION,
+        rawResponse,
+        thinkingText,
+        decision,
+        httpStatus,
+        promptTokens: usage?.prompt_tokens,
+        thoughtTokens: usage?.completion_tokens_details?.reasoning_tokens,
+        outputTokens: usage?.completion_tokens,
+        totalTokens: usage?.total_tokens,
+      });
+      return decision;
+    } catch (err) {
+      recordAIInteraction({
+        id: uuidv7(),
+        requestId: request.requestId ?? uuidv7(),
+        sessionId: request.sessionId ?? '',
+        attempt: request.attempt ?? 1,
+        timestamp: Date.now(),
+        provider: 'tokenrouter',
+        model: request.model,
+        seed: request.seed,
+        turnIndex: request.turnIndex,
+        config: request.config,
+        outcome: 'error',
+        durationMs: Date.now() - startedAt,
+        prompt,
+        promptTemplateHash,
+        promptTemplateFinalisedAt: PROMPT_TEMPLATE_FINALISED_AT,
+        promptTemplateVersion: PROMPT_TEMPLATE_VERSION,
+        inferenceParams: { temperature: AI_TEMPERATURE },
+        promptLayoutVersion: PROMPT_LAYOUT_VERSION,
+        rawResponse,
+        thinkingText,
+        httpStatus,
+        errorKind: err instanceof AIError ? err.kind : 'network',
+        errorMessage: err instanceof Error ? err.message : String(err),
+      });
+      throw err;
+    }
+  },
+};

--- a/packages/app/src/ai/providers/index.ts
+++ b/packages/app/src/ai/providers/index.ts
@@ -13,10 +13,12 @@
 
 import { AIError, type AIProvider, type AIProviderId } from '../types';
 import { geminiProvider } from './GeminiProvider';
+import { tokenRouterProvider } from './TokenRouterProvider';
 
 /** All registered providers, keyed by id. */
 const REGISTRY: Record<AIProviderId, AIProvider> = {
   gemini: geminiProvider,
+  tokenrouter: tokenRouterProvider,
 };
 
 /** Active test override; when set, {@link getProvider} returns it for any id. */
@@ -53,5 +55,6 @@ export function getProviderOverride(): AIProvider | null {
 }
 
 export { geminiProvider } from './GeminiProvider';
+export { tokenRouterProvider } from './TokenRouterProvider';
 export { createStubProvider } from './stubProvider';
 export type { StubDecisionFn } from './stubProvider';

--- a/packages/app/src/ai/types.ts
+++ b/packages/app/src/ai/types.ts
@@ -17,7 +17,7 @@ import type { Suit } from '../types';
 // ---------------------------------------------------------------------------
 
 /** Identifier for an LLM provider. Extend this union to add new providers. */
-export type AIProviderId = 'gemini';
+export type AIProviderId = 'gemini' | 'tokenrouter';
 
 /**
  * Context verbosity preset. Controls how much information is sent to the LLM.

--- a/packages/app/src/components/AIKeyModal.tsx
+++ b/packages/app/src/components/AIKeyModal.tsx
@@ -15,21 +15,41 @@ const AIKeyModalContent: React.FC = () => {
   const setAIConfig = useGameStore((s) => s.setAIConfig);
 
   const providers = listProviders();
-  const provider = providers.find((p) => p.id === aiConfig.provider) ?? providers[0];
-  const providerId = aiConfig.provider as AIProviderId;
 
+  const [providerId, setProviderId] = useState<AIProviderId>(aiConfig.provider);
   const [keyInput, setKeyInput] = useState('');
   const [model, setModel] = useState(aiConfig.model);
   const [keyAlreadySet, setKeyAlreadySet] = useState(() => hasUserKey(providerId));
   const [notice, setNotice] = useState<string | null>(null);
 
+  const provider = providers.find((p) => p.id === providerId) ?? providers[0];
+
   if (!provider) return null;
 
-  const devKeyAvailable = getDevFallbackKey().length > 0;
+  const devKeyAvailable = getDevFallbackKey(providerId).length > 0;
+
+  const handleProviderChange = (id: AIProviderId) => {
+    const next = providers.find((p) => p.id === id);
+    if (!next) return;
+    setProviderId(id);
+    // Model lists are provider-specific; switching keeps the stored model only
+    // when it is valid for the new provider.
+    setModel(id === aiConfig.provider ? aiConfig.model : next.defaultModel);
+    setKeyInput('');
+    setKeyAlreadySet(hasUserKey(id));
+    setNotice(null);
+  };
 
   const handleSave = () => {
+    const patch: { provider?: AIProviderId; model?: string } = {};
+    if (providerId !== aiConfig.provider) {
+      patch.provider = providerId;
+    }
     if (model.trim().length > 0 && model.trim() !== aiConfig.model) {
-      setAIConfig({ model: model.trim() });
+      patch.model = model.trim();
+    }
+    if (Object.keys(patch).length > 0) {
+      setAIConfig(patch);
     }
     const trimmed = keyInput.trim();
     if (trimmed.length > 0) {
@@ -73,10 +93,25 @@ const AIKeyModalContent: React.FC = () => {
         </div>
 
         {/* Provider */}
-        <label className="block text-sm font-semibold text-gray-700 mb-1">Provider</label>
-        <div className="mb-4 text-sm text-gray-800 bg-gray-100 rounded px-3 py-2">
-          {provider.displayName}
-        </div>
+        <label
+          htmlFor="ai-provider-input"
+          className="block text-sm font-semibold text-gray-700 mb-1"
+        >
+          Provider
+        </label>
+        <select
+          id="ai-provider-input"
+          data-testid="ai-provider-input"
+          value={providerId}
+          onChange={(e) => handleProviderChange(e.target.value as AIProviderId)}
+          className="w-full border border-gray-300 rounded px-3 py-2 mb-4 text-sm bg-white"
+        >
+          {providers.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.displayName}
+            </option>
+          ))}
+        </select>
 
         {/* Model — a dropdown of the provider's known models. If the stored
             config names one outside that list (e.g. a legacy value), include
@@ -100,11 +135,18 @@ const AIKeyModalContent: React.FC = () => {
             </option>
           ))}
         </select>
-        <p className="text-xs text-gray-500 mb-4">
-          Default <code>gemma-4-31b-it</code> is a thinking model — a suggestion can take
-          up to ~3 minutes. Pick a faster model (e.g.{' '}
-          <code>gemini-3.1-flash-lite</code>) for quicker, lower-quality advice.
-        </p>
+        {provider.id === 'gemini' ? (
+          <p className="text-xs text-gray-500 mb-4">
+            Default <code>gemma-4-31b-it</code> is a thinking model — a suggestion can take
+            up to ~3 minutes. Pick a faster model (e.g.{' '}
+            <code>gemini-3.1-flash-lite</code>) for quicker, lower-quality advice.
+          </p>
+        ) : (
+          <p className="text-xs text-gray-500 mb-4">
+            <code>MiniMax-M3</code> is a thinking model — a suggestion can take a minute or
+            two on a complex board.
+          </p>
+        )}
 
         {/* API key */}
         <label htmlFor="ai-key-input" className="block text-sm font-semibold text-gray-700 mb-1">

--- a/packages/app/src/utils/modelLabel.ts
+++ b/packages/app/src/utils/modelLabel.ts
@@ -11,6 +11,7 @@ const MODEL_EMOJI: Record<string, string> = {
   'gemma-4-31b-it': '🔵',
   'gemma-4-26b-a4b-it': '🟢',
   'gemini-3.1-flash-lite': '🟡',
+  'MiniMax-M3': '🟣',
 };
 
 /** The colour emoji for a model ID, or ⚪ if unrecognised. */

--- a/packages/app/src/vite-env.d.ts
+++ b/packages/app/src/vite-env.d.ts
@@ -7,3 +7,8 @@ declare const __COMMIT_HASH__: string
  * Empty string in production builds. See `vite.config.ts`.
  */
 declare const __DEV_GEMINI_KEY__: string
+/**
+ * Dev-only TokenRouter API key, injected from the repo-root `.env` by Vite.
+ * Empty string in production builds. See `vite.config.ts`.
+ */
+declare const __DEV_TOKENROUTER_KEY__: string

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -26,6 +26,7 @@ export default defineConfig(({ mode }) => {
   // development — a production build always receives an empty string, so the
   // key is never embedded in shipped code and prod users must paste their own.
   const devGeminiKey = mode === 'development' ? (rootEnv.GEMINI_API_KEY ?? '') : ''
+  const devTokenRouterKey = mode === 'development' ? (rootEnv.TOKENROUTER_API_KEY ?? '') : ''
 
   return {
     plugins: [react()],
@@ -34,6 +35,7 @@ export default defineConfig(({ mode }) => {
       __BUILD_TIME__: JSON.stringify(getBuildInfo().buildTime),
       __COMMIT_HASH__: JSON.stringify(getBuildInfo().commitHash),
       __DEV_GEMINI_KEY__: JSON.stringify(devGeminiKey),
+      __DEV_TOKENROUTER_KEY__: JSON.stringify(devTokenRouterKey),
     },
     build: {
       // The `echarts` chunk below is a deliberately large vendor bundle that is


### PR DESCRIPTION
## Summary

Adds **TokenRouter** (https://www.tokenrouter.com) as a second AI Move Advisor provider, alongside Gemini, via its OpenAI-compatible `/v1/chat/completions` gateway (`https://api.tokenrouter.com/v1`, Bearer auth, permissive CORS). Default and only listed model: `MiniMax-M3`.

## Changes

- **`TokenRouterProvider`** — same transport contract as the Gemini provider: single user message (system instruction + hybrid context), `parseDecision` on the answer, full interaction logging on both success and error branches. MiniMax-M3 emits its reasoning inline as a `<think>…</think>` block; it is stripped before parsing and harvested as `thinkingText` (a separate `reasoning_content` field is honoured too). OpenAI usage fields map onto the existing token columns (`completion_tokens_details.reasoning_tokens` → `thoughtTokens`).
- **Error mapping** — 401/403 → `invalid_key`, 429 → `rate_limited` honouring `Retry-After`, 404 → `config`, 5xx → `unavailable`; whole-operation timeout including the body read, mirroring the Gemini provider.
- **Provider-aware dev key** — `getDevFallbackKey(provider)`; `TOKENROUTER_API_KEY` from the repo-root `.env` is injected as `__DEV_TOKENROUTER_KEY__` in dev builds only (verified absent from the production bundle).
- **AI key modal** — the static provider label becomes a dropdown (`data-testid="ai-provider-input"`); switching providers resets the model to the new provider's default and re-resolves the stored-key state.

## Testing

- 14 new unit tests for the provider (mocked `fetch`): request shape, `<think>` stripping, usage capture, resignation, full error mapping, abort-during-body-read. `pnpm run test:run`: 409 passed; lint, typecheck, e2e (71 passed), and production build all green.
- Live headless smoke test against the real API on a seeded board: HTTP 200 in ~105 s, decision parsed (AC → clubs foundation) and applied, thinking text + token usage + layout/template stamps all recorded in the interaction log.