### PR TITLE
fix(app): recolour Export/Replay/Ask AI so AI Auto stands out

### DIFF
--- a/packages/app/src/components/ControlPanel.tsx
+++ b/packages/app/src/components/ControlPanel.tsx
@@ -266,7 +266,7 @@ const ControlPanel: React.FC = () => {
         <button
           data-testid="export-btn"
           onClick={handleExport}
-          className="w-full bg-purple-600 hover:bg-purple-700 text-white font-semibold py-2 px-4 rounded transition-colors text-sm"
+          className="w-full bg-sky-600 hover:bg-sky-700 text-white font-semibold py-2 px-4 rounded transition-colors text-sm"
         >
           Export Game
         </button>
@@ -275,7 +275,7 @@ const ControlPanel: React.FC = () => {
           <button
             data-testid="replay-btn"
             onClick={startReplay}
-            className="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded transition-colors text-sm"
+            className="w-full bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-4 rounded transition-colors text-sm"
           >
             🎬 Start Replay
           </button>
@@ -289,8 +289,8 @@ const ControlPanel: React.FC = () => {
           disabled={replayMode || autoPlayEnabled || gameWon || aiThinking || aiAutoPlay}
           className={`w-full font-semibold py-2 px-4 rounded transition-colors text-sm ${
             aiThinking && !aiAutoPlay
-              ? 'bg-indigo-400 text-white cursor-wait'
-              : 'bg-indigo-600 hover:bg-indigo-700 text-white'
+              ? 'bg-cyan-400 text-white cursor-wait'
+              : 'bg-cyan-600 hover:bg-cyan-700 text-white'
           } ${
             replayMode || autoPlayEnabled || gameWon || aiAutoPlay
               ? 'opacity-50 cursor-not-allowed'


### PR DESCRIPTION
## Why

AI Auto-Play is now the most-used control, but it was easy to misclick. Export Game (`purple-600`) and Start Replay / Ask AI (`indigo-600`) reused the exact two halves of AI Auto-Play's `indigo→purple` gradient, so four near-identical buttons sat stacked together.

## What

- **Export Game**: `purple-600` → `sky-600`
- **Start Replay**: `indigo-600` → `red-600` (matches the existing in-replay "Exit Replay" button)
- **Ask AI**: `indigo-600` → `cyan-600` (thinking state `indigo-400` → `cyan-400`)
- **AI Auto-Play**: unchanged — now the only indigo/purple button in the control panel, so nothing adjacent shares its colour family

## Verification

- Headless screenshot of the control panel (seeded `?seed=42&difficulty=3`, one move so Start Replay renders) — AI Auto-Play reads as the sole purple button, clearly distinct from the cyan Ask AI directly above it.
- No test changes needed: the only e2e colour assertions are on the Valid Moves (green) and God Mode (purple) toggles, both untouched.
